### PR TITLE
feat(agents): Assign Halo-themed call signs to 9 development agents

### DIFF
--- a/.claude/registry/agents.index.json
+++ b/.claude/registry/agents.index.json
@@ -3107,7 +3107,7 @@
         "priority": "high"
       },
       "claude-desktop-extension": {
-        "callsign": "Nexus",
+        "callsign": "Bridge",
         "faction": "Promethean",
         "path": "agents/orchestration/claude-desktop-extension.md",
         "type": "developer",
@@ -3198,7 +3198,7 @@
         "priority": "medium"
       },
       "model-context-protocol-mcp-expert": {
-        "callsign": "Conduit",
+        "callsign": "Protocol",
         "faction": "Promethean",
         "path": "agents/orchestration/model-context-protocol-mcp-expert.md",
         "type": "developer",
@@ -3598,7 +3598,7 @@
     },
     "atlassian": {
       "github-jira-sync": {
-        "callsign": "Nexus",
+        "callsign": "Liaison",
         "faction": "Forerunner",
         "path": "jira-orchestrator/agents/github-jira-sync.md",
         "type": "coordinator",
@@ -3623,7 +3623,7 @@
         "priority": "high"
       },
       "smart-commit-generator": {
-        "callsign": "Scribe",
+        "callsign": "Quill",
         "faction": "Promethean",
         "path": "jira-orchestrator/agents/smart-commit-generator.md",
         "type": "developer",
@@ -3737,7 +3737,7 @@
         "priority": "high"
       },
       "code-reviewer": {
-        "callsign": "Arbiter",
+        "callsign": "Magistrate",
         "faction": "Spartan",
         "path": "jira-orchestrator/agents/code-reviewer.md",
         "type": "validator",
@@ -3759,7 +3759,7 @@
         "priority": "high"
       },
       "documentation-writer": {
-        "callsign": "Chronicler",
+        "callsign": "Scrivener",
         "faction": "Forerunner",
         "path": "jira-orchestrator/agents/documentation-writer.md",
         "type": "developer",
@@ -3942,7 +3942,7 @@
         "priority": "medium"
       },
       "requirements-analyzer": {
-        "callsign": "Inspector",
+        "callsign": "Analyst",
         "faction": "Promethean",
         "path": "jira-orchestrator/agents/requirements-analyzer.md",
         "type": "analyst",
@@ -3981,7 +3981,7 @@
         "priority": "high"
       },
       "qa-ticket-reviewer": {
-        "callsign": "Examiner",
+        "callsign": "Inspector",
         "faction": "Spartan",
         "path": "jira-orchestrator/agents/qa-ticket-reviewer.md",
         "type": "validator",
@@ -4021,7 +4021,7 @@
         "priority": "medium"
       },
       "qa-confluence-documenter": {
-        "callsign": "Archivist",
+        "callsign": "Chronicler",
         "faction": "Forerunner",
         "path": "jira-orchestrator/agents/qa-confluence-documenter.md",
         "type": "developer",
@@ -4101,7 +4101,7 @@
         "priority": "low"
       },
       "quality-enhancer": {
-        "callsign": "Refiner",
+        "callsign": "Polisher",
         "faction": "Spartan",
         "path": "jira-orchestrator/agents/quality-enhancer.md",
         "type": "developer",

--- a/.claude/registry/agents.index.json
+++ b/.claude/registry/agents.index.json
@@ -97,7 +97,7 @@
         "priority": "medium"
       },
       "ai-engineer": {
-        "callsign": "ai-engineer",
+        "callsign": "Cortex",
         "faction": "Promethean",
         "path": "agents/development/ai-engineer.md",
         "type": "developer",
@@ -141,7 +141,7 @@
         "priority": "high"
       },
       "api-integration-specialist": {
-        "callsign": "api-integration-specialist",
+        "callsign": "Nexus",
         "faction": "Promethean",
         "path": "agents/development/api-integration-specialist.md",
         "type": "developer",
@@ -183,7 +183,7 @@
         "priority": "high"
       },
       "code-architect": {
-        "callsign": "code-architect",
+        "callsign": "Blueprint",
         "faction": "Promethean",
         "path": "agents/development/code-architect.md",
         "type": "developer",
@@ -224,7 +224,7 @@
         "priority": "high"
       },
       "desktop-app-dev": {
-        "callsign": "desktop-app-dev",
+        "callsign": "Terminal",
         "faction": "Promethean",
         "path": "agents/development/desktop-app-dev.md",
         "type": "developer",
@@ -265,7 +265,7 @@
         "priority": "medium"
       },
       "enterprise-integrator-architect": {
-        "callsign": "enterprise-integrator-architect",
+        "callsign": "Conduit",
         "faction": "Promethean",
         "path": "agents/development/enterprise-integrator-architect.md",
         "type": "developer",
@@ -307,7 +307,7 @@
         "priority": "high"
       },
       "mobile-app-builder": {
-        "callsign": "mobile-app-builder",
+        "callsign": "Nomad",
         "faction": "Promethean",
         "path": "agents/development/mobile-app-builder.md",
         "type": "developer",
@@ -346,7 +346,7 @@
         "priority": "medium"
       },
       "project-curator": {
-        "callsign": "project-curator",
+        "callsign": "Keeper",
         "faction": "Promethean",
         "path": "agents/development/project-curator.md",
         "type": "developer",
@@ -384,7 +384,7 @@
         "priority": "medium"
       },
       "rapid-prototyper": {
-        "callsign": "rapid-prototyper",
+        "callsign": "Forge",
         "faction": "Promethean",
         "path": "agents/development/rapid-prototyper.md",
         "type": "developer",
@@ -423,7 +423,7 @@
         "priority": "high"
       },
       "vision-specialist": {
-        "callsign": "vision-specialist",
+        "callsign": "Optic",
         "faction": "Promethean",
         "path": "agents/development/vision-specialist.md",
         "type": "developer",

--- a/.claude/registry/index.json
+++ b/.claude/registry/index.json
@@ -13,6 +13,7 @@
     "totalMcpTools": 80,
     "totalBuiltinTools": 17,
     "totalPlugins": 14,
+    "totalTeams": 16,
     "innovativePlugins": 6
   },
 
@@ -24,7 +25,8 @@
     "workflows": "./workflows.index.json",
     "mcps": "./mcps.index.json",
     "tools": "./tools.index.json",
-    "plugins": "./plugins.index.json"
+    "plugins": "./plugins.index.json",
+    "teams": "./teams.index.json"
   },
 
   "loadStrategy": {

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -1,16 +1,17 @@
 {
   "$schema": "./schema/plugins.schema.json",
   "version": "1.0.0",
-  "lastUpdated": "2025-12-26",
+  "lastUpdated": "2025-12-31",
   "description": "Plugin registry for Claude Code orchestration plugins",
 
   "plugins": {
     "core": {
       "jira-orchestrator": {
-        "path": "../../jira-orchestrator/.claude-plugin/plugin.json",
+        "path": "../../plugins/jira-orchestrator/.claude-plugin/plugin.json",
         "callsign": "Arbiter",
-        "version": "4.0.0",
-        "provides": { "commands": 35, "agents": 60, "skills": 6, "hooks": 7 },
+        "version": "7.1.0",
+        "provides": { "commands": 12, "agents": 66, "teams": 16, "skills": 9, "hooks": 7 },
+        "features": ["autogen-teams", "parent-child-orchestration", "domain-affinity-routing"],
         "status": "active",
         "tier": "enterprise"
       },
@@ -231,9 +232,10 @@
       "standard": 8,
       "advanced": 6
     },
-    "totalCommands": 209,
-    "totalAgents": 191,
-    "totalSkills": 86,
+    "totalCommands": 186,
+    "totalAgents": 197,
+    "totalTeams": 16,
+    "totalSkills": 89,
     "totalHooks": 63,
     "totalWorkflows": 3,
     "innovativePlugins": 7,

--- a/.claude/registry/schema/teams.schema.json
+++ b/.claude/registry/schema/teams.schema.json
@@ -1,0 +1,221 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://anthropic.com/claude-code/teams.schema.v1.json",
+  "title": "Claude Code Agent Teams",
+  "description": "Schema for defining AutoGen-style agent teams with coordination patterns",
+  "type": "object",
+  "required": ["version", "teams"],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "description": {
+      "type": "string"
+    },
+    "lastUpdated": {
+      "type": "string",
+      "format": "date"
+    },
+    "teamPatterns": {
+      "type": "object",
+      "description": "Available coordination patterns for teams",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "teams": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/team"
+      }
+    },
+    "teamCategories": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "activationRules": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "$ref": "#/definitions/activationConfig"
+        },
+        "byComplexity": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/activationConfig"
+          }
+        }
+      }
+    },
+    "communicationProtocols": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/protocol"
+      }
+    }
+  },
+  "definitions": {
+    "team": {
+      "type": "object",
+      "required": ["name", "callsign", "purpose", "pattern", "lead", "members"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable team name"
+        },
+        "callsign": {
+          "type": "string",
+          "description": "Team call sign for identification",
+          "pattern": "^[A-Z]+-\\d+$"
+        },
+        "purpose": {
+          "type": "string",
+          "description": "Team's primary purpose and responsibility"
+        },
+        "pattern": {
+          "type": "string",
+          "enum": ["hierarchical", "round-robin", "broadcast", "debate", "pipeline", "swarm"],
+          "description": "Coordination pattern for team communication"
+        },
+        "faction": {
+          "type": "string",
+          "enum": ["Forerunner", "Promethean", "Spartan", "Mixed"],
+          "description": "Dominant faction alignment"
+        },
+        "lead": {
+          "$ref": "#/definitions/teamMember",
+          "description": "Team leader/coordinator"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/teamMember"
+          },
+          "minItems": 2,
+          "maxItems": 12
+        },
+        "triggers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Keywords/phrases that activate this team"
+        },
+        "workflow": {
+          "type": "object",
+          "properties": {
+            "phases": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "handoffs": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "gates": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "quorum": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "consensusRequired": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "approvalRequired": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "outputs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Combined capabilities of the team"
+        }
+      }
+    },
+    "teamMember": {
+      "type": "object",
+      "required": ["callsign", "agent", "role"],
+      "properties": {
+        "callsign": {
+          "type": "string",
+          "description": "Agent's call sign"
+        },
+        "agent": {
+          "type": "string",
+          "description": "Agent identifier (kebab-case)"
+        },
+        "role": {
+          "type": "string",
+          "description": "Member's role within the team"
+        }
+      }
+    },
+    "activationConfig": {
+      "type": "object",
+      "properties": {
+        "minAgents": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxAgents": {
+          "type": "integer",
+          "maximum": 15
+        },
+        "timeoutMinutes": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "protocol": {
+      "type": "object",
+      "required": ["description", "flow", "aggregation"],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "flow": {
+          "type": "string"
+        },
+        "aggregation": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/.claude/registry/teams.index.json
+++ b/.claude/registry/teams.index.json
@@ -1,0 +1,511 @@
+{
+  "$schema": "./schema/teams.schema.json",
+  "version": "1.0.0",
+  "description": "AutoGen-style agent teams for orchestrated multi-agent collaboration",
+  "lastUpdated": "2024-12-31",
+
+  "teamPatterns": {
+    "hierarchical": "Lead agent coordinates, delegates to specialists, aggregates results",
+    "round-robin": "Agents take turns contributing, each building on previous",
+    "broadcast": "Lead broadcasts task, all agents work in parallel, results merged",
+    "debate": "Agents argue positions, vote on best approach, consensus required",
+    "pipeline": "Sequential handoff, each agent transforms and passes forward",
+    "swarm": "Dynamic self-organization, agents claim tasks based on capability"
+  },
+
+  "teams": {
+    "code-strike": {
+      "name": "Code Strike Team",
+      "callsign": "STRIKE-1",
+      "purpose": "Rapid feature development with built-in architecture review and testing",
+      "pattern": "hierarchical",
+      "faction": "Promethean",
+      "lead": {
+        "callsign": "Genesis",
+        "agent": "feature-dev",
+        "role": "Coordinates feature implementation, delegates to specialists"
+      },
+      "members": [
+        {"callsign": "Blueprint", "agent": "code-architect", "role": "System design and architecture decisions"},
+        {"callsign": "Cortex", "agent": "ai-engineer", "role": "AI/ML implementation when needed"},
+        {"callsign": "Nexus", "agent": "api-integration-specialist", "role": "API design and integration"},
+        {"callsign": "Falcon", "agent": "vitest-specialist", "role": "Unit and integration testing"},
+        {"callsign": "Scrutineer", "agent": "code-review-assistant", "role": "Code quality review"},
+        {"callsign": "Veritas", "agent": "double-check", "role": "Final verification"}
+      ],
+      "triggers": ["implement feature", "build new", "add functionality", "create component"],
+      "workflow": {
+        "phases": ["design", "implement", "test", "review", "verify"],
+        "handoffs": {
+          "design": ["Blueprint"],
+          "implement": ["Genesis", "Cortex", "Nexus"],
+          "test": ["Falcon"],
+          "review": ["Scrutineer"],
+          "verify": ["Veritas"]
+        }
+      },
+      "capabilities": ["feature-development", "architecture", "testing", "code-review"]
+    },
+
+    "quality-council": {
+      "name": "Quality Council",
+      "callsign": "COUNCIL-Q",
+      "purpose": "Comprehensive quality assurance and code review tribunal",
+      "pattern": "debate",
+      "faction": "Mixed",
+      "lead": {
+        "callsign": "Paramount",
+        "agent": "ceo-quality-controller-agent",
+        "role": "Final quality arbiter, breaks ties, sets standards"
+      },
+      "members": [
+        {"callsign": "Magistrate", "agent": "code-reviewer", "role": "Code standards enforcement"},
+        {"callsign": "Inspector", "agent": "qa-ticket-reviewer", "role": "QA checklist validation"},
+        {"callsign": "Bulwark", "agent": "spec-validator", "role": "Specification compliance"},
+        {"callsign": "The Ethereal", "agent": "coverage-analyzer", "role": "Test coverage analysis"},
+        {"callsign": "Diagnostician", "agent": "test-results-analyzer", "role": "Test result interpretation"},
+        {"callsign": "Polisher", "agent": "quality-enhancer", "role": "Quality improvement suggestions"}
+      ],
+      "triggers": ["review code", "quality check", "audit", "approve PR", "gate check"],
+      "workflow": {
+        "phases": ["analyze", "debate", "vote", "verdict"],
+        "quorum": 4,
+        "consensusRequired": 0.66
+      },
+      "capabilities": ["code-review", "quality-assurance", "compliance", "coverage-analysis"]
+    },
+
+    "debug-squadron": {
+      "name": "Debug Squadron",
+      "callsign": "DEBUG-1",
+      "purpose": "Rapid bug detection, root cause analysis, and fix implementation",
+      "pattern": "pipeline",
+      "faction": "Spartan",
+      "lead": {
+        "callsign": "Sleuth",
+        "agent": "bug-detective",
+        "role": "Lead investigator, hypothesis generation"
+      },
+      "members": [
+        {"callsign": "Tracer", "agent": "debug-session", "role": "Execution tracing and state inspection"},
+        {"callsign": "The Illuminant", "agent": "error-analyzer", "role": "Error pattern recognition"},
+        {"callsign": "Prism", "agent": "refractor", "role": "Code path analysis"},
+        {"callsign": "Patcher", "agent": "bug-fix", "role": "Fix implementation"},
+        {"callsign": "Mender", "agent": "test-writer-fixer", "role": "Regression test creation"},
+        {"callsign": "Resolver", "agent": "fix-pr", "role": "PR preparation and CI fixes"}
+      ],
+      "triggers": ["debug", "fix bug", "error", "failing test", "investigate", "root cause"],
+      "workflow": {
+        "phases": ["detect", "trace", "analyze", "hypothesize", "fix", "verify"],
+        "handoffs": {
+          "detect": ["Sleuth", "The Illuminant"],
+          "trace": ["Tracer"],
+          "analyze": ["Prism"],
+          "hypothesize": ["Sleuth"],
+          "fix": ["Patcher"],
+          "verify": ["Mender", "Resolver"]
+        }
+      },
+      "capabilities": ["debugging", "root-cause-analysis", "fix-implementation", "regression-testing"]
+    },
+
+    "ship-crew": {
+      "name": "Ship Crew",
+      "callsign": "SHIP-1",
+      "purpose": "End-to-end deployment pipeline from commit to production",
+      "pattern": "pipeline",
+      "faction": "Spartan",
+      "lead": {
+        "callsign": "Launcher",
+        "agent": "project-shipper",
+        "role": "Deployment orchestration and go/no-go decisions"
+      },
+      "members": [
+        {"callsign": "Chronicler-Prime", "agent": "commit", "role": "Git operations and commit management"},
+        {"callsign": "Navigator", "agent": "helm-chart-developer", "role": "Helm chart preparation"},
+        {"callsign": "Quartermaster", "agent": "helm-release-manager", "role": "Release management"},
+        {"callsign": "Orchestrator-Prime", "agent": "k8s-architect", "role": "Kubernetes deployment"},
+        {"callsign": "Beacon", "agent": "deployment-tracker", "role": "Deployment monitoring"},
+        {"callsign": "Configurator", "agent": "helm-values-manager", "role": "Environment configuration"}
+      ],
+      "triggers": ["deploy", "ship", "release", "push to prod", "helm upgrade", "rollout"],
+      "workflow": {
+        "phases": ["prepare", "configure", "deploy", "verify", "announce"],
+        "gates": {
+          "pre-deploy": ["tests-pass", "review-approved", "security-scan"],
+          "post-deploy": ["health-check", "smoke-test", "rollback-ready"]
+        }
+      },
+      "capabilities": ["deployment", "helm", "kubernetes", "release-management"]
+    },
+
+    "documentation-guild": {
+      "name": "Documentation Guild",
+      "callsign": "DOCS-1",
+      "purpose": "Comprehensive documentation creation and maintenance",
+      "pattern": "broadcast",
+      "faction": "Forerunner",
+      "lead": {
+        "callsign": "Archivist",
+        "agent": "codebase-documenter",
+        "role": "Documentation strategy and synthesis"
+      },
+      "members": [
+        {"callsign": "Scrivener", "agent": "documentation-writer", "role": "Technical writing"},
+        {"callsign": "Surveyor", "agent": "analyze-codebase", "role": "Codebase analysis for docs"},
+        {"callsign": "Publisher", "agent": "confluence-documentation-creator", "role": "Confluence publishing"},
+        {"callsign": "Retriever", "agent": "context7-docs-fetcher", "role": "External docs research"},
+        {"callsign": "Librarian", "agent": "confluence-manager", "role": "Documentation organization"},
+        {"callsign": "Scriptor", "agent": "generate-api-docs", "role": "API documentation"}
+      ],
+      "triggers": ["document", "write docs", "update readme", "api docs", "confluence"],
+      "workflow": {
+        "phases": ["analyze", "draft", "review", "publish", "index"],
+        "outputs": ["README.md", "API docs", "Architecture docs", "Confluence pages"]
+      },
+      "capabilities": ["documentation", "technical-writing", "api-docs", "confluence"]
+    },
+
+    "security-tribunal": {
+      "name": "Security Tribunal",
+      "callsign": "SEC-1",
+      "purpose": "Security review, vulnerability assessment, and compliance verification",
+      "pattern": "debate",
+      "faction": "Mixed",
+      "lead": {
+        "callsign": "Bastion",
+        "agent": "security-guidance",
+        "role": "Security strategy and final verdict"
+      },
+      "members": [
+        {"callsign": "Sentinel-Enterprise", "agent": "enterprise-security-reviewer", "role": "Enterprise security review"},
+        {"callsign": "Custodian", "agent": "data-privacy-engineer", "role": "Data privacy assessment"},
+        {"callsign": "Ethicist", "agent": "ai-ethics-governance-specialist", "role": "AI ethics review"},
+        {"callsign": "Guardian-K8s", "agent": "k8s-security-specialist", "role": "Kubernetes security"},
+        {"callsign": "Auditor-Prime", "agent": "legal-compliance-checker", "role": "Compliance verification"},
+        {"callsign": "Counselor", "agent": "legal-advisor", "role": "Legal implications"}
+      ],
+      "triggers": ["security review", "vulnerability", "audit", "compliance", "penetration test", "threat model"],
+      "workflow": {
+        "phases": ["scan", "analyze", "assess", "debate", "verdict", "remediate"],
+        "severityLevels": ["critical", "high", "medium", "low", "informational"],
+        "requiredForMerge": true
+      },
+      "capabilities": ["security-review", "vulnerability-assessment", "compliance", "threat-modeling"]
+    },
+
+    "mobile-force": {
+      "name": "Mobile Force",
+      "callsign": "MOBILE-1",
+      "purpose": "Cross-platform mobile development and optimization",
+      "pattern": "hierarchical",
+      "faction": "Promethean",
+      "lead": {
+        "callsign": "Hybrid-Prime",
+        "agent": "react-native-specialist",
+        "role": "Cross-platform strategy and coordination"
+      },
+      "members": [
+        {"callsign": "Apex", "agent": "ios-specialist", "role": "iOS-specific implementation"},
+        {"callsign": "Droid", "agent": "android-specialist", "role": "Android-specific implementation"},
+        {"callsign": "Wings", "agent": "flutter-specialist", "role": "Flutter alternatives"},
+        {"callsign": "Nomad", "agent": "mobile-app-builder", "role": "Mobile app architecture"},
+        {"callsign": "Touch", "agent": "mobile-ux-optimizer", "role": "Mobile UX optimization"},
+        {"callsign": "Ranker", "agent": "app-store-optimizer", "role": "App store optimization"}
+      ],
+      "triggers": ["mobile app", "ios", "android", "react native", "flutter", "app store"],
+      "workflow": {
+        "phases": ["design", "implement", "test-devices", "optimize", "publish"]
+      },
+      "capabilities": ["mobile-development", "ios", "android", "react-native", "flutter"]
+    },
+
+    "data-pipeline": {
+      "name": "Data Pipeline",
+      "callsign": "DATA-1",
+      "purpose": "Data architecture, analytics, and AI/ML implementation",
+      "pattern": "pipeline",
+      "faction": "Promethean",
+      "lead": {
+        "callsign": "Cortex",
+        "agent": "ai-engineer",
+        "role": "AI/ML strategy and implementation"
+      },
+      "members": [
+        {"callsign": "Schema-Forge", "agent": "mongodb-schema-designer", "role": "Database schema design"},
+        {"callsign": "Query-Master", "agent": "mongodb-query-optimizer", "role": "Query optimization"},
+        {"callsign": "Aggregator", "agent": "mongodb-aggregation-specialist", "role": "Data aggregation"},
+        {"callsign": "Cipher-Prime", "agent": "analytics-reporter", "role": "Analytics and reporting"},
+        {"callsign": "Epoch", "agent": "kafka-specialist", "role": "Event streaming"},
+        {"callsign": "Spectra", "agent": "prisma-specialist", "role": "ORM and type-safe queries"}
+      ],
+      "triggers": ["data pipeline", "analytics", "ml model", "database", "mongodb", "kafka"],
+      "workflow": {
+        "phases": ["schema", "ingest", "transform", "analyze", "serve"]
+      },
+      "capabilities": ["data-engineering", "analytics", "machine-learning", "databases"]
+    },
+
+    "frontend-forge": {
+      "name": "Frontend Forge",
+      "callsign": "UI-1",
+      "purpose": "Frontend development, theming, and UX optimization",
+      "pattern": "hierarchical",
+      "faction": "Promethean",
+      "lead": {
+        "callsign": "Weaver",
+        "agent": "theme-system-architect",
+        "role": "Frontend architecture and design system"
+      },
+      "members": [
+        {"callsign": "Artisan", "agent": "theme-builder", "role": "Theme implementation"},
+        {"callsign": "Chameleon", "agent": "white-label-specialist", "role": "White-label customization"},
+        {"callsign": "Resonant", "agent": "graphql-specialist", "role": "GraphQL data layer"},
+        {"callsign": "Illustrator", "agent": "visual-storyteller", "role": "Visual design"},
+        {"callsign": "Empathist", "agent": "ux-researcher", "role": "UX research and testing"},
+        {"callsign": "Aegis-Prime", "agent": "brand-guardian", "role": "Brand consistency"}
+      ],
+      "triggers": ["frontend", "ui", "theme", "design system", "component", "ux"],
+      "workflow": {
+        "phases": ["design", "prototype", "implement", "test", "polish"]
+      },
+      "capabilities": ["frontend-development", "theming", "design-systems", "ux"]
+    },
+
+    "identity-vault": {
+      "name": "Identity Vault",
+      "callsign": "AUTH-1",
+      "purpose": "Authentication, authorization, and identity management",
+      "pattern": "hierarchical",
+      "faction": "Promethean",
+      "lead": {
+        "callsign": "Realm-Master",
+        "agent": "keycloak-realm-admin",
+        "role": "Identity architecture and realm management"
+      },
+      "members": [
+        {"callsign": "Identity", "agent": "keycloak-identity-specialist", "role": "Identity configuration"},
+        {"callsign": "Sentinel-Auth", "agent": "keycloak-auth-flow-designer", "role": "Auth flow design"},
+        {"callsign": "Inquisitor-Auth", "agent": "keycloak-security-auditor", "role": "Security auditing"},
+        {"callsign": "Stylist", "agent": "keycloak-theme-developer", "role": "Login theme customization"},
+        {"callsign": "Custodian", "agent": "data-privacy-engineer", "role": "Privacy compliance"}
+      ],
+      "triggers": ["keycloak", "authentication", "oauth", "sso", "identity", "login"],
+      "workflow": {
+        "phases": ["design", "configure", "secure", "theme", "test"]
+      },
+      "capabilities": ["authentication", "authorization", "keycloak", "sso", "oauth"]
+    },
+
+    "atlassian-ops": {
+      "name": "Atlassian Ops",
+      "callsign": "JIRA-1",
+      "purpose": "Jira and Confluence workflow automation",
+      "pattern": "swarm",
+      "faction": "Forerunner",
+      "lead": {
+        "callsign": "Conductor",
+        "agent": "completion-orchestrator",
+        "role": "Workflow orchestration and completion tracking"
+      },
+      "members": [
+        {"callsign": "Sentinel", "agent": "triage-agent", "role": "Issue triage and prioritization"},
+        {"callsign": "Enhancer", "agent": "task-enricher", "role": "Task enrichment"},
+        {"callsign": "Divider", "agent": "epic-decomposer", "role": "Epic breakdown"},
+        {"callsign": "Liaison", "agent": "github-jira-sync", "role": "GitHub-Jira synchronization"},
+        {"callsign": "Librarian", "agent": "confluence-manager", "role": "Confluence management"},
+        {"callsign": "Tactician", "agent": "test-strategist", "role": "Test strategy planning"},
+        {"callsign": "Gateway", "agent": "pr-creator", "role": "PR creation and linking"},
+        {"callsign": "Quill", "agent": "smart-commit-generator", "role": "Smart commit messages"}
+      ],
+      "triggers": ["jira", "confluence", "sprint", "epic", "story", "ticket"],
+      "workflow": {
+        "phases": ["triage", "enrich", "decompose", "assign", "track", "complete"]
+      },
+      "capabilities": ["jira-automation", "confluence", "workflow-management", "sprint-planning"]
+    },
+
+    "pr-review-panel": {
+      "name": "PR Review Panel",
+      "callsign": "REVIEW-1",
+      "purpose": "Comprehensive pull request review and approval",
+      "pattern": "round-robin",
+      "faction": "Mixed",
+      "lead": {
+        "callsign": "Inquisitor",
+        "agent": "pr-review-toolkit",
+        "role": "Review orchestration and final approval"
+      },
+      "members": [
+        {"callsign": "Examiner", "agent": "analyze-issue", "role": "Issue-PR alignment check"},
+        {"callsign": "Scrutineer", "agent": "code-review-assistant", "role": "Code quality review"},
+        {"callsign": "Magistrate", "agent": "code-reviewer", "role": "Standards enforcement"},
+        {"callsign": "Falcon", "agent": "vitest-specialist", "role": "Test review"},
+        {"callsign": "Moderator", "agent": "review-facilitator", "role": "Discussion facilitation"},
+        {"callsign": "Monitor", "agent": "review-progress-tracker", "role": "Progress tracking"}
+      ],
+      "triggers": ["review pr", "pull request", "code review", "approve", "request changes"],
+      "workflow": {
+        "phases": ["context", "review", "discuss", "iterate", "approve"],
+        "approvalRequired": 2
+      },
+      "capabilities": ["code-review", "pr-management", "quality-gates"]
+    },
+
+    "growth-squad": {
+      "name": "Growth Squad",
+      "callsign": "GROWTH-1",
+      "purpose": "Marketing, growth hacking, and user acquisition",
+      "pattern": "broadcast",
+      "faction": "Spartan",
+      "lead": {
+        "callsign": "Accelerant",
+        "agent": "growth-hacker",
+        "role": "Growth strategy and experimentation"
+      },
+      "members": [
+        {"callsign": "Wordsmith", "agent": "content-creator", "role": "Content creation"},
+        {"callsign": "Tweeter", "agent": "twitter-engager", "role": "Twitter/X engagement"},
+        {"callsign": "Redditor", "agent": "reddit-community-builder", "role": "Reddit community"},
+        {"callsign": "Viral", "agent": "tiktok-strategist", "role": "TikTok strategy"},
+        {"callsign": "Aesthete", "agent": "instagram-curator", "role": "Instagram curation"},
+        {"callsign": "Ranker", "agent": "app-store-optimizer", "role": "ASO optimization"}
+      ],
+      "triggers": ["marketing", "growth", "social media", "content", "viral", "acquisition"],
+      "workflow": {
+        "phases": ["strategize", "create", "distribute", "engage", "analyze"]
+      },
+      "capabilities": ["marketing", "social-media", "content-creation", "growth-hacking"]
+    },
+
+    "migration-convoy": {
+      "name": "Migration Convoy",
+      "callsign": "MIGRATE-1",
+      "purpose": "Code migration, refactoring, and modernization",
+      "pattern": "pipeline",
+      "faction": "Promethean",
+      "lead": {
+        "callsign": "Exodus",
+        "agent": "code-migration-specialist",
+        "role": "Migration strategy and execution"
+      },
+      "members": [
+        {"callsign": "Zephyrus", "agent": "refactoring-guru", "role": "Refactoring patterns"},
+        {"callsign": "Surveyor", "agent": "analyze-codebase", "role": "Codebase analysis"},
+        {"callsign": "Blueprint", "agent": "code-architect", "role": "Architecture planning"},
+        {"callsign": "Silhouette", "agent": "dependency-analyzer", "role": "Dependency mapping"},
+        {"callsign": "Mender", "agent": "test-writer-fixer", "role": "Test migration"},
+        {"callsign": "Veritas", "agent": "double-check", "role": "Migration verification"}
+      ],
+      "triggers": ["migrate", "refactor", "modernize", "upgrade", "legacy"],
+      "workflow": {
+        "phases": ["analyze", "plan", "migrate", "test", "verify", "cleanup"]
+      },
+      "capabilities": ["migration", "refactoring", "modernization", "dependency-management"]
+    },
+
+    "messaging-hub": {
+      "name": "Messaging Hub",
+      "callsign": "MSG-1",
+      "purpose": "Event-driven architecture and messaging systems",
+      "pattern": "hierarchical",
+      "faction": "Promethean",
+      "lead": {
+        "callsign": "The Solstice",
+        "agent": "event-streaming-architect",
+        "role": "Event architecture design"
+      },
+      "members": [
+        {"callsign": "Epoch", "agent": "kafka-specialist", "role": "Kafka implementation"},
+        {"callsign": "Striker", "agent": "rabbitmq-specialist", "role": "RabbitMQ implementation"},
+        {"callsign": "Conduit", "agent": "enterprise-integrator-architect", "role": "Enterprise integration"},
+        {"callsign": "Static", "agent": "redis-specialist", "role": "Redis pub/sub and caching"}
+      ],
+      "triggers": ["kafka", "rabbitmq", "event-driven", "messaging", "pub-sub", "queue"],
+      "workflow": {
+        "phases": ["design", "implement", "test", "deploy", "monitor"]
+      },
+      "capabilities": ["event-streaming", "messaging", "kafka", "rabbitmq", "redis"]
+    },
+
+    "multi-tenant-architects": {
+      "name": "Multi-Tenant Architects",
+      "callsign": "TENANT-1",
+      "purpose": "Multi-tenant architecture and tenant provisioning",
+      "pattern": "hierarchical",
+      "faction": "Promethean",
+      "lead": {
+        "callsign": "Partitioner",
+        "agent": "multi-tenant-architect",
+        "role": "Multi-tenant architecture design"
+      },
+      "members": [
+        {"callsign": "Provisioner", "agent": "tenant-provisioning-specialist", "role": "Tenant provisioning"},
+        {"callsign": "Realm-Master", "agent": "keycloak-realm-admin", "role": "Tenant identity"},
+        {"callsign": "Schema-Forge", "agent": "mongodb-schema-designer", "role": "Tenant data isolation"},
+        {"callsign": "Merchant", "agent": "stripe-integration-specialist", "role": "Tenant billing"},
+        {"callsign": "Chameleon", "agent": "white-label-specialist", "role": "Tenant branding"}
+      ],
+      "triggers": ["multi-tenant", "tenant", "saas", "isolation", "provisioning"],
+      "workflow": {
+        "phases": ["design", "provision", "configure", "brand", "activate"]
+      },
+      "capabilities": ["multi-tenancy", "saas-architecture", "tenant-isolation", "provisioning"]
+    }
+  },
+
+  "teamCategories": {
+    "development": ["code-strike", "frontend-forge", "mobile-force", "data-pipeline"],
+    "quality": ["quality-council", "debug-squadron", "pr-review-panel", "security-tribunal"],
+    "operations": ["ship-crew", "atlassian-ops", "messaging-hub"],
+    "specialized": ["identity-vault", "multi-tenant-architects", "migration-convoy"],
+    "business": ["growth-squad", "documentation-guild"]
+  },
+
+  "activationRules": {
+    "default": {
+      "minAgents": 3,
+      "maxAgents": 8,
+      "timeoutMinutes": 30
+    },
+    "byComplexity": {
+      "simple": {"minAgents": 2, "maxAgents": 4},
+      "moderate": {"minAgents": 3, "maxAgents": 6},
+      "complex": {"minAgents": 5, "maxAgents": 10},
+      "critical": {"minAgents": 6, "maxAgents": 12}
+    }
+  },
+
+  "communicationProtocols": {
+    "hierarchical": {
+      "description": "Lead coordinates all communication",
+      "flow": "lead -> members -> lead",
+      "aggregation": "lead synthesizes all outputs"
+    },
+    "round-robin": {
+      "description": "Sequential contribution building on previous",
+      "flow": "member1 -> member2 -> ... -> memberN",
+      "aggregation": "final member produces combined output"
+    },
+    "broadcast": {
+      "description": "Parallel execution with merge",
+      "flow": "lead -> all members (parallel) -> lead",
+      "aggregation": "lead merges parallel outputs"
+    },
+    "debate": {
+      "description": "Adversarial discussion with voting",
+      "flow": "all members debate -> vote -> consensus",
+      "aggregation": "majority or consensus decision"
+    },
+    "pipeline": {
+      "description": "Sequential transformation chain",
+      "flow": "stage1 -> stage2 -> ... -> stageN",
+      "aggregation": "final stage output is result"
+    },
+    "swarm": {
+      "description": "Self-organizing task claiming",
+      "flow": "tasks broadcast -> agents claim -> execute",
+      "aggregation": "dynamic based on completion"
+    }
+  }
+}

--- a/plugins/jira-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/jira-orchestrator/.claude-plugin/plugin.json
@@ -1,15 +1,23 @@
 {
   "name": "jira-orchestrator",
-  "version": "6.0.0",
-  "description": "Enterprise Jira orchestration - 66 agents, 12 commands (consolidated from 40), hook-based automation",
+  "version": "7.1.0",
+  "description": "Enterprise Jira orchestration - 66 agents, 16 teams, 12 commands, hook-based automation with AutoGen-style team coordination",
   "author": {"name": "The Lobbi", "email": "developers@thelobbi.io"},
-  "keywords": ["jira", "confluence", "orchestration", "automation", "agile", "sprint", "enterprise", "compliance", "harness", "helm", "terraform", "kubernetes", "infrastructure", "gitops", "hooks"],
+  "keywords": ["jira", "confluence", "orchestration", "automation", "agile", "sprint", "enterprise", "compliance", "harness", "helm", "terraform", "kubernetes", "infrastructure", "gitops", "hooks", "autogen", "teams", "multi-agent"],
   "license": "MIT",
   "registry": {
     "agents": "registry/agents.index.json",
     "commands": "registry/commands.index.json",
     "hooks": "hooks/orchestration-hooks.json",
-    "workflows": "registry/workflows.index.json"
+    "workflows": "registry/workflows.index.json",
+    "teams": "../../.claude/registry/teams.index.json",
+    "teamConfig": "config/agent-teams.yaml"
+  },
+  "features": {
+    "autogenTeams": true,
+    "parentChildOrchestration": true,
+    "domainAffinityRouting": true,
+    "phaseTeamMapping": true
   },
   "context_efficient": true,
   "load_strategy": "on-demand",

--- a/plugins/jira-orchestrator/README.md
+++ b/plugins/jira-orchestrator/README.md
@@ -1,8 +1,10 @@
 # Jira Orchestrator Plugin
 
-**Version:** 7.0.0 | **Agents:** 66 | **Skills:** 9 | **Commands:** 12 | **Hooks:** Auto-triggered
+**Version:** 7.1.0 | **Agents:** 66 | **Teams:** 16 | **Skills:** 9 | **Commands:** 12 | **Hooks:** Auto-triggered
 
-**NEW in v7.0:** Comprehensive Harness platform knowledge - CI, CD, Code, Feature Flags, STO, CCM, SRM, Chaos Engineering, IaCM, Delegates, RBAC, OPA, Templates, and Secrets Management.
+**NEW in v7.1:** AutoGen-style agent teams for orchestrated collaboration, parent-child issue orchestration, and domain affinity routing.
+
+**v7.0 Features:** Comprehensive Harness platform knowledge - CI, CD, Code, Feature Flags, STO, CCM, SRM, Chaos Engineering, IaCM, Delegates, RBAC, OPA, Templates, and Secrets Management.
 
 ---
 

--- a/plugins/jira-orchestrator/commands/work.md
+++ b/plugins/jira-orchestrator/commands/work.md
@@ -488,6 +488,76 @@ for agent in agent_selection.recommended_agents:
 
 **Fallback Strategy:** If no specific agents match, use phase-appropriate defaults from agent-router output.
 
+### AutoGen-Style Team Activation (NEW - RECOMMENDED)
+
+**IMPORTANT:** For complex issues, activate full agent TEAMS instead of individual agents.
+
+Teams provide coordinated multi-agent collaboration with defined leads and communication patterns.
+See `jira-orchestrator/config/agent-teams.yaml` for full team configuration.
+
+#### Team Activation by Phase:
+
+| Phase | Primary Team | Call Sign | Lead Agent |
+|-------|--------------|-----------|------------|
+| EXPLORE | Documentation Guild | DOCS-1 | Archivist |
+| PLAN | Code Strike Team | STRIKE-1 | Genesis |
+| CODE | Code Strike Team | STRIKE-1 | Genesis |
+| TEST | Quality Council | COUNCIL-Q | Paramount |
+| FIX | Debug Squadron | DEBUG-1 | Sleuth |
+| DOCUMENT | Documentation Guild | DOCS-1 | Archivist |
+
+#### Team Activation by Issue Type:
+
+| Issue Type | Primary Team | Pattern |
+|------------|--------------|---------|
+| Bug | Debug Squadron (DEBUG-1) | pipeline |
+| Story | Code Strike (STRIKE-1) | hierarchical |
+| Task | Code Strike (STRIKE-1) | hierarchical |
+| Epic | Atlassian Ops (JIRA-1) | swarm |
+
+#### Domain-Specific Teams (activated by labels/components):
+
+| Domain | Team | Call Sign | When to Activate |
+|--------|------|-----------|------------------|
+| Frontend | Frontend Forge | UI-1 | `domain:frontend`, `tech:react` |
+| Mobile | Mobile Force | MOBILE-1 | `domain:mobile`, `tech:react-native` |
+| Auth | Identity Vault | AUTH-1 | `domain:security`, `tech:keycloak` |
+| Data/ML | Data Pipeline | DATA-1 | `domain:database`, `tech:mongodb` |
+| DevOps | Ship Crew | SHIP-1 | `domain:devops`, `tech:kubernetes` |
+| Security | Security Tribunal | SEC-1 | `needs:security-review` |
+| Messaging | Messaging Hub | MSG-1 | `tech:kafka`, `tech:rabbitmq` |
+
+#### Team Activation Example:
+
+```yaml
+# For a Story with labels: [domain:frontend, tech:react, needs:review]
+
+1. Load teams config: jira-orchestrator/config/agent-teams.yaml
+2. Match labels against label_teams:
+   - domain:frontend → frontend-forge (UI-1)
+   - needs:review → pr-review-panel (REVIEW-1)
+3. Activate teams for CODE phase:
+   - Primary: code-strike (STRIKE-1) - Genesis leads
+   - Domain: frontend-forge (UI-1) - Weaver leads
+4. Execute with team coordination:
+   - Genesis (STRIKE-1 lead) coordinates with Weaver (UI-1 lead)
+   - Team members work in parallel per team pattern
+   - Checkpoint sync between teams
+```
+
+#### Team Communication Patterns:
+
+| Pattern | Description | Best For |
+|---------|-------------|----------|
+| hierarchical | Lead coordinates all | Feature development |
+| round-robin | Sequential contributions | Code review |
+| broadcast | Parallel execution | Documentation |
+| debate | Discussion with voting | Quality decisions |
+| pipeline | Sequential transformation | Bug fixing |
+| swarm | Self-organizing | Complex epics |
+
+**Configuration:** See `.claude/registry/teams.index.json` for full team definitions.
+
 ### NEW: PR Size Strategy (After PLAN phase)
 
 **IMPORTANT:** Before starting CODE phase, invoke the `pr-size-estimator` agent to:

--- a/plugins/jira-orchestrator/commands/work.md
+++ b/plugins/jira-orchestrator/commands/work.md
@@ -508,12 +508,17 @@ See `jira-orchestrator/config/agent-teams.yaml` for full team configuration.
 
 #### Team Activation by Issue Type:
 
-| Issue Type | Primary Team | Pattern |
-|------------|--------------|---------|
-| Bug | Debug Squadron (DEBUG-1) | pipeline |
-| Story | Code Strike (STRIKE-1) | hierarchical |
-| Task | Code Strike (STRIKE-1) | hierarchical |
-| Epic | Atlassian Ops (JIRA-1) | swarm |
+| Issue Type | Primary Team | Pattern | Description |
+|------------|--------------|---------|-------------|
+| Initiative | Atlassian Ops (JIRA-1) | swarm | Strategic initiatives spanning epics |
+| Epic | Atlassian Ops (JIRA-1) | swarm | Large features → stories |
+| Story | Code Strike (STRIKE-1) | hierarchical | User-facing features |
+| Task | Code Strike (STRIKE-1) | hierarchical | Technical work items |
+| Sub-task | Code Strike (STRIKE-1) | pipeline | Granular work (inherits parent) |
+| Bug | Debug Squadron (DEBUG-1) | pipeline | Defects and fixes |
+| Spike | Documentation Guild (DOCS-1) | broadcast | Research & investigation |
+| Technical-Debt | Migration Convoy (MIGRATE-1) | pipeline | Refactoring work |
+| Security | Security Tribunal (SEC-1) | debate | Security hardening |
 
 #### Domain-Specific Teams (activated by labels/components):
 

--- a/plugins/jira-orchestrator/config/agent-teams.yaml
+++ b/plugins/jira-orchestrator/config/agent-teams.yaml
@@ -408,20 +408,238 @@ metrics:
   report_to: "confluence"
   dashboard_page: "Team Performance Dashboard"
 
-# Example Usage in Jira Work Command
+# Parent-Child Issue Orchestration
+# Handles Task with Sub-tasks, Story with Tasks, Epic with Stories
+parent_child_orchestration:
+  # Enable parent-child detection and handling
+  enabled: true
+
+  # Hierarchy definitions
+  hierarchy:
+    Initiative:
+      children: ["Epic"]
+      orchestration_pattern: "cascade"
+    Epic:
+      children: ["Story", "Task", "Bug"]
+      orchestration_pattern: "cascade"
+    Story:
+      children: ["Sub-task", "Task"]
+      orchestration_pattern: "parallel"
+    Task:
+      children: ["Sub-task"]
+      orchestration_pattern: "parallel"
+
+  # Team inheritance rules
+  inheritance:
+    # How child issues inherit team assignments
+    strategy: "merge"  # merge, override, inherit_primary
+
+    # What to inherit from parent
+    inherit_from_parent:
+      - primary_team
+      - domain_teams      # From labels like domain:frontend
+      - technology_teams  # From labels like tech:react
+      - component_teams
+
+    # Child can override these
+    child_can_override:
+      - phase_teams
+      - secondary_teams
+
+    # Always use parent's team for these
+    force_parent_teams:
+      - security_context   # Security team from parent always applies
+      - review_teams       # PR review inherits parent context
+
+  # Parallel Sub-task Execution
+  parallel_subtasks:
+    enabled: true
+    max_concurrent: 5
+
+    # How to distribute work
+    distribution:
+      strategy: "domain_affinity"  # domain_affinity, round_robin, load_balanced
+
+      # Domain affinity rules - route subtasks to specialized teams
+      affinity_rules:
+        - pattern: ".*frontend.*|.*UI.*|.*component.*"
+          team: "frontend-forge"
+        - pattern: ".*backend.*|.*API.*|.*service.*"
+          team: "code-strike"
+        - pattern: ".*test.*|.*spec.*|.*coverage.*"
+          team: "quality-council"
+        - pattern: ".*database.*|.*migration.*|.*schema.*"
+          team: "data-pipeline"
+        - pattern: ".*auth.*|.*login.*|.*permission.*"
+          team: "identity-vault"
+        - pattern: ".*deploy.*|.*infra.*|.*k8s.*"
+          team: "ship-crew"
+        - pattern: ".*doc.*|.*readme.*|.*confluence.*"
+          team: "documentation-guild"
+
+    # Synchronization points
+    sync_points:
+      - after_explore: true    # Sync after all subtasks complete EXPLORE
+      - after_code: true       # Sync after all subtasks complete CODE
+      - before_test: true      # Sync before parent TEST phase
+      - after_fix: true        # Sync fixes before final review
+
+    # Dependency handling
+    dependencies:
+      respect_jira_links: true   # Honor Jira "blocks" relationships
+      auto_sequence: false       # Auto-detect dependencies from code
+      block_on_failure: true     # Block dependent subtasks on failure
+
+  # Parent Task Coordination
+  parent_coordination:
+    # Parent task role during subtask execution
+    parent_role: "coordinator"  # coordinator, participant, observer
+
+    # Teams for parent coordination
+    coordinator_teams:
+      primary: "atlassian-ops"   # JIRA-1: Divider manages decomposition
+      support: "code-strike"     # STRIKE-1: Blueprint for architecture
+
+    # Parent responsibilities
+    responsibilities:
+      - monitor_subtask_progress
+      - resolve_blockers
+      - merge_subtask_results
+      - quality_gate_enforcement
+      - status_aggregation
+
+    # Status propagation rules
+    status_propagation:
+      # When all subtasks complete, update parent
+      all_complete: "mark_parent_ready_for_review"
+      # When any subtask fails, update parent
+      any_failed: "mark_parent_blocked"
+      # When any subtask blocked, notify parent
+      any_blocked: "escalate_to_parent_team"
+
+    # Aggregation rules
+    aggregation:
+      # How to combine subtask outputs
+      code_changes: "merge_to_parent_branch"
+      test_results: "aggregate_coverage"
+      documentation: "compile_to_parent_page"
+
+  # Phase Coordination for Parent-Child
+  phase_coordination:
+    EXPLORE:
+      parent_action: "decompose_and_assign"
+      subtask_action: "analyze_assigned_scope"
+      teams:
+        parent: ["atlassian-ops", "documentation-guild"]
+        subtask: "inherit"  # Inherits from parent
+      sync_required: true
+
+    PLAN:
+      parent_action: "review_subtask_plans"
+      subtask_action: "plan_implementation"
+      teams:
+        parent: ["atlassian-ops"]
+        subtask: ["code-strike"]
+      sync_required: true
+
+    CODE:
+      parent_action: "monitor_and_unblock"
+      subtask_action: "implement"
+      teams:
+        parent: ["atlassian-ops"]
+        subtask: "domain_affinity"  # Based on subtask content
+      sync_required: false  # Parallel execution
+      parallel_allowed: true
+
+    TEST:
+      parent_action: "aggregate_results"
+      subtask_action: "test_scope"
+      teams:
+        parent: ["quality-council"]
+        subtask: ["quality-council"]
+      sync_required: true  # Wait for all tests
+
+    FIX:
+      parent_action: "coordinate_fixes"
+      subtask_action: "fix_assigned"
+      teams:
+        parent: ["debug-squadron"]
+        subtask: ["debug-squadron", "code-strike"]
+      sync_required: false
+      parallel_allowed: true
+
+    DOCUMENT:
+      parent_action: "compile_documentation"
+      subtask_action: "document_scope"
+      teams:
+        parent: ["documentation-guild", "atlassian-ops"]
+        subtask: ["documentation-guild"]
+      sync_required: true
+
+  # Subtask Creation Rules
+  subtask_creation:
+    # When parent detects need for subtasks
+    auto_create: false  # Manual or via /jira:prepare
+
+    # Template for new subtasks
+    template:
+      inherit_labels: true
+      inherit_components: true
+      inherit_sprint: true
+      add_labels:
+        - "auto-created"
+        - "parent:${PARENT_KEY}"
+
+    # Team assignment for new subtasks
+    team_assignment:
+      strategy: "domain_detection"  # Analyze subtask summary for domain
+      fallback: "parent_primary"    # Use parent's primary team
+
+  # Completion Criteria
+  completion:
+    # Parent can only complete when:
+    require_all_subtasks_done: true
+    require_all_tests_pass: true
+    require_documentation: true
+
+    # Automatic status transitions
+    auto_transitions:
+      all_subtasks_in_review: "parent_to_review"
+      all_subtasks_done: "parent_to_qa"
+      qa_passed: "parent_to_done"
+
+# Example Usage for Task with Subtasks
 #
-# 1. On /jira:work ABC-123:
-#    - Fetch issue type, labels, components
-#    - Match against label_teams, component_teams
-#    - Activate phase_teams[EXPLORE].primary
-#    - Use team leads for coordination
+# 1. On /jira:work TASK-123 (has 3 subtasks):
+#    - Detect parent-child relationship
+#    - Load parent context (labels, components, teams)
+#    - Identify subtasks: TASK-123-1, TASK-123-2, TASK-123-3
 #
-# 2. During CODE phase with labels ["domain:frontend", "tech:react"]:
-#    - Primary: code-strike (STRIKE-1)
-#    - Additional: frontend-forge (UI-1)
-#    - Lead coordination: Genesis -> Weaver
+# 2. EXPLORE Phase:
+#    - Parent Team (JIRA-1): Analyze full scope
+#    - Assign subtasks to teams based on domain affinity
+#    - TASK-123-1 (frontend) -> UI-1
+#    - TASK-123-2 (backend) -> STRIKE-1
+#    - TASK-123-3 (tests) -> COUNCIL-Q
 #
-# 3. On transition to Code Review:
-#    - Activate: pr-review-panel (REVIEW-1)
-#    - Activate: quality-council (COUNCIL-Q)
-#    - Lead: Inquisitor coordinates review
+# 3. CODE Phase (Parallel):
+#    - Launch parallel agents for each subtask
+#    - UI-1 works on TASK-123-1
+#    - STRIKE-1 works on TASK-123-2
+#    - COUNCIL-Q prepares test scaffolding for TASK-123-3
+#    - Parent coordinator (JIRA-1) monitors progress
+#
+# 4. Sync Point (after CODE):
+#    - Aggregate changes from all subtasks
+#    - Merge to parent branch
+#    - Run integration tests
+#
+# 5. TEST Phase:
+#    - COUNCIL-Q runs full test suite
+#    - Includes tests from all subtasks
+#    - Report to parent issue
+#
+# 6. Completion:
+#    - All subtasks marked Done
+#    - Parent automatically transitions to Done
+#    - Documentation compiled to Confluence

--- a/plugins/jira-orchestrator/config/agent-teams.yaml
+++ b/plugins/jira-orchestrator/config/agent-teams.yaml
@@ -73,18 +73,34 @@ phase_teams:
 # Issue Type Mappings
 # Activates specific teams based on Jira issue type
 issue_type_teams:
-  Bug:
-    primary: "debug-squadron"       # DEBUG-1: Specialized for bugs
+  Initiative:
+    primary: "atlassian-ops"        # JIRA-1: High-level portfolio planning
+    pattern: "swarm"
+    description: "Strategic initiatives spanning multiple epics"
     phases:
-      EXPLORE: ["debug-squadron"]
-      PLAN: ["debug-squadron"]
-      CODE: ["debug-squadron", "code-strike"]
+      EXPLORE: ["documentation-guild", "atlassian-ops"]
+      PLAN: ["atlassian-ops", "code-strike"]
+      CODE: ["code-strike"]
+      TEST: ["quality-council"]
+      FIX: ["debug-squadron"]
+      DOCUMENT: ["documentation-guild"]
+
+  Epic:
+    primary: "atlassian-ops"        # JIRA-1: Epic decomposition
+    pattern: "swarm"
+    description: "Large features broken into stories"
+    phases:
+      EXPLORE: ["documentation-guild", "atlassian-ops"]
+      PLAN: ["atlassian-ops", "code-strike"]
+      CODE: ["code-strike"]
       TEST: ["quality-council"]
       FIX: ["debug-squadron"]
       DOCUMENT: ["documentation-guild"]
 
   Story:
     primary: "code-strike"          # STRIKE-1: Feature development
+    pattern: "hierarchical"
+    description: "User-facing features with acceptance criteria"
     phases:
       EXPLORE: ["documentation-guild", "code-strike"]
       PLAN: ["code-strike"]
@@ -94,7 +110,9 @@ issue_type_teams:
       DOCUMENT: ["documentation-guild"]
 
   Task:
-    primary: "code-strike"
+    primary: "code-strike"          # STRIKE-1: Technical tasks
+    pattern: "hierarchical"
+    description: "Technical work items"
     phases:
       EXPLORE: ["documentation-guild"]
       PLAN: ["code-strike"]
@@ -103,19 +121,66 @@ issue_type_teams:
       FIX: ["debug-squadron"]
       DOCUMENT: ["documentation-guild"]
 
-  Epic:
-    primary: "atlassian-ops"        # JIRA-1: Epic decomposition
+  Sub-task:
+    primary: "code-strike"          # STRIKE-1: Granular work items
+    pattern: "pipeline"
+    description: "Granular tasks under stories/tasks"
+    inherit_parent_teams: true      # Use parent issue's team assignments
     phases:
-      EXPLORE: ["documentation-guild", "atlassian-ops"]
-      PLAN: ["atlassian-ops", "code-strike"]
+      EXPLORE: ["code-strike"]
+      PLAN: ["code-strike"]
       CODE: ["code-strike"]
       TEST: ["quality-council"]
       FIX: ["debug-squadron"]
       DOCUMENT: ["documentation-guild"]
 
-  Sub-task:
-    primary: "code-strike"
-    inherit_parent_teams: true      # Use parent issue's team assignments
+  Bug:
+    primary: "debug-squadron"       # DEBUG-1: Specialized for bugs
+    pattern: "pipeline"
+    description: "Defects and issues requiring fixes"
+    phases:
+      EXPLORE: ["debug-squadron"]
+      PLAN: ["debug-squadron"]
+      CODE: ["debug-squadron", "code-strike"]
+      TEST: ["quality-council"]
+      FIX: ["debug-squadron"]
+      DOCUMENT: ["documentation-guild"]
+
+  Spike:
+    primary: "documentation-guild"  # DOCS-1: Research and exploration
+    pattern: "broadcast"
+    description: "Research and technical investigation"
+    phases:
+      EXPLORE: ["documentation-guild", "code-strike"]
+      PLAN: ["code-strike"]
+      CODE: ["code-strike"]
+      TEST: ["quality-council"]
+      FIX: ["debug-squadron"]
+      DOCUMENT: ["documentation-guild"]
+
+  Technical-Debt:
+    primary: "migration-convoy"     # MIGRATE-1: Refactoring expertise
+    pattern: "pipeline"
+    description: "Refactoring and code improvement"
+    phases:
+      EXPLORE: ["documentation-guild", "migration-convoy"]
+      PLAN: ["migration-convoy", "code-strike"]
+      CODE: ["migration-convoy", "code-strike"]
+      TEST: ["quality-council"]
+      FIX: ["debug-squadron"]
+      DOCUMENT: ["documentation-guild"]
+
+  Security:
+    primary: "security-tribunal"    # SEC-1: Security-focused work
+    pattern: "debate"
+    description: "Security vulnerabilities and hardening"
+    phases:
+      EXPLORE: ["security-tribunal"]
+      PLAN: ["security-tribunal", "code-strike"]
+      CODE: ["security-tribunal", "code-strike"]
+      TEST: ["security-tribunal", "quality-council"]
+      FIX: ["security-tribunal", "debug-squadron"]
+      DOCUMENT: ["security-tribunal", "documentation-guild"]
 
 # Label-Based Team Activation
 # Activates teams based on Jira labels

--- a/plugins/jira-orchestrator/config/agent-teams.yaml
+++ b/plugins/jira-orchestrator/config/agent-teams.yaml
@@ -1,0 +1,362 @@
+# Agent Teams Integration for Jira Orchestrator
+# Maps Jira workflows, issue types, and phases to AutoGen-style agent teams
+# Reference: .claude/registry/teams.index.json
+
+version: "1.0.0"
+description: "Team activation rules for Jira orchestration workflows"
+
+# Team Registry Reference
+teams_registry: ".claude/registry/teams.index.json"
+
+# Phase-to-Team Mapping
+# Maps 6-phase protocol to appropriate teams
+phase_teams:
+  EXPLORE:
+    primary: "documentation-guild"  # DOCS-1: Surveyor, Archivist analyze codebase
+    secondary: "debug-squadron"     # DEBUG-1: Sleuth for investigation
+    triggers:
+      - "analyze"
+      - "investigate"
+      - "understand"
+      - "research"
+
+  PLAN:
+    primary: "code-strike"          # STRIKE-1: Blueprint for architecture
+    secondary: "atlassian-ops"      # JIRA-1: Divider for epic decomposition
+    triggers:
+      - "design"
+      - "architect"
+      - "plan"
+      - "strategy"
+
+  CODE:
+    primary: "code-strike"          # STRIKE-1: Genesis leads implementation
+    fallback_teams:
+      frontend: "frontend-forge"    # UI-1: For frontend-heavy work
+      mobile: "mobile-force"        # MOBILE-1: For mobile work
+      backend: "data-pipeline"      # DATA-1: For data/backend work
+      auth: "identity-vault"        # AUTH-1: For authentication work
+      messaging: "messaging-hub"    # MSG-1: For event-driven work
+    triggers:
+      - "implement"
+      - "build"
+      - "create"
+      - "develop"
+
+  TEST:
+    primary: "quality-council"      # COUNCIL-Q: Comprehensive QA
+    secondary: "debug-squadron"     # DEBUG-1: For test failures
+    triggers:
+      - "test"
+      - "validate"
+      - "verify"
+      - "coverage"
+
+  FIX:
+    primary: "debug-squadron"       # DEBUG-1: Sleuth leads debugging
+    secondary: "code-strike"        # STRIKE-1: For implementing fixes
+    triggers:
+      - "fix"
+      - "debug"
+      - "resolve"
+      - "patch"
+
+  DOCUMENT:
+    primary: "documentation-guild"  # DOCS-1: Full documentation
+    secondary: "atlassian-ops"      # JIRA-1: Confluence integration
+    triggers:
+      - "document"
+      - "write"
+      - "update docs"
+      - "confluence"
+
+# Issue Type Mappings
+# Activates specific teams based on Jira issue type
+issue_type_teams:
+  Bug:
+    primary: "debug-squadron"       # DEBUG-1: Specialized for bugs
+    phases:
+      EXPLORE: ["debug-squadron"]
+      PLAN: ["debug-squadron"]
+      CODE: ["debug-squadron", "code-strike"]
+      TEST: ["quality-council"]
+      FIX: ["debug-squadron"]
+      DOCUMENT: ["documentation-guild"]
+
+  Story:
+    primary: "code-strike"          # STRIKE-1: Feature development
+    phases:
+      EXPLORE: ["documentation-guild", "code-strike"]
+      PLAN: ["code-strike"]
+      CODE: ["code-strike"]  # + domain-specific teams
+      TEST: ["quality-council"]
+      FIX: ["debug-squadron"]
+      DOCUMENT: ["documentation-guild"]
+
+  Task:
+    primary: "code-strike"
+    phases:
+      EXPLORE: ["documentation-guild"]
+      PLAN: ["code-strike"]
+      CODE: ["code-strike"]
+      TEST: ["quality-council"]
+      FIX: ["debug-squadron"]
+      DOCUMENT: ["documentation-guild"]
+
+  Epic:
+    primary: "atlassian-ops"        # JIRA-1: Epic decomposition
+    phases:
+      EXPLORE: ["documentation-guild", "atlassian-ops"]
+      PLAN: ["atlassian-ops", "code-strike"]
+      CODE: ["code-strike"]
+      TEST: ["quality-council"]
+      FIX: ["debug-squadron"]
+      DOCUMENT: ["documentation-guild"]
+
+  Sub-task:
+    primary: "code-strike"
+    inherit_parent_teams: true      # Use parent issue's team assignments
+
+# Label-Based Team Activation
+# Activates teams based on Jira labels
+label_teams:
+  # Domain Labels
+  "domain:frontend":
+    teams: ["frontend-forge"]
+    priority: "high"
+
+  "domain:backend":
+    teams: ["code-strike", "data-pipeline"]
+    priority: "high"
+
+  "domain:database":
+    teams: ["data-pipeline"]
+    priority: "high"
+
+  "domain:testing":
+    teams: ["quality-council"]
+    priority: "high"
+
+  "domain:devops":
+    teams: ["ship-crew"]
+    priority: "high"
+
+  "domain:security":
+    teams: ["security-tribunal"]
+    priority: "critical"
+
+  "domain:api":
+    teams: ["code-strike"]
+    priority: "high"
+
+  "domain:docs":
+    teams: ["documentation-guild"]
+    priority: "medium"
+
+  # Technology Labels
+  "tech:react":
+    teams: ["frontend-forge"]
+    priority: "high"
+
+  "tech:mobile":
+    teams: ["mobile-force"]
+    priority: "high"
+
+  "tech:keycloak":
+    teams: ["identity-vault"]
+    priority: "high"
+
+  "tech:kafka":
+    teams: ["messaging-hub"]
+    priority: "high"
+
+  "tech:kubernetes":
+    teams: ["ship-crew"]
+    priority: "high"
+
+  "tech:mongodb":
+    teams: ["data-pipeline"]
+    priority: "high"
+
+  # Process Labels
+  "needs:review":
+    teams: ["pr-review-panel", "quality-council"]
+    priority: "high"
+
+  "needs:security-review":
+    teams: ["security-tribunal"]
+    priority: "critical"
+
+  "needs:docs":
+    teams: ["documentation-guild"]
+    priority: "medium"
+
+# Component-Based Team Activation
+# Maps Jira components to teams
+component_teams:
+  "Frontend":
+    teams: ["frontend-forge"]
+
+  "Backend":
+    teams: ["code-strike", "data-pipeline"]
+
+  "API":
+    teams: ["code-strike"]
+
+  "Database":
+    teams: ["data-pipeline"]
+
+  "Authentication":
+    teams: ["identity-vault"]
+
+  "Infrastructure":
+    teams: ["ship-crew"]
+
+  "Mobile":
+    teams: ["mobile-force"]
+
+  "Security":
+    teams: ["security-tribunal"]
+
+  "Documentation":
+    teams: ["documentation-guild"]
+
+# Workflow Stage Teams
+# Teams for specific Jira workflow transitions
+workflow_teams:
+  "To Do -> In Progress":
+    activate: ["code-strike"]
+    notification: "Team STRIKE-1 activated for development"
+
+  "In Progress -> Code Review":
+    activate: ["pr-review-panel", "quality-council"]
+    notification: "Teams REVIEW-1 and COUNCIL-Q activated for review"
+
+  "Code Review -> QA":
+    activate: ["quality-council"]
+    notification: "Team COUNCIL-Q activated for QA"
+
+  "QA -> Done":
+    activate: ["documentation-guild", "ship-crew"]
+    notification: "Teams DOCS-1 and SHIP-1 activated for completion"
+
+  "* -> Blocked":
+    activate: ["debug-squadron"]
+    notification: "Team DEBUG-1 activated for blockers"
+
+# PR Review Teams
+# Teams activated for pull request workflows
+pr_teams:
+  create:
+    teams: ["pr-review-panel"]
+    lead: "Inquisitor"
+
+  review_requested:
+    teams: ["pr-review-panel", "quality-council"]
+    lead: "Inquisitor"
+
+  changes_requested:
+    teams: ["debug-squadron", "code-strike"]
+    lead: "Sleuth"
+
+  approved:
+    teams: ["ship-crew"]
+    lead: "Launcher"
+
+  merged:
+    teams: ["documentation-guild"]
+    lead: "Archivist"
+
+# Confluence Documentation Teams
+confluence_teams:
+  "Technical Design":
+    team: "code-strike"
+    lead: "Blueprint"
+
+  "Implementation Notes":
+    team: "code-strike"
+    lead: "Genesis"
+
+  "Test Plan & Results":
+    team: "quality-council"
+    lead: "Paramount"
+
+  "Runbook":
+    team: "ship-crew"
+    lead: "Launcher"
+
+  "Security Review":
+    team: "security-tribunal"
+    lead: "Bastion"
+
+# Team Activation Rules
+activation_rules:
+  # Minimum agents from team to activate
+  min_agents: 3
+
+  # Maximum teams active simultaneously
+  max_concurrent_teams: 3
+
+  # Team priority when multiple match
+  priority_order:
+    - "security-tribunal"   # Security always first
+    - "debug-squadron"      # Bugs/issues high priority
+    - "quality-council"     # Quality gates
+    - "code-strike"         # Development
+    - "pr-review-panel"     # Reviews
+    - "ship-crew"           # Deployment
+    - "documentation-guild" # Documentation
+    - "frontend-forge"      # Domain-specific
+    - "mobile-force"
+    - "data-pipeline"
+    - "identity-vault"
+    - "messaging-hub"
+    - "atlassian-ops"
+    - "growth-squad"
+    - "migration-convoy"
+    - "multi-tenant-architects"
+
+  # Auto-deactivate teams after phase completion
+  auto_deactivate: true
+
+  # Handoff between teams
+  handoff_protocol: "checkpoint"  # checkpoint, immediate, queued
+
+# Team Communication
+team_communication:
+  # How teams report progress
+  reporting:
+    channel: "jira-comment"
+    frequency: "phase-complete"
+    include_confluence_links: true
+
+  # Inter-team coordination
+  coordination:
+    method: "lead-to-lead"
+    checkpoint_sync: true
+
+# Metrics & Tracking
+metrics:
+  track_team_usage: true
+  track_phase_duration: true
+  track_team_effectiveness: true
+  report_to: "confluence"
+  dashboard_page: "Team Performance Dashboard"
+
+# Example Usage in Jira Work Command
+#
+# 1. On /jira:work ABC-123:
+#    - Fetch issue type, labels, components
+#    - Match against label_teams, component_teams
+#    - Activate phase_teams[EXPLORE].primary
+#    - Use team leads for coordination
+#
+# 2. During CODE phase with labels ["domain:frontend", "tech:react"]:
+#    - Primary: code-strike (STRIKE-1)
+#    - Additional: frontend-forge (UI-1)
+#    - Lead coordination: Genesis -> Weaver
+#
+# 3. On transition to Code Review:
+#    - Activate: pr-review-panel (REVIEW-1)
+#    - Activate: quality-council (COUNCIL-Q)
+#    - Lead: Inquisitor coordinates review

--- a/plugins/jira-orchestrator/hooks/orchestration-hooks.json
+++ b/plugins/jira-orchestrator/hooks/orchestration-hooks.json
@@ -1,6 +1,6 @@
 {
-  "version": "6.0.0",
-  "description": "Hook-based automation for Jira Orchestrator - eliminates need for explicit commands",
+  "version": "7.1.0",
+  "description": "Hook-based automation for Jira Orchestrator with AutoGen-style team coordination",
 
   "git_hooks": {
     "pre-commit": {

--- a/plugins/jira-orchestrator/scripts/install.sh
+++ b/plugins/jira-orchestrator/scripts/install.sh
@@ -18,7 +18,7 @@ NC='\033[0m' # No Color
 
 # Plugin information
 PLUGIN_NAME="jira-orchestrator"
-PLUGIN_VERSION="6.0.0"
+PLUGIN_VERSION="7.1.0"
 MCP_SERVER_NAME="atlassian"
 MCP_SERVER_URL="https://mcp.atlassian.com/v1/sse"
 


### PR DESCRIPTION
- ai-engineer → Cortex (neural/AI brain reference)
- api-integration-specialist → Nexus (connection hub)
- code-architect → Blueprint (architectural design)
- desktop-app-dev → Terminal (system interface)
- enterprise-integrator-architect → Conduit (data flow channels)
- mobile-app-builder → Nomad (cross-platform mobility)
- project-curator → Keeper (organizational guardian)
- rapid-prototyper → Forge (rapid construction)
- vision-specialist → Optic (visual processing)

All agents now have proper faction-aligned call signs following the
Halo-themed naming convention: Forerunner, Promethean, or Spartan.