### PR TITLE
feat(jira-orchestrator): Add development standards and template library v7.0.0

### DIFF
--- a/plugins/jira-orchestrator/agents/worktree-orchestrator.md
+++ b/plugins/jira-orchestrator/agents/worktree-orchestrator.md
@@ -1,0 +1,430 @@
+# Worktree Orchestrator Agent
+
+**Purpose:** Manage git worktrees for parallel development with sub-agents
+**Model:** sonnet (for coordination) | haiku (for individual worktrees)
+**Category:** git
+
+---
+
+## Overview
+
+The Worktree Orchestrator manages parallel development workflows using git worktrees. It enables multiple sub-agents to work simultaneously on different parts of a feature or epic, each in their own isolated worktree.
+
+---
+
+## Capabilities
+
+- Create and manage git worktrees
+- Spawn sub-agents per worktree
+- Coordinate parallel development
+- Merge worktree changes in dependency order
+- Clean up completed worktrees
+
+---
+
+## When to Use
+
+| Scenario | Use Worktrees? | Reason |
+|----------|----------------|--------|
+| Epic with 3+ sub-issues | **YES** | Parallel development |
+| Multiple independent features | **YES** | No context switching |
+| Long-running feature + hotfix | **YES** | Don't block hotfix |
+| Single simple task | No | Overhead not justified |
+| Complex feature with dependencies | **YES** | Clear separation |
+
+---
+
+## Workflow
+
+### 1. Analyze Task
+
+```yaml
+action: analyze_task
+input:
+  issue_key: ${issue_key}
+  sub_issues: ${sub_issue_list}
+
+output:
+  worktree_plan:
+    parallel_groups:
+      - level_0: [PROJ-101, PROJ-102]  # No dependencies
+      - level_1: [PROJ-103]            # Depends on level_0
+      - level_2: [PROJ-104]            # Depends on level_1
+    total_worktrees: 4
+    estimated_parallelism: 3x
+```
+
+### 2. Create Worktrees
+
+```bash
+# Create worktree for each sub-issue
+git worktree add ../worktree-PROJ-101 -b feature/PROJ-101-frontend
+git worktree add ../worktree-PROJ-102 -b feature/PROJ-102-backend
+git worktree add ../worktree-PROJ-103 -b feature/PROJ-103-integration
+```
+
+### 3. Spawn Sub-Agents
+
+```yaml
+action: spawn_sub_agents
+parallel_execution: true
+
+agents:
+  - name: "frontend-specialist"
+    worktree: "../worktree-PROJ-101"
+    issue: "PROJ-101"
+    model: "sonnet"
+    task: "Implement frontend component"
+
+  - name: "backend-specialist"
+    worktree: "../worktree-PROJ-102"
+    issue: "PROJ-102"
+    model: "sonnet"
+    task: "Implement backend API"
+
+coordination:
+  sync_interval: 5_minutes
+  progress_reporting: true
+  dependency_checking: true
+```
+
+### 4. Monitor Progress
+
+```yaml
+action: monitor_progress
+
+tracking:
+  - issue: PROJ-101
+    status: in_progress
+    completion: 60%
+    agent: frontend-specialist
+
+  - issue: PROJ-102
+    status: in_progress
+    completion: 45%
+    agent: backend-specialist
+
+aggregated:
+  total_completion: 52.5%
+  blocking_issues: []
+  next_level_ready: false
+```
+
+### 5. Create PRs Per Worktree
+
+```yaml
+action: create_prs
+
+prs_created:
+  - issue: PROJ-101
+    branch: feature/PROJ-101-frontend
+    pr_number: 123
+    status: ready_for_review
+
+  - issue: PROJ-102
+    branch: feature/PROJ-102-backend
+    pr_number: 124
+    status: ready_for_review
+
+merge_order:
+  1: [PR-123, PR-124]  # Can merge in parallel
+  2: [PR-125]          # After level 1 merged
+```
+
+### 6. Cleanup Worktrees
+
+```bash
+# After PR merged
+git worktree remove ../worktree-PROJ-101
+git worktree remove ../worktree-PROJ-102
+
+# Force remove if needed
+git worktree remove --force ../worktree-PROJ-103
+```
+
+---
+
+## Worktree Structure
+
+```
+workspace/
+├── main-repo/                   # Main repository (main branch)
+│   └── .git/                    # Git directory
+├── worktree-PROJ-101/           # Worktree for sub-issue 101
+│   ├── src/
+│   └── tests/
+├── worktree-PROJ-102/           # Worktree for sub-issue 102
+│   ├── src/
+│   └── tests/
+└── worktree-PROJ-103/           # Worktree for sub-issue 103
+    ├── src/
+    └── tests/
+```
+
+---
+
+## Sub-Agent Assignment
+
+### Expert Matching
+
+| File Pattern | Specialist Agent |
+|--------------|------------------|
+| `*.tsx`, `*.jsx`, `components/` | react-component-architect |
+| `*.py`, `api/`, `services/` | backend-specialist |
+| `*.prisma`, `migrations/` | database-specialist |
+| `*.test.*`, `tests/` | test-writer-fixer |
+| `*.tf`, `terraform/` | terraform-specialist |
+| `helm/`, `k8s/` | helm-chart-developer |
+
+### Model Assignment
+
+| Complexity | Model | Reason |
+|------------|-------|--------|
+| Simple UI component | haiku | Fast, straightforward |
+| Business logic | sonnet | Requires reasoning |
+| Architecture decisions | opus | Strategic thinking |
+| Documentation | haiku | Quick generation |
+
+---
+
+## Parallel Execution Example
+
+```
+Epic: PROJ-100 "Implement OAuth2 Login"
+  │
+  ├── LEVEL 0 (parallel - no dependencies):
+  │     │
+  │     ├── WORKTREE: ../worktree-PROJ-101
+  │     │   Issue: PROJ-101 "Database schema for users"
+  │     │   Agent: prisma-specialist (sonnet)
+  │     │   Status: ▓▓▓▓▓▓▓▓░░ 80%
+  │     │
+  │     └── WORKTREE: ../worktree-PROJ-102
+  │         Issue: PROJ-102 "Design login UI mockup"
+  │         Agent: ux-researcher (haiku)
+  │         Status: ▓▓▓▓▓▓▓▓▓▓ 100% ✓
+  │
+  ├── LEVEL 1 (after LEVEL 0):
+  │     │
+  │     ├── WORKTREE: ../worktree-PROJ-103
+  │     │   Issue: PROJ-103 "Implement Keycloak integration"
+  │     │   Agent: keycloak-specialist (sonnet)
+  │     │   Status: ░░░░░░░░░░ Waiting
+  │     │
+  │     └── WORKTREE: ../worktree-PROJ-104
+  │         Issue: PROJ-104 "Create LoginForm component"
+  │         Agent: react-component-architect (sonnet)
+  │         Status: ░░░░░░░░░░ Waiting
+  │
+  └── LEVEL 2 (after LEVEL 1):
+        │
+        └── WORKTREE: ../worktree-PROJ-105
+            Issue: PROJ-105 "Integration tests for auth flow"
+            Agent: test-writer-fixer (sonnet)
+            Status: ░░░░░░░░░░ Waiting
+
+Parallelism: 2-3 agents working simultaneously
+Estimated speedup: 2.5x vs sequential
+```
+
+---
+
+## Commands
+
+### Create Worktree
+
+```bash
+/worktree:create PROJ-101 --base main --description "user-auth-frontend"
+```
+
+Creates:
+- Branch: `feature/PROJ-101-user-auth-frontend`
+- Worktree: `../worktree-PROJ-101`
+- Spawns appropriate sub-agent
+
+### List Worktrees
+
+```bash
+/worktree:list
+```
+
+Output:
+```
+Active Worktrees:
+  ../worktree-PROJ-101  feature/PROJ-101-frontend    [80% complete]
+  ../worktree-PROJ-102  feature/PROJ-102-backend     [45% complete]
+
+Main Repository:
+  ./                    main                          [primary]
+```
+
+### Remove Worktree
+
+```bash
+/worktree:remove PROJ-101 --cleanup
+```
+
+Actions:
+1. Verifies PR is merged
+2. Removes worktree directory
+3. Deletes local branch (if merged)
+4. Updates Jira issue
+
+### Sync Worktrees
+
+```bash
+/worktree:sync --all
+```
+
+Actions:
+1. Fetches latest from origin
+2. Rebases each worktree on main
+3. Resolves conflicts if needed
+4. Reports status
+
+---
+
+## Integration
+
+### With /jira:work
+
+When `/jira:work` detects multiple sub-issues:
+
+```yaml
+auto_worktree:
+  threshold: 3  # Create worktrees if >= 3 sub-issues
+  enabled: true
+  cleanup_on_complete: true
+```
+
+### With /jira:pr
+
+Each worktree creates its own PR:
+
+```yaml
+pr_strategy:
+  one_pr_per_worktree: true
+  link_to_parent: true
+  merge_order: "dependency_aware"
+```
+
+### With Jira
+
+Updates posted for each worktree:
+
+```markdown
+## Worktree Status
+
+| Issue | Branch | Agent | Progress |
+|-------|--------|-------|----------|
+| PROJ-101 | feature/PROJ-101-frontend | react-architect | 80% |
+| PROJ-102 | feature/PROJ-102-backend | backend-specialist | 45% |
+```
+
+---
+
+## Error Handling
+
+### Worktree Creation Fails
+
+```yaml
+error: worktree_creation_failed
+cause: "Branch already exists"
+resolution:
+  1. Check if branch exists: git branch -a | grep PROJ-101
+  2. Delete if stale: git branch -D feature/PROJ-101-xxx
+  3. Retry creation
+```
+
+### Merge Conflicts
+
+```yaml
+error: merge_conflict
+worktree: "../worktree-PROJ-103"
+conflicts:
+  - src/services/auth.ts
+
+resolution:
+  1. Navigate to worktree: cd ../worktree-PROJ-103
+  2. Resolve conflicts manually
+  3. Commit resolution
+  4. Continue: /worktree:continue PROJ-103
+```
+
+### Agent Failure
+
+```yaml
+error: agent_failed
+worktree: "../worktree-PROJ-102"
+agent: backend-specialist
+reason: "Test failures"
+
+resolution:
+  1. Review failures in worktree
+  2. Fix issues manually or reassign agent
+  3. Resume: /worktree:resume PROJ-102
+```
+
+---
+
+## Best Practices
+
+1. **Keep worktrees isolated** - Each worktree should be self-contained
+2. **Sync regularly** - Rebase on main frequently to avoid conflicts
+3. **Clean up promptly** - Remove worktrees after PR merge
+4. **Use dependency order** - Merge in correct order to avoid issues
+5. **Monitor progress** - Check worktree status regularly
+6. **Limit parallelism** - Max 5-6 concurrent worktrees
+
+---
+
+## Configuration
+
+```yaml
+# jira-orchestrator/config/worktree.yml
+worktree:
+  enabled: true
+  base_path: "../"  # Relative to main repo
+  naming_pattern: "worktree-{issue_key}"
+
+  auto_create:
+    threshold: 3  # Min sub-issues for auto-worktree
+
+  cleanup:
+    on_pr_merge: true
+    on_error: false
+    retain_days: 7
+
+  sub_agents:
+    spawn_per_worktree: true
+    model_default: "sonnet"
+    max_parallel: 6
+```
+
+---
+
+## Related Agents
+
+- `parallel-sub-issue-worker` - Executes sub-issues in parallel
+- `expert-agent-matcher` - Selects best agent for each worktree
+- `pr-size-estimator` - Determines if worktrees are needed
+- `agent-router` - Routes work to appropriate specialists
+
+---
+
+## Metrics
+
+| Metric | Target | Actual |
+|--------|--------|--------|
+| Parallel speedup | 2-3x | Measured per epic |
+| Merge conflicts | < 5% | Tracked |
+| Worktree cleanup | 100% | Automated |
+| Sub-agent success | > 95% | Monitored |
+
+---
+
+## See Also
+
+- [Development Standards](../docs/DEVELOPMENT-STANDARDS.md#sub-agent--git-worktrees)
+- [Parallel Sub-Issue Worker](./parallel-sub-issue-worker.md)
+- [Expert Agent Matcher](./expert-agent-matcher.md)

--- a/plugins/jira-orchestrator/commands/work.md
+++ b/plugins/jira-orchestrator/commands/work.md
@@ -46,6 +46,60 @@ Time logging can be configured in `jira-orchestrator/config/time-logging.yml`:
 
 ---
 
+## MANDATORY DEVELOPMENT STANDARDS
+
+**CRITICAL:** All work MUST comply with [Development Standards](../docs/DEVELOPMENT-STANDARDS.md).
+
+### PR-Only Workflow (ENFORCED)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     ❌ DIRECT COMMITS TO MAIN ARE BLOCKED                    │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   ALL changes MUST go through Pull Requests:                                │
+│                                                                             │
+│   1. Create feature branch: feature/${issue_key}-description                │
+│   2. Make changes on feature branch                                         │
+│   3. Create PR via /jira:pr command                                         │
+│   4. Get approval (minimum 1 reviewer)                                      │
+│   5. Merge via GitHub/Harness (squash preferred)                            │
+│                                                                             │
+│   ❌ NEVER: git push origin main                                            │
+│   ✅ ALWAYS: Create PR, get approval, merge                                 │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Code Quality Requirements
+
+| Requirement | Standard | Enforcement |
+|-------------|----------|-------------|
+| SOLID Principles | MANDATORY | Code review |
+| Test Coverage | >= 80% | CI/CD block |
+| Clean Code | Required | Linting + review |
+| Documentation | Required | PR template |
+
+### Deployment Standards
+
+| Environment | Method | Docker Compose |
+|-------------|--------|----------------|
+| Local Dev | Docker Compose | ✅ Allowed |
+| Development | Helm + K8s | ❌ Forbidden |
+| Staging | Helm + K8s | ❌ Forbidden |
+| Production | Helm + K8s | ❌ Forbidden |
+
+### Sub-Agent & Git Worktrees
+
+For complex tasks (multiple sub-issues):
+- **REQUIRED:** Use git worktrees for parallel development
+- **REQUIRED:** Spawn sub-agents per worktree
+- **MINIMUM:** 3-5 sub-agents per task
+
+See [Development Standards](../docs/DEVELOPMENT-STANDARDS.md) for full requirements.
+
+---
+
 ## ENHANCED WORKFLOW OVERVIEW
 
 ```

--- a/plugins/jira-orchestrator/docs/DEVELOPMENT-STANDARDS.md
+++ b/plugins/jira-orchestrator/docs/DEVELOPMENT-STANDARDS.md
@@ -1,0 +1,891 @@
+# Development Standards & Best Practices
+
+**Version:** 1.0.0 | **Last Updated:** 2025-12-31 | **Status:** MANDATORY
+
+---
+
+## Table of Contents
+
+1. [Git Workflow Standards](#git-workflow-standards)
+2. [SOLID Principles & Clean Code](#solid-principles--clean-code)
+3. [Deployment Standards](#deployment-standards)
+4. [Documentation Requirements](#documentation-requirements)
+5. [Repository Structure Standards](#repository-structure-standards)
+6. [Sub-Agent & Git Worktrees](#sub-agent--git-worktrees)
+7. [Template Library](#template-library)
+8. [Enforcement Mechanisms](#enforcement-mechanisms)
+
+---
+
+## Git Workflow Standards
+
+### PR-Only Workflow (MANDATORY)
+
+**CRITICAL:** Direct commits to `main` or `master` branches are **STRICTLY PROHIBITED**.
+
+All changes MUST go through the Pull Request workflow:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         MANDATORY PR WORKFLOW                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   ┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐ │
+│   │   CREATE    │ -> │    CODE     │ -> │   CREATE    │ -> │   MERGE     │ │
+│   │   BRANCH    │    │   & TEST    │    │     PR      │    │   TO MAIN   │ │
+│   └─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘ │
+│         │                  │                  │                  │         │
+│         v                  v                  v                  v         │
+│   feature/PROJ-123   All tests pass    Review required    Squash merge   │
+│   or bugfix/...      Code quality      Approvals met      CI passed      │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Branch Naming Convention
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Feature | `feature/{ISSUE-KEY}-{description}` | `feature/PROJ-123-user-auth` |
+| Bug Fix | `bugfix/{ISSUE-KEY}-{description}` | `bugfix/PROJ-456-fix-login` |
+| Hotfix | `hotfix/{ISSUE-KEY}-{description}` | `hotfix/PROJ-789-critical-patch` |
+| Release | `release/{version}` | `release/v2.0.0` |
+
+### Commit Message Format
+
+```
+{ISSUE-KEY}: Brief description (imperative mood)
+
+- Detailed bullet point if needed
+- Another point
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+```
+
+### PR Requirements (BLOCKING)
+
+Before a PR can be merged:
+
+- [ ] **Branch protection enabled** on main/master
+- [ ] **At least 1 approval** from code owner
+- [ ] **All CI checks passing** (tests, lint, build)
+- [ ] **Code coverage >= 80%** for new code
+- [ ] **No direct pushes** - all via PR
+- [ ] **Squash merge** preferred for clean history
+- [ ] **Linked Jira issue** in PR description
+
+### Branch Protection Rules
+
+```yaml
+# Required branch protection settings
+branch_protection:
+  branches:
+    - main
+    - master
+  rules:
+    require_pull_request:
+      required_approving_review_count: 1
+      dismiss_stale_reviews: true
+      require_code_owner_reviews: true
+    require_status_checks:
+      strict: true
+      contexts:
+        - "CI / Build"
+        - "CI / Test"
+        - "CI / Lint"
+    restrict_pushes:
+      allow_force_pushes: false
+      allow_deletions: false
+```
+
+---
+
+## SOLID Principles & Clean Code
+
+### SOLID Principles (MANDATORY)
+
+Every code contribution MUST adhere to SOLID principles:
+
+#### S - Single Responsibility Principle (SRP)
+
+```typescript
+// BAD: Class handles multiple responsibilities
+class UserManager {
+  createUser() { /* ... */ }
+  sendEmail() { /* ... */ }
+  validateInput() { /* ... */ }
+  logActivity() { /* ... */ }
+}
+
+// GOOD: Each class has one responsibility
+class UserService {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly validator: UserValidator
+  ) {}
+
+  createUser(data: UserData): User {
+    this.validator.validate(data);
+    return this.userRepository.save(data);
+  }
+}
+
+class EmailService {
+  sendWelcomeEmail(user: User): void { /* ... */ }
+}
+
+class ActivityLogger {
+  log(activity: Activity): void { /* ... */ }
+}
+```
+
+#### O - Open/Closed Principle (OCP)
+
+```typescript
+// BAD: Modifying existing code for new features
+function calculateDiscount(type: string, price: number): number {
+  if (type === 'regular') return price * 0.1;
+  if (type === 'premium') return price * 0.2;
+  if (type === 'vip') return price * 0.3; // Added later - violates OCP
+}
+
+// GOOD: Open for extension, closed for modification
+interface DiscountStrategy {
+  calculate(price: number): number;
+}
+
+class RegularDiscount implements DiscountStrategy {
+  calculate(price: number): number { return price * 0.1; }
+}
+
+class PremiumDiscount implements DiscountStrategy {
+  calculate(price: number): number { return price * 0.2; }
+}
+
+class VIPDiscount implements DiscountStrategy {
+  calculate(price: number): number { return price * 0.3; }
+}
+```
+
+#### L - Liskov Substitution Principle (LSP)
+
+```typescript
+// BAD: Subclass violates parent contract
+class Bird {
+  fly(): void { /* ... */ }
+}
+
+class Penguin extends Bird {
+  fly(): void { throw new Error("Can't fly!"); } // Violates LSP
+}
+
+// GOOD: Proper abstraction hierarchy
+interface Bird {
+  move(): void;
+}
+
+interface FlyingBird extends Bird {
+  fly(): void;
+}
+
+class Sparrow implements FlyingBird {
+  move(): void { this.fly(); }
+  fly(): void { /* ... */ }
+}
+
+class Penguin implements Bird {
+  move(): void { this.swim(); }
+  swim(): void { /* ... */ }
+}
+```
+
+#### I - Interface Segregation Principle (ISP)
+
+```typescript
+// BAD: Fat interface
+interface Worker {
+  work(): void;
+  eat(): void;
+  sleep(): void;
+  code(): void;
+  design(): void;
+}
+
+// GOOD: Segregated interfaces
+interface Workable {
+  work(): void;
+}
+
+interface Eatable {
+  eat(): void;
+}
+
+interface Codeable {
+  code(): void;
+}
+
+interface Designable {
+  design(): void;
+}
+
+class Developer implements Workable, Codeable {
+  work(): void { /* ... */ }
+  code(): void { /* ... */ }
+}
+```
+
+#### D - Dependency Inversion Principle (DIP)
+
+```typescript
+// BAD: High-level module depends on low-level module
+class UserService {
+  private database = new MySQLDatabase(); // Direct dependency
+
+  getUser(id: string): User {
+    return this.database.query(`SELECT * FROM users WHERE id = ${id}`);
+  }
+}
+
+// GOOD: Both depend on abstractions
+interface Database {
+  query(sql: string): any;
+}
+
+class UserService {
+  constructor(private readonly database: Database) {} // Injected
+
+  getUser(id: string): User {
+    return this.database.query(`SELECT * FROM users WHERE id = ${id}`);
+  }
+}
+
+// Can now use MySQL, PostgreSQL, or any Database implementation
+```
+
+### Clean Code Standards
+
+#### Naming Conventions
+
+| Type | Convention | Example |
+|------|------------|---------|
+| Classes | PascalCase | `UserService`, `PaymentProcessor` |
+| Interfaces | PascalCase (no I prefix) | `Repository`, `Logger` |
+| Functions/Methods | camelCase | `calculateTotal`, `getUserById` |
+| Variables | camelCase | `userName`, `totalAmount` |
+| Constants | UPPER_SNAKE_CASE | `MAX_RETRIES`, `API_BASE_URL` |
+| Files | kebab-case | `user-service.ts`, `payment-utils.ts` |
+| Test files | `*.test.ts` or `*.spec.ts` | `user-service.test.ts` |
+
+#### Function Guidelines
+
+```typescript
+// Maximum function length: 20-30 lines
+// Maximum parameters: 3-4 (use object for more)
+
+// BAD
+function createUser(name: string, email: string, password: string,
+                    role: string, department: string, manager: string,
+                    startDate: Date, salary: number): User { /* ... */ }
+
+// GOOD
+interface CreateUserRequest {
+  name: string;
+  email: string;
+  password: string;
+  role?: string;
+  department?: string;
+  manager?: string;
+  startDate?: Date;
+  salary?: number;
+}
+
+function createUser(request: CreateUserRequest): User { /* ... */ }
+```
+
+#### Error Handling
+
+```typescript
+// Always use typed errors
+class UserNotFoundError extends Error {
+  constructor(public readonly userId: string) {
+    super(`User not found: ${userId}`);
+    this.name = 'UserNotFoundError';
+  }
+}
+
+// Handle errors explicitly
+async function getUser(id: string): Promise<User> {
+  const user = await this.repository.findById(id);
+  if (!user) {
+    throw new UserNotFoundError(id);
+  }
+  return user;
+}
+```
+
+---
+
+## Deployment Standards
+
+### Helm-First Deployment (MANDATORY)
+
+**CRITICAL:** All Kubernetes deployments MUST use Helm charts. Docker Compose is for **local development only**.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         DEPLOYMENT HIERARCHY                                 │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   Production   │  Helm + Kubernetes        │  REQUIRED                     │
+│   Staging      │  Helm + Kubernetes        │  REQUIRED                     │
+│   Development  │  Helm + Kubernetes        │  RECOMMENDED                  │
+│   Local Dev    │  Docker Compose           │  ALLOWED (dev only)           │
+│                                                                             │
+│   ❌ NEVER use Docker Compose for: staging, production, CI/CD              │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Helm Chart Structure (MANDATORY)
+
+Every deployable service MUST include:
+
+```
+deployment/
+├── helm/
+│   └── {service-name}/
+│       ├── Chart.yaml
+│       ├── values.yaml              # Default values
+│       ├── values-dev.yaml          # Development overrides
+│       ├── values-staging.yaml      # Staging overrides
+│       ├── values-prod.yaml         # Production overrides
+│       ├── templates/
+│       │   ├── _helpers.tpl
+│       │   ├── deployment.yaml
+│       │   ├── service.yaml
+│       │   ├── ingress.yaml
+│       │   ├── configmap.yaml
+│       │   ├── secrets.yaml
+│       │   ├── hpa.yaml             # Horizontal Pod Autoscaler
+│       │   └── pdb.yaml             # Pod Disruption Budget
+│       └── README.md
+└── terraform/                        # Infrastructure as Code
+    └── environments/
+        ├── dev/
+        ├── staging/
+        └── prod/
+```
+
+### Helm Deployment Commands
+
+```bash
+# Development
+helm upgrade --install {service} ./deployment/helm/{service} \
+  -n {namespace} \
+  -f ./deployment/helm/{service}/values-dev.yaml
+
+# Staging
+helm upgrade --install {service} ./deployment/helm/{service} \
+  -n {namespace} \
+  -f ./deployment/helm/{service}/values-staging.yaml
+
+# Production (REQUIRES APPROVAL)
+helm upgrade --install {service} ./deployment/helm/{service} \
+  -n {namespace} \
+  -f ./deployment/helm/{service}/values-prod.yaml \
+  --wait --timeout 5m
+```
+
+### When Docker Compose is Allowed
+
+Docker Compose is ONLY permitted for:
+
+1. **Local development** - Running services on developer machines
+2. **Quick prototyping** - Initial exploration before Helm chart creation
+3. **Integration tests** - Spinning up test dependencies locally
+
+```yaml
+# docker-compose.yml - LOCAL DEVELOPMENT ONLY
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+    # ⚠️ This file is for LOCAL DEVELOPMENT ONLY
+    # ⚠️ Use Helm charts for staging/production
+```
+
+---
+
+## Documentation Requirements
+
+### Docs Folder Structure (MANDATORY)
+
+Every repository MUST include a `docs/` folder with Confluence links:
+
+```
+docs/
+├── README.md                    # Index with Confluence links
+├── architecture.md              # High-level architecture
+├── api.md                       # API documentation
+├── deployment.md                # Deployment guide
+├── runbook.md                   # Operations runbook
+└── adr/                         # Architecture Decision Records
+    ├── 0001-initial-architecture.md
+    └── template.md
+```
+
+### README with Confluence Links (MANDATORY)
+
+Every repository README MUST include a documentation table linking to Confluence:
+
+```markdown
+# {Service Name}
+
+**Status:** Active | **Jira:** [PROJ-123](https://jira.example.com/browse/PROJ-123)
+
+## Quick Start
+
+\`\`\`bash
+# Local development
+docker-compose up -d
+
+# Helm deployment (staging/prod)
+helm upgrade --install {service} ./deployment/helm/{service}
+\`\`\`
+
+## Documentation
+
+| Document | Description | Link |
+|----------|-------------|------|
+| Technical Design | Architecture & design decisions | [Confluence](https://confluence.example.com/tdd-PROJ-123) |
+| API Reference | Endpoint documentation | [Confluence](https://confluence.example.com/api-PROJ-123) |
+| Runbook | Operations & troubleshooting | [Confluence](https://confluence.example.com/runbook-PROJ-123) |
+| ADRs | Architecture decisions | [docs/adr/](./docs/adr/) |
+
+## Architecture
+
+See [docs/architecture.md](./docs/architecture.md) for detailed architecture.
+
+## Development
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development guidelines.
+
+## Team
+
+**Owner:** {Team Name} | **Slack:** #{service-name}-support
+```
+
+### Confluence Page Requirements
+
+For every major feature/service, create these Confluence pages:
+
+| Page Type | Required | Template |
+|-----------|----------|----------|
+| Technical Design Document (TDD) | **MANDATORY** | `templates/confluence/tdd.md` |
+| API Documentation | If applicable | `templates/confluence/api.md` |
+| Runbook | **MANDATORY** | `templates/confluence/runbook.md` |
+| Implementation Notes | Recommended | `templates/confluence/implementation.md` |
+| Test Results | For major features | `templates/confluence/test-results.md` |
+
+---
+
+## Repository Structure Standards
+
+### Standard Directory Structure
+
+All repositories MUST follow this consistent structure:
+
+```
+{repository-name}/
+├── .github/
+│   ├── workflows/               # CI/CD pipelines
+│   │   ├── ci.yml
+│   │   └── cd.yml
+│   ├── CODEOWNERS
+│   └── PULL_REQUEST_TEMPLATE.md
+├── .harness/                    # Harness pipeline definitions
+│   ├── pipeline.yaml
+│   └── triggers.yaml
+├── deployment/
+│   ├── helm/{service-name}/     # Helm charts (MANDATORY)
+│   ├── terraform/               # Infrastructure as Code
+│   └── k8s/                     # Raw K8s manifests (if needed)
+├── docs/                        # Documentation (MANDATORY)
+│   ├── README.md
+│   ├── architecture.md
+│   ├── api.md
+│   └── adr/
+├── src/                         # Source code
+│   ├── controllers/
+│   ├── services/
+│   ├── repositories/
+│   ├── models/
+│   ├── utils/
+│   └── index.ts
+├── tests/                       # Tests
+│   ├── unit/
+│   ├── integration/
+│   └── e2e/
+├── scripts/                     # Utility scripts
+├── .jira/                       # Jira orchestrator config
+│   └── config.yml
+├── docker-compose.yml           # Local development only
+├── Dockerfile
+├── README.md                    # With Confluence links
+├── CONTRIBUTING.md
+├── CHANGELOG.md
+├── package.json                 # or equivalent
+└── tsconfig.json                # or equivalent
+```
+
+### Source Code Organization
+
+```
+src/
+├── controllers/                 # Request handlers
+│   └── user.controller.ts
+├── services/                    # Business logic (SOLID)
+│   └── user.service.ts
+├── repositories/                # Data access
+│   └── user.repository.ts
+├── models/                      # Domain models
+│   ├── entities/
+│   └── dto/
+├── interfaces/                  # TypeScript interfaces
+├── middleware/                  # Express/Fastify middleware
+├── utils/                       # Utility functions
+├── config/                      # Configuration
+└── index.ts                     # Application entry point
+```
+
+---
+
+## Sub-Agent & Git Worktrees
+
+### Sub-Agent Requirements (MANDATORY)
+
+Complex tasks MUST use sub-agents for parallel processing:
+
+```yaml
+# Minimum sub-agents per task type
+task_types:
+  simple_fix:
+    min_agents: 3
+    max_agents: 5
+
+  standard_feature:
+    min_agents: 5
+    max_agents: 8
+
+  complex_feature:
+    min_agents: 8
+    max_agents: 13
+
+  epic_decomposition:
+    min_agents: 4
+    max_agents: 6
+```
+
+### Git Worktrees for Parallel Development
+
+Use git worktrees when working on multiple features simultaneously:
+
+```bash
+# Create worktree for a feature
+git worktree add ../feature-PROJ-123 feature/PROJ-123-user-auth
+
+# Create worktree for a bugfix
+git worktree add ../bugfix-PROJ-456 bugfix/PROJ-456-fix-login
+
+# List worktrees
+git worktree list
+
+# Remove worktree when done
+git worktree remove ../feature-PROJ-123
+```
+
+### Worktree Structure
+
+```
+workspace/
+├── main-repo/                   # Main repository (main branch)
+├── feature-PROJ-123/            # Worktree for feature
+├── feature-PROJ-124/            # Worktree for another feature
+└── bugfix-PROJ-456/             # Worktree for bugfix
+```
+
+### When to Use Worktrees
+
+| Scenario | Use Worktrees? | Reason |
+|----------|----------------|--------|
+| Multiple features in parallel | **YES** | Avoid context switching |
+| Long-running feature + hotfix | **YES** | Don't block hotfix |
+| Single feature | No | Overhead not justified |
+| Epic with multiple sub-tasks | **YES** | Parallel development |
+
+### Sub-Agent + Worktree Workflow
+
+```yaml
+# Example: Epic with 3 sub-tasks
+epic: PROJ-100
+sub_tasks:
+  - PROJ-101: Frontend component
+  - PROJ-102: Backend API
+  - PROJ-103: Database schema
+
+workflow:
+  1. Create worktrees:
+     - git worktree add ../proj-101 feature/PROJ-101-frontend
+     - git worktree add ../proj-102 feature/PROJ-102-backend
+     - git worktree add ../proj-103 feature/PROJ-103-database
+
+  2. Assign sub-agents:
+     - Agent 1 → ../proj-101 (frontend specialist)
+     - Agent 2 → ../proj-102 (backend specialist)
+     - Agent 3 → ../proj-103 (database specialist)
+
+  3. Parallel execution:
+     - All agents work simultaneously
+     - Each creates PR for their sub-task
+     - Merge PRs in dependency order
+
+  4. Cleanup:
+     - git worktree remove ../proj-101
+     - git worktree remove ../proj-102
+     - git worktree remove ../proj-103
+```
+
+---
+
+## Template Library
+
+### Available Templates
+
+Templates are stored in `plugins/jira-orchestrator/templates/`:
+
+```
+templates/
+├── repository/                  # Repository templates
+│   ├── microservice/
+│   │   ├── README.md.template
+│   │   ├── CONTRIBUTING.md.template
+│   │   ├── Dockerfile.template
+│   │   └── package.json.template
+│   ├── helm-chart/
+│   ├── terraform-module/
+│   └── shared-lib/
+├── confluence/                  # Confluence page templates
+│   ├── tdd.md.template          # Technical Design Document
+│   ├── api.md.template          # API Documentation
+│   ├── runbook.md.template      # Operations Runbook
+│   ├── implementation.md.template
+│   └── test-results.md.template
+├── helm/                        # Helm chart templates
+│   ├── Chart.yaml.template
+│   ├── values.yaml.template
+│   └── templates/
+├── github/                      # GitHub templates
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   ├── CODEOWNERS.template
+│   └── workflows/
+├── adr/                         # ADR templates
+│   └── adr-template.md
+└── code/                        # Code templates
+    ├── typescript/
+    │   ├── service.ts.template
+    │   ├── controller.ts.template
+    │   └── repository.ts.template
+    └── python/
+        ├── service.py.template
+        └── repository.py.template
+```
+
+### Using Templates
+
+Templates use variable substitution:
+
+```markdown
+# {{SERVICE_NAME}}
+
+**Status:** Active | **Jira:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+
+## Documentation
+
+| Document | Link |
+|----------|------|
+| Technical Design | [Confluence]({{CONFLUENCE_BASE}}/tdd-{{JIRA_KEY}}) |
+
+## Team
+
+**Owner:** {{TEAM_NAME}} | **Slack:** #{{SERVICE_NAME}}-support
+```
+
+### Template Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{SERVICE_NAME}}` | Name of the service | `user-service` |
+| `{{JIRA_KEY}}` | Jira issue key | `PROJ-123` |
+| `{{JIRA_URL}}` | Jira instance URL | `https://jira.example.com` |
+| `{{CONFLUENCE_BASE}}` | Confluence base URL | `https://confluence.example.com` |
+| `{{TEAM_NAME}}` | Owning team | `Platform Team` |
+| `{{DATE}}` | Current date | `2025-12-31` |
+| `{{AUTHOR}}` | Author name | `Developer Name` |
+
+---
+
+## Enforcement Mechanisms
+
+### Pre-Commit Hooks
+
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+
+# Block direct commits to main/master
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  echo "❌ Direct commits to $BRANCH are not allowed!"
+  echo "Please create a feature branch and submit a PR."
+  exit 1
+fi
+
+# Run linting
+npm run lint || exit 1
+
+# Run tests
+npm test || exit 1
+```
+
+### CI/CD Checks
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+on:
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  standards-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check branch protection
+        run: |
+          if [ "${{ github.event_name }}" == "push" ] && \
+             [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            echo "❌ Direct push to main detected!"
+            exit 1
+          fi
+
+      - name: Verify Helm charts exist
+        run: |
+          if [ ! -d "deployment/helm" ]; then
+            echo "❌ Missing Helm charts in deployment/helm/"
+            exit 1
+          fi
+
+      - name: Check docs folder
+        run: |
+          if [ ! -d "docs" ]; then
+            echo "❌ Missing docs/ folder"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check coverage
+        run: |
+          COVERAGE=$(npm run coverage -- --silent | grep "All files" | awk '{print $10}')
+          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
+            echo "❌ Coverage $COVERAGE% is below 80%"
+            exit 1
+          fi
+```
+
+### Jira Orchestrator Enforcement
+
+The Jira orchestrator automatically enforces these standards:
+
+```yaml
+# Enforcement rules
+enforcement:
+  pr_only:
+    enabled: true
+    block_direct_commits: true
+    required_approvals: 1
+
+  deployment:
+    helm_required: true
+    docker_compose_allowed_envs: ["local"]
+
+  documentation:
+    docs_folder_required: true
+    confluence_links_required: true
+    readme_template_required: true
+
+  code_quality:
+    solid_principles: enforced
+    test_coverage_min: 80
+    lint_required: true
+
+  agents:
+    min_sub_agents: 3
+    max_sub_agents: 13
+    worktrees_for_parallel: recommended
+```
+
+---
+
+## Compliance Checklist
+
+Before merging any PR, verify:
+
+### Git Workflow
+- [ ] Created feature branch (not committing to main)
+- [ ] Branch follows naming convention
+- [ ] Commits reference Jira issue
+- [ ] PR created with proper template
+- [ ] At least 1 approval obtained
+- [ ] All CI checks passing
+
+### Code Quality
+- [ ] Follows SOLID principles
+- [ ] Clean code standards met
+- [ ] Unit tests added/updated
+- [ ] Test coverage >= 80%
+- [ ] No linting errors
+
+### Deployment
+- [ ] Helm charts exist and are valid
+- [ ] Values files for all environments
+- [ ] No Docker Compose for non-local envs
+- [ ] Infrastructure as Code if applicable
+
+### Documentation
+- [ ] `docs/` folder exists
+- [ ] README has Confluence links
+- [ ] Architecture documented
+- [ ] API documented (if applicable)
+- [ ] Runbook created/updated
+- [ ] ADRs for significant decisions
+
+---
+
+## Related Documentation
+
+- [Orchestration Protocol](./ARCHITECTURE-SUMMARY.md)
+- [GitHub-Jira Integration](./GITHUB-JIRA-INTEGRATION-GUIDE.md)
+- [Harness Setup](./HARNESS-JIRA-CONNECTOR-SETUP.md)
+- [Template Library](../templates/README.md)
+
+---
+
+**Enforcement:** These standards are automatically enforced by the Jira Orchestrator hooks and CI/CD pipelines. Non-compliant code will be blocked from merging.

--- a/plugins/jira-orchestrator/templates/README.md
+++ b/plugins/jira-orchestrator/templates/README.md
@@ -1,0 +1,195 @@
+# Template Library
+
+**Version:** 1.0.0 | **Templates:** 15+ | **Categories:** 6
+
+---
+
+## Overview
+
+This template library ensures consistency across all repositories and documentation. Templates use variable substitution with the `{{VARIABLE_NAME}}` syntax.
+
+---
+
+## Template Categories
+
+| Category | Purpose | Location |
+|----------|---------|----------|
+| Repository | Project scaffolding | `repository/` |
+| Confluence | Documentation pages | `confluence/` |
+| Helm | Kubernetes deployment | `helm/` |
+| GitHub | CI/CD & workflows | `github/` |
+| ADR | Architecture decisions | `adr/` |
+| Code | Source code patterns | `code/` |
+
+---
+
+## Quick Reference
+
+### Repository Templates
+
+| Template | Use For | Command |
+|----------|---------|---------|
+| `microservice/` | Full-stack services | `/jira:create-repo --type microservice` |
+| `helm-chart/` | Reusable Helm charts | `/jira:create-repo --type helm-chart` |
+| `terraform-module/` | Infrastructure modules | `/jira:create-repo --type terraform-module` |
+| `shared-lib/` | Shared libraries | `/jira:create-repo --type shared-lib` |
+
+### Confluence Templates
+
+| Template | When to Use |
+|----------|-------------|
+| `tdd.md.template` | Every new feature/service (MANDATORY) |
+| `api.md.template` | Services with REST/GraphQL APIs |
+| `runbook.md.template` | Every deployable service (MANDATORY) |
+| `implementation.md.template` | Complex implementations |
+| `test-results.md.template` | Major feature releases |
+
+### Helm Templates
+
+| Template | Description |
+|----------|-------------|
+| `Chart.yaml.template` | Chart metadata |
+| `values.yaml.template` | Default values |
+| `templates/deployment.yaml` | Kubernetes Deployment |
+| `templates/service.yaml` | Kubernetes Service |
+| `templates/ingress.yaml` | Ingress configuration |
+
+---
+
+## Variable Reference
+
+### Core Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{SERVICE_NAME}}` | Service/repo name | `user-service` |
+| `{{SERVICE_NAME_UPPER}}` | Uppercase name | `USER_SERVICE` |
+| `{{SERVICE_NAME_PASCAL}}` | PascalCase name | `UserService` |
+| `{{JIRA_KEY}}` | Jira issue key | `PROJ-123` |
+| `{{JIRA_PROJECT}}` | Jira project key | `PROJ` |
+
+### URL Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{JIRA_URL}}` | Jira instance URL | `https://jira.example.com` |
+| `{{CONFLUENCE_BASE}}` | Confluence base URL | `https://confluence.example.com` |
+| `{{REPO_URL}}` | Repository URL | `https://github.com/org/repo` |
+| `{{HARNESS_URL}}` | Harness URL | `https://app.harness.io` |
+
+### Metadata Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{TEAM_NAME}}` | Owning team | `Platform Team` |
+| `{{AUTHOR}}` | Author name | `John Doe` |
+| `{{DATE}}` | Current date (ISO) | `2025-12-31` |
+| `{{VERSION}}` | Version number | `1.0.0` |
+| `{{DESCRIPTION}}` | Service description | `User management service` |
+
+### Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{NAMESPACE_DEV}}` | Dev namespace | `user-service-dev` |
+| `{{NAMESPACE_STAGING}}` | Staging namespace | `user-service-staging` |
+| `{{NAMESPACE_PROD}}` | Prod namespace | `user-service-prod` |
+| `{{REPLICAS_DEV}}` | Dev replicas | `1` |
+| `{{REPLICAS_STAGING}}` | Staging replicas | `2` |
+| `{{REPLICAS_PROD}}` | Prod replicas | `3` |
+
+---
+
+## Usage Examples
+
+### Creating a Microservice Repository
+
+```bash
+/jira:create-repo my-service --jira PROJ-123 --type microservice --team "Platform Team"
+```
+
+This uses templates from:
+- `repository/microservice/README.md.template`
+- `repository/microservice/Dockerfile.template`
+- `helm/Chart.yaml.template`
+- `helm/values.yaml.template`
+- `github/workflows/ci.yml.template`
+
+### Creating Confluence Documentation
+
+When the orchestrator creates Confluence pages, it uses:
+- `confluence/tdd.md.template` for Technical Design Document
+- `confluence/api.md.template` for API Documentation
+- `confluence/runbook.md.template` for Operations Runbook
+
+### Adding Helm Charts to Existing Repo
+
+Templates used:
+- `helm/Chart.yaml.template`
+- `helm/values.yaml.template`
+- `helm/templates/deployment.yaml.template`
+- `helm/templates/service.yaml.template`
+
+---
+
+## Customization
+
+### Adding New Templates
+
+1. Create template file with `.template` extension
+2. Use `{{VARIABLE_NAME}}` for substitution
+3. Add to appropriate category directory
+4. Update this README
+
+### Template Syntax
+
+```markdown
+# {{SERVICE_NAME}}
+
+Created: {{DATE}}
+Author: {{AUTHOR}}
+Jira: [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+
+## Description
+
+{{DESCRIPTION}}
+
+## Team
+
+**Owner:** {{TEAM_NAME}}
+```
+
+### Conditional Sections
+
+Use comments for conditional content:
+
+```markdown
+<!-- IF: HAS_API -->
+## API Documentation
+
+See [API Reference]({{CONFLUENCE_BASE}}/api-{{JIRA_KEY}})
+<!-- ENDIF: HAS_API -->
+```
+
+---
+
+## Template Validation
+
+Templates are validated for:
+- Required variables present
+- Valid markdown syntax
+- No undefined variables used
+- Consistent formatting
+
+Run validation:
+```bash
+./scripts/validate-templates.sh
+```
+
+---
+
+## Related Documentation
+
+- [Development Standards](../docs/DEVELOPMENT-STANDARDS.md)
+- [Repository Structure](../docs/DEVELOPMENT-STANDARDS.md#repository-structure-standards)
+- [Create Repo Command](../commands/create-repo.md)

--- a/plugins/jira-orchestrator/templates/adr/adr-template.md
+++ b/plugins/jira-orchestrator/templates/adr/adr-template.md
@@ -1,0 +1,131 @@
+# ADR-{{ADR_NUMBER}}: {{ADR_TITLE}}
+
+**Date:** {{DATE}}
+**Status:** Proposed | Accepted | Deprecated | Superseded
+**Deciders:** {{AUTHOR}}, {{TEAM_NAME}}
+**Jira:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+
+---
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+Describe the context and problem statement here. Include:
+- Current state
+- Pain points
+- Business requirements
+- Technical constraints
+
+## Decision Drivers
+
+- Driver 1 (e.g., performance requirements)
+- Driver 2 (e.g., team expertise)
+- Driver 3 (e.g., cost constraints)
+- Driver 4 (e.g., time to market)
+
+## Considered Options
+
+### Option 1: {{OPTION_1_NAME}}
+
+**Description:** Brief description of this option.
+
+**Pros:**
+- Pro 1
+- Pro 2
+
+**Cons:**
+- Con 1
+- Con 2
+
+**Effort:** Low | Medium | High
+
+---
+
+### Option 2: {{OPTION_2_NAME}}
+
+**Description:** Brief description of this option.
+
+**Pros:**
+- Pro 1
+- Pro 2
+
+**Cons:**
+- Con 1
+- Con 2
+
+**Effort:** Low | Medium | High
+
+---
+
+### Option 3: {{OPTION_3_NAME}}
+
+**Description:** Brief description of this option.
+
+**Pros:**
+- Pro 1
+- Pro 2
+
+**Cons:**
+- Con 1
+- Con 2
+
+**Effort:** Low | Medium | High
+
+## Decision Outcome
+
+**Chosen Option:** "Option X" because {justification}.
+
+### Positive Consequences
+
+- Benefit 1
+- Benefit 2
+- Benefit 3
+
+### Negative Consequences
+
+- Drawback 1
+- Drawback 2
+
+### Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Risk 1 | Medium | High | Mitigation strategy |
+| Risk 2 | Low | Medium | Mitigation strategy |
+
+## Implementation
+
+### Action Items
+
+- [ ] Action 1 - Assigned to: @person - Due: YYYY-MM-DD
+- [ ] Action 2 - Assigned to: @person - Due: YYYY-MM-DD
+- [ ] Action 3 - Assigned to: @person - Due: YYYY-MM-DD
+
+### Rollout Plan
+
+1. Phase 1: Description
+2. Phase 2: Description
+3. Phase 3: Description
+
+## Validation
+
+How will we know if this decision was successful?
+
+- Metric 1: Target value
+- Metric 2: Target value
+- Review date: YYYY-MM-DD
+
+## Links
+
+- [Technical Design Document]({{CONFLUENCE_BASE}}/tdd-{{JIRA_KEY}})
+- [Related ADRs](./README.md)
+- [External Reference](https://example.com)
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| {{DATE}} | {{AUTHOR}} | Initial draft |

--- a/plugins/jira-orchestrator/templates/confluence/runbook.md.template
+++ b/plugins/jira-orchestrator/templates/confluence/runbook.md.template
@@ -1,0 +1,312 @@
+# Runbook: {{SERVICE_NAME}}
+
+**Service:** {{SERVICE_NAME}}
+**Team:** {{TEAM_NAME}}
+**Jira:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+**Last Updated:** {{DATE}}
+
+---
+
+## Service Overview
+
+| Property | Value |
+|----------|-------|
+| Repository | [GitHub]({{REPO_URL}}) |
+| Pipeline | [Harness]({{HARNESS_URL}}/pipelines/{{SERVICE_NAME}}) |
+| Namespace (Prod) | `{{NAMESPACE_PROD}}` |
+| Slack | #{{SERVICE_NAME}}-support |
+| On-Call | [PagerDuty](https://pagerduty.com/...) |
+
+---
+
+## Quick Actions
+
+### Health Check
+
+```bash
+# Check pod status
+kubectl get pods -n {{NAMESPACE_PROD}} -l app={{SERVICE_NAME}}
+
+# Check service health
+curl https://{{SERVICE_NAME}}.example.com/health
+
+# View logs
+kubectl logs -n {{NAMESPACE_PROD}} -l app={{SERVICE_NAME}} --tail=100 -f
+```
+
+### Restart Service
+
+```bash
+# Rolling restart
+kubectl rollout restart deployment/{{SERVICE_NAME}} -n {{NAMESPACE_PROD}}
+
+# Watch rollout
+kubectl rollout status deployment/{{SERVICE_NAME}} -n {{NAMESPACE_PROD}}
+```
+
+### Scale Service
+
+```bash
+# Scale to 5 replicas
+kubectl scale deployment/{{SERVICE_NAME}} -n {{NAMESPACE_PROD}} --replicas=5
+
+# Or via Helm
+helm upgrade {{SERVICE_NAME}} ./deployment/helm/{{SERVICE_NAME}} \
+  -n {{NAMESPACE_PROD}} \
+  --set replicaCount=5
+```
+
+---
+
+## Deployment
+
+### Standard Deployment
+
+```bash
+# Via Harness (recommended)
+# 1. Go to Harness UI
+# 2. Select {{SERVICE_NAME}} pipeline
+# 3. Click "Run Pipeline"
+# 4. Select environment (dev/staging/prod)
+
+# Via Helm (manual)
+helm upgrade --install {{SERVICE_NAME}} ./deployment/helm/{{SERVICE_NAME}} \
+  -n {{NAMESPACE_PROD}} \
+  -f ./deployment/helm/{{SERVICE_NAME}}/values-prod.yaml \
+  --wait --timeout 5m
+```
+
+### Rollback
+
+```bash
+# Helm rollback
+helm rollback {{SERVICE_NAME}} -n {{NAMESPACE_PROD}}
+
+# Rollback to specific revision
+helm rollback {{SERVICE_NAME}} 3 -n {{NAMESPACE_PROD}}
+
+# View history
+helm history {{SERVICE_NAME}} -n {{NAMESPACE_PROD}}
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+#### Issue: Pods Not Starting
+
+**Symptoms:**
+- Pods in `CrashLoopBackOff` or `Pending` state
+- Service unavailable
+
+**Investigation:**
+```bash
+# Check pod events
+kubectl describe pod -n {{NAMESPACE_PROD}} -l app={{SERVICE_NAME}}
+
+# Check logs
+kubectl logs -n {{NAMESPACE_PROD}} -l app={{SERVICE_NAME}} --previous
+
+# Check resource limits
+kubectl top pods -n {{NAMESPACE_PROD}}
+```
+
+**Common Causes:**
+1. **OOM Killed** - Increase memory limit
+2. **Config error** - Check ConfigMap/Secrets
+3. **Image pull error** - Verify registry credentials
+
+---
+
+#### Issue: High Latency
+
+**Symptoms:**
+- Response times > 500ms
+- Alert: High Latency
+
+**Investigation:**
+```bash
+# Check metrics
+kubectl port-forward svc/{{SERVICE_NAME}} 9090:9090 -n {{NAMESPACE_PROD}}
+# Visit http://localhost:9090/metrics
+
+# Check database connections
+kubectl exec -it deployment/{{SERVICE_NAME}} -n {{NAMESPACE_PROD}} -- \
+  node -e "console.log(process.env.DATABASE_POOL_SIZE)"
+```
+
+**Resolutions:**
+1. **Increase replicas** - Scale horizontally
+2. **Check database** - Verify connection pool, slow queries
+3. **Check cache** - Redis connectivity, hit rate
+
+---
+
+#### Issue: High Error Rate
+
+**Symptoms:**
+- Error rate > 1%
+- Alert: High Error Rate
+
+**Investigation:**
+```bash
+# View error logs
+kubectl logs -n {{NAMESPACE_PROD}} -l app={{SERVICE_NAME}} | grep -i error
+
+# Check recent changes
+helm history {{SERVICE_NAME}} -n {{NAMESPACE_PROD}}
+git log --oneline -10
+```
+
+**Resolutions:**
+1. **Recent deployment** - Rollback if needed
+2. **External dependency** - Check downstream services
+3. **Database issues** - Check connection, deadlocks
+
+---
+
+### Database Issues
+
+#### Connection Pool Exhausted
+
+```bash
+# Check active connections
+psql -h $DB_HOST -U $DB_USER -c "SELECT count(*) FROM pg_stat_activity"
+
+# Kill idle connections
+psql -h $DB_HOST -U $DB_USER -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE state = 'idle'"
+```
+
+#### Slow Queries
+
+```bash
+# Identify slow queries
+psql -h $DB_HOST -U $DB_USER -c "SELECT pid, query, age(clock_timestamp(), query_start) FROM pg_stat_activity WHERE state != 'idle' ORDER BY query_start"
+```
+
+---
+
+## Monitoring
+
+### Dashboards
+
+| Dashboard | URL | Purpose |
+|-----------|-----|---------|
+| Service Overview | [Grafana](https://grafana.example.com/d/{{SERVICE_NAME}}) | General health |
+| API Metrics | [Grafana](https://grafana.example.com/d/{{SERVICE_NAME}}-api) | Endpoint metrics |
+| Database | [Grafana](https://grafana.example.com/d/postgres) | DB performance |
+
+### Key Metrics
+
+| Metric | Good | Warning | Critical |
+|--------|------|---------|----------|
+| Error Rate | < 0.1% | < 1% | > 1% |
+| Latency (p99) | < 200ms | < 500ms | > 500ms |
+| CPU Usage | < 50% | < 80% | > 80% |
+| Memory Usage | < 60% | < 80% | > 90% |
+
+### Alerts
+
+| Alert | Severity | Action |
+|-------|----------|--------|
+| HighErrorRate | Critical | Page on-call, investigate immediately |
+| HighLatency | Warning | Investigate during business hours |
+| PodRestart | Warning | Check logs, investigate cause |
+| HighCPU | Warning | Consider scaling |
+
+---
+
+## Incident Response
+
+### Severity Levels
+
+| Level | Definition | Response Time | Examples |
+|-------|------------|---------------|----------|
+| SEV1 | Service down | 15 min | Complete outage |
+| SEV2 | Degraded | 30 min | High error rate |
+| SEV3 | Minor issue | 4 hours | Non-critical bug |
+
+### Escalation Path
+
+1. **Primary On-Call** - {{TEAM_NAME}} engineer
+2. **Secondary On-Call** - Tech Lead
+3. **Escalation** - Engineering Manager
+
+### Communication
+
+- **Slack:** #{{SERVICE_NAME}}-incidents
+- **Status Page:** https://status.example.com
+- **Post-mortem Template:** [Confluence]({{CONFLUENCE_BASE}}/postmortem-template)
+
+---
+
+## Maintenance
+
+### Regular Tasks
+
+| Task | Frequency | Procedure |
+|------|-----------|-----------|
+| Log rotation | Automatic | Configured via Helm |
+| Dependency updates | Monthly | PR via Dependabot |
+| Security patches | As needed | Emergency deployment |
+| Database vacuum | Weekly | Automated job |
+
+### Backup & Recovery
+
+```bash
+# Database backup (daily, automated)
+# Retention: 30 days
+# Location: S3/GCS bucket
+
+# Manual backup
+pg_dump -h $DB_HOST -U $DB_USER {{SERVICE_NAME}} > backup.sql
+
+# Restore
+psql -h $DB_HOST -U $DB_USER {{SERVICE_NAME}} < backup.sql
+```
+
+---
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Secret |
+|----------|-------------|--------|
+| `DATABASE_URL` | DB connection string | Yes |
+| `REDIS_URL` | Cache connection | Yes |
+| `API_KEY` | External API key | Yes |
+| `LOG_LEVEL` | Logging verbosity | No |
+
+### Secrets Management
+
+```bash
+# View secrets (names only)
+kubectl get secrets -n {{NAMESPACE_PROD}}
+
+# Update secret
+kubectl create secret generic {{SERVICE_NAME}}-secrets \
+  -n {{NAMESPACE_PROD}} \
+  --from-literal=key=value \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+---
+
+## Contacts
+
+| Role | Contact | Availability |
+|------|---------|--------------|
+| Team Lead | @lead | Business hours |
+| On-Call | [PagerDuty](https://pagerduty.com/...) | 24/7 |
+| Database Admin | @dba | Business hours |
+
+---
+
+## Related Documentation
+
+- [Technical Design]({{CONFLUENCE_BASE}}/tdd-{{JIRA_KEY}})
+- [API Documentation]({{CONFLUENCE_BASE}}/api-{{JIRA_KEY}})
+- [Development Standards](../docs/DEVELOPMENT-STANDARDS.md)

--- a/plugins/jira-orchestrator/templates/confluence/tdd.md.template
+++ b/plugins/jira-orchestrator/templates/confluence/tdd.md.template
@@ -1,0 +1,257 @@
+# Technical Design Document: {{SERVICE_NAME}}
+
+**Jira Issue:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+**Author:** {{AUTHOR}}
+**Created:** {{DATE}}
+**Status:** Draft | In Review | Approved
+
+---
+
+## Overview
+
+### Problem Statement
+
+{{DESCRIPTION}}
+
+### Goals
+
+- [ ] Goal 1
+- [ ] Goal 2
+- [ ] Goal 3
+
+### Non-Goals
+
+- Non-goal 1
+- Non-goal 2
+
+---
+
+## Architecture
+
+### High-Level Design
+
+```
+[Diagram placeholder - add architecture diagram]
+```
+
+### Component Diagram
+
+| Component | Purpose | Technology |
+|-----------|---------|------------|
+| API Gateway | Request routing | Kong/NGINX |
+| Service | Business logic | Node.js/Python |
+| Database | Data storage | PostgreSQL |
+| Cache | Performance | Redis |
+
+### Data Flow
+
+```
+[Client] → [API Gateway] → [Service] → [Database]
+                              ↓
+                          [Cache]
+```
+
+---
+
+## Technical Decisions
+
+### Technology Stack
+
+| Layer | Technology | Rationale |
+|-------|------------|-----------|
+| Runtime | Node.js 20 | Team expertise, performance |
+| Framework | Fastify | Speed, TypeScript support |
+| Database | PostgreSQL | ACID compliance, JSON support |
+| ORM | Prisma | Type safety, migrations |
+| Container | Docker | Consistency, K8s deployment |
+| Orchestration | Kubernetes | Scalability, Helm charts |
+
+### Architecture Decisions
+
+See [ADR Index](./adr/) for detailed decisions:
+- [ADR-001: Initial Architecture](./adr/0001-initial-architecture.md)
+
+---
+
+## API Design
+
+### Endpoints
+
+| Method | Endpoint | Description | Auth |
+|--------|----------|-------------|------|
+| GET | `/api/v1/resource` | List resources | JWT |
+| POST | `/api/v1/resource` | Create resource | JWT |
+| GET | `/api/v1/resource/:id` | Get resource | JWT |
+| PUT | `/api/v1/resource/:id` | Update resource | JWT |
+| DELETE | `/api/v1/resource/:id` | Delete resource | JWT |
+
+### Request/Response Examples
+
+```json
+// GET /api/v1/resource/:id
+{
+  "id": "123",
+  "name": "Example",
+  "createdAt": "2025-12-31T00:00:00Z"
+}
+```
+
+---
+
+## Data Model
+
+### Entity Diagram
+
+```
+[Entity A] 1──* [Entity B] *──1 [Entity C]
+```
+
+### Database Schema
+
+```sql
+CREATE TABLE resources (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+```
+
+---
+
+## Security Considerations
+
+### Authentication
+
+- JWT-based authentication
+- Token expiration: 1 hour
+- Refresh token support
+
+### Authorization
+
+- Role-based access control (RBAC)
+- Permission levels: read, write, admin
+
+### Data Protection
+
+- [ ] Encryption at rest
+- [ ] Encryption in transit (TLS)
+- [ ] PII handling compliance
+
+---
+
+## Deployment
+
+### Infrastructure
+
+| Environment | Replicas | Resources |
+|-------------|----------|-----------|
+| Development | 1 | 256Mi/0.5 CPU |
+| Staging | 2 | 512Mi/1 CPU |
+| Production | 3+ | 1Gi/2 CPU |
+
+### Helm Chart
+
+Located in `deployment/helm/{{SERVICE_NAME}}/`
+
+### CI/CD Pipeline
+
+- Build: Docker image
+- Test: Unit + Integration
+- Deploy: Helm via Harness
+
+---
+
+## Monitoring & Observability
+
+### Metrics
+
+| Metric | Description | Alert Threshold |
+|--------|-------------|-----------------|
+| `http_requests_total` | Total requests | N/A |
+| `http_request_duration_seconds` | Latency | p99 > 500ms |
+| `error_rate` | Error percentage | > 1% |
+
+### Logging
+
+- Format: JSON structured
+- Level: INFO (prod), DEBUG (dev)
+- Destination: CloudWatch/Stackdriver
+
+### Alerts
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| High Error Rate | > 1% errors | Critical |
+| High Latency | p99 > 500ms | Warning |
+| Pod Restarts | > 3 in 5min | Warning |
+
+---
+
+## Testing Strategy
+
+### Test Types
+
+| Type | Coverage Target | Tools |
+|------|-----------------|-------|
+| Unit | 80% | Jest/Vitest |
+| Integration | Key flows | Supertest |
+| E2E | Critical paths | Playwright |
+
+### Test Environments
+
+- Unit: In-memory
+- Integration: Docker Compose
+- E2E: Staging cluster
+
+---
+
+## Rollout Plan
+
+### Phase 1: Development
+
+- [ ] Core functionality
+- [ ] Unit tests
+- [ ] Local testing
+
+### Phase 2: Staging
+
+- [ ] Integration tests
+- [ ] Performance testing
+- [ ] Security review
+
+### Phase 3: Production
+
+- [ ] Canary deployment (10%)
+- [ ] Full rollout
+- [ ] Monitoring setup
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Database bottleneck | High | Medium | Connection pooling, caching |
+| Third-party API failure | Medium | Low | Circuit breaker, fallbacks |
+
+---
+
+## Open Questions
+
+- [ ] Question 1
+- [ ] Question 2
+
+---
+
+## Appendix
+
+### References
+
+- [SOLID Principles](../docs/DEVELOPMENT-STANDARDS.md#solid-principles--clean-code)
+- [Helm Standards](../docs/DEVELOPMENT-STANDARDS.md#deployment-standards)
+
+### Related Documents
+
+- [API Documentation]({{CONFLUENCE_BASE}}/api-{{JIRA_KEY}})
+- [Runbook]({{CONFLUENCE_BASE}}/runbook-{{JIRA_KEY}})

--- a/plugins/jira-orchestrator/templates/github/PULL_REQUEST_TEMPLATE.md
+++ b/plugins/jira-orchestrator/templates/github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,106 @@
+## Summary
+
+Brief description of changes (2-3 sentences).
+
+**Jira Issue:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+
+## Changes
+
+### Features
+- Feature 1
+- Feature 2
+
+### Bug Fixes
+- Fix 1
+
+### Refactoring
+- Refactor 1
+
+## Acceptance Criteria
+
+- [ ] Criterion 1 from Jira
+- [ ] Criterion 2 from Jira
+- [ ] Criterion 3 from Jira
+
+## Testing
+
+### Test Coverage
+- Unit tests: X% coverage
+- Integration tests: Passing
+- E2E tests: Passing
+
+### Manual Testing Instructions
+1. Step 1
+2. Step 2
+3. Verify expected behavior
+
+## Screenshots
+
+**Before:**
+<!-- Add screenshot if UI changes -->
+
+**After:**
+<!-- Add screenshot if UI changes -->
+
+## Deployment Notes
+
+### Breaking Changes
+- [ ] No breaking changes
+- [ ] Breaking changes documented below:
+  - Change 1: Migration steps...
+
+### Database Migrations
+- [ ] No database migrations
+- [ ] Migrations included: `migrations/XXX_description.sql`
+
+### Environment Variables
+- [ ] No new environment variables
+- [ ] New variables required:
+  ```bash
+  NEW_VAR=value  # Description
+  ```
+
+### Dependencies
+- [ ] No new dependencies
+- [ ] New dependencies:
+  - `package@version` - Purpose
+
+## Code Review Checklist
+
+### Code Quality
+- [ ] Follows SOLID principles
+- [ ] Clean code standards met
+- [ ] No code smells or anti-patterns
+- [ ] Comments added for complex logic
+
+### Testing
+- [ ] Unit tests added/updated
+- [ ] Integration tests for key flows
+- [ ] Coverage >= 80% for new code
+
+### Documentation
+- [ ] README updated (if needed)
+- [ ] API docs updated (if applicable)
+- [ ] Runbook updated (if applicable)
+- [ ] Confluence pages linked
+
+### Security
+- [ ] No secrets in code
+- [ ] Input validation added
+- [ ] SQL injection prevented
+- [ ] XSS prevented (if applicable)
+
+### Deployment
+- [ ] Helm charts valid
+- [ ] Values files updated per environment
+- [ ] No Docker Compose for staging/prod
+
+## Related Issues
+
+- Jira: [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+- Parent: [{{PARENT_KEY}}]({{JIRA_URL}}/browse/{{PARENT_KEY}}) (if applicable)
+- Related: [{{RELATED_KEY}}]({{JIRA_URL}}/browse/{{RELATED_KEY}}) (if applicable)
+
+---
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

--- a/plugins/jira-orchestrator/templates/helm/Chart.yaml.template
+++ b/plugins/jira-orchestrator/templates/helm/Chart.yaml.template
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: {{SERVICE_NAME}}
+description: {{DESCRIPTION}}
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+
+keywords:
+  - {{SERVICE_NAME}}
+  - microservice
+
+home: {{REPO_URL}}
+
+sources:
+  - {{REPO_URL}}
+
+maintainers:
+  - name: {{TEAM_NAME}}
+    email: {{TEAM_EMAIL}}
+
+annotations:
+  jira.issue: "{{JIRA_KEY}}"
+  created.by: "jira-orchestrator"
+  created.date: "{{DATE}}"

--- a/plugins/jira-orchestrator/templates/helm/values.yaml.template
+++ b/plugins/jira-orchestrator/templates/helm/values.yaml.template
@@ -1,0 +1,139 @@
+# Default values for {{SERVICE_NAME}}
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: {{DOCKER_REGISTRY}}/{{SERVICE_NAME}}
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "9090"
+  prometheus.io/path: "/metrics"
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+ingress:
+  enabled: false
+  className: "nginx"
+  annotations:
+    kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: {{SERVICE_NAME}}.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Health checks
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# Environment variables
+env:
+  - name: NODE_ENV
+    value: "production"
+  - name: PORT
+    value: "3000"
+  - name: LOG_LEVEL
+    value: "info"
+
+# External secrets (from Kubernetes secrets)
+envFrom: []
+  # - secretRef:
+  #     name: {{SERVICE_NAME}}-secrets
+
+# ConfigMap
+configMap:
+  enabled: false
+  data: {}
+
+# Persistent Volume
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+
+# Pod Disruption Budget
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Network Policy
+networkPolicy:
+  enabled: false
+
+# Service Monitor for Prometheus
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  path: /metrics
+
+# Jira integration metadata
+jira:
+  issueKey: "{{JIRA_KEY}}"
+  projectKey: "{{JIRA_PROJECT}}"

--- a/plugins/jira-orchestrator/templates/repository/microservice/README.md.template
+++ b/plugins/jira-orchestrator/templates/repository/microservice/README.md.template
@@ -1,0 +1,124 @@
+# {{SERVICE_NAME}}
+
+**Status:** Active | **Jira:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+
+---
+
+## Quick Start
+
+### Local Development
+
+```bash
+# Start with Docker Compose (local only)
+docker-compose up -d
+
+# Run tests
+npm test
+
+# Run linting
+npm run lint
+```
+
+### Kubernetes Deployment
+
+```bash
+# Development
+helm upgrade --install {{SERVICE_NAME}} ./deployment/helm/{{SERVICE_NAME}} \
+  -n {{NAMESPACE_DEV}} \
+  -f ./deployment/helm/{{SERVICE_NAME}}/values-dev.yaml
+
+# Staging
+helm upgrade --install {{SERVICE_NAME}} ./deployment/helm/{{SERVICE_NAME}} \
+  -n {{NAMESPACE_STAGING}} \
+  -f ./deployment/helm/{{SERVICE_NAME}}/values-staging.yaml
+
+# Production (via Harness pipeline)
+# Use Harness UI or: /jira:deploy production --issue {{JIRA_KEY}}
+```
+
+---
+
+## Documentation
+
+| Document | Description | Link |
+|----------|-------------|------|
+| Technical Design | Architecture & design decisions | [Confluence]({{CONFLUENCE_BASE}}/tdd-{{JIRA_KEY}}) |
+| API Reference | Endpoint documentation | [Confluence]({{CONFLUENCE_BASE}}/api-{{JIRA_KEY}}) |
+| Runbook | Operations & troubleshooting | [Confluence]({{CONFLUENCE_BASE}}/runbook-{{JIRA_KEY}}) |
+| ADRs | Architecture decisions | [docs/adr/](./docs/adr/) |
+
+---
+
+## Architecture
+
+```
+{{SERVICE_NAME}}/
+├── src/
+│   ├── controllers/    # Request handlers
+│   ├── services/       # Business logic
+│   ├── repositories/   # Data access
+│   └── models/         # Domain models
+├── tests/
+├── deployment/
+│   └── helm/           # Kubernetes deployment
+└── docs/
+```
+
+See [docs/architecture.md](./docs/architecture.md) for detailed architecture.
+
+---
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/health` | Health check |
+| GET | `/ready` | Readiness probe |
+| GET | `/metrics` | Prometheus metrics |
+
+See [API Documentation]({{CONFLUENCE_BASE}}/api-{{JIRA_KEY}}) for full API reference.
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description | Default |
+|----------|----------|-------------|---------|
+| `NODE_ENV` | Yes | Environment | `development` |
+| `PORT` | No | Service port | `3000` |
+| `LOG_LEVEL` | No | Logging level | `info` |
+
+---
+
+## Pipeline
+
+| Stage | Description | Trigger |
+|-------|-------------|---------|
+| Build | Build Docker image | PR, Push |
+| Test | Run unit & integration tests | PR, Push |
+| Deploy Dev | Deploy to development | Push to main |
+| Deploy Staging | Deploy to staging | Manual |
+| Deploy Prod | Deploy to production | Manual + Approval |
+
+**Harness:** [View Pipeline]({{HARNESS_URL}}/pipelines/{{SERVICE_NAME}})
+
+---
+
+## Contributing
+
+1. Create feature branch: `feature/{{JIRA_PROJECT}}-XXX-description`
+2. Make changes following [Development Standards](./docs/DEVELOPMENT-STANDARDS.md)
+3. Submit PR (direct commits to main are blocked)
+4. Get approval and merge
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed guidelines.
+
+---
+
+## Team
+
+**Owner:** {{TEAM_NAME}} | **Slack:** #{{SERVICE_NAME}}-support
+
+---
+
+**Created:** {{DATE}} | **Last Updated:** {{DATE}}


### PR DESCRIPTION
BREAKING: Enforce PR-only workflow, Helm-first deployment, SOLID principles

Standards Added:
- PR-only workflow (direct commits to main blocked)
- Helm-first deployment (Docker Compose for local dev only)
- SOLID principles and clean code requirements
- Docs folder with Confluence links requirement
- Consistent repository structure standards
- Sub-agents and git worktrees for parallel development

Template Library:
- Repository templates (microservice README)
- Confluence templates (TDD, runbook)
- Helm chart templates (Chart.yaml, values.yaml)
- GitHub templates (PR template)
- ADR templates

New Agent:
- worktree-orchestrator: Manage git worktrees for parallel sub-agent work

Updated Commands:
- work.md: Added mandatory development standards section
- deploy.md: Added Helm-first deployment enforcement

Files: 12 added/modified, 2726 insertions