### PR TITLE
fix: Register frontend-design-system plugin in all registries

### DIFF
--- a/.claude/registry/commands.index.json
+++ b/.claude/registry/commands.index.json
@@ -733,6 +733,64 @@
         "priority": "medium"
       }
     },
+    "frontend-design-system": {
+      "design:style": {
+        "path": "../../plugins/frontend-design-system/commands/style.md",
+        "description": "Apply a design style from 263+ curated options",
+        "keywords": ["design", "style", "css", "theme", "apply"],
+        "usage": "/design:style <style-name> [target]",
+        "priority": "high"
+      },
+      "design:theme": {
+        "path": "../../plugins/frontend-design-system/commands/theme.md",
+        "description": "Create or modify themes with color palettes",
+        "keywords": ["design", "theme", "colors", "palette", "create"],
+        "usage": "/design:theme <action> [name]",
+        "priority": "high"
+      },
+      "design:tokens": {
+        "path": "../../plugins/frontend-design-system/commands/tokens.md",
+        "description": "Manage design tokens (colors, spacing, typography)",
+        "keywords": ["design", "tokens", "variables", "css-vars"],
+        "usage": "/design:tokens <action> [token-path]",
+        "priority": "high"
+      },
+      "design:component": {
+        "path": "../../plugins/frontend-design-system/commands/component.md",
+        "description": "Generate styled components with design system",
+        "keywords": ["design", "component", "generate", "styled"],
+        "usage": "/design:component <name> [--style=<style>]",
+        "priority": "high"
+      },
+      "design:palette": {
+        "path": "../../plugins/frontend-design-system/commands/palette.md",
+        "description": "Generate and manage color palettes",
+        "keywords": ["design", "palette", "colors", "generate"],
+        "usage": "/design:palette <action> [options]",
+        "priority": "medium"
+      },
+      "design:keycloak": {
+        "path": "../../plugins/frontend-design-system/commands/keycloak.md",
+        "description": "Generate Keycloak themes for multi-tenant apps",
+        "keywords": ["design", "keycloak", "theme", "tenant", "login"],
+        "usage": "/design:keycloak <action> [tenant]",
+        "priority": "high"
+      },
+      "design:audit": {
+        "path": "../../plugins/frontend-design-system/commands/audit.md",
+        "description": "Audit design system consistency and accessibility",
+        "keywords": ["design", "audit", "accessibility", "wcag", "a11y"],
+        "usage": "/design:audit [path] [--fix]",
+        "priority": "high"
+      },
+      "design:convert": {
+        "path": "../../plugins/frontend-design-system/commands/convert.md",
+        "description": "Convert between CSS, SCSS, Tailwind, and CSS-in-JS",
+        "keywords": ["design", "convert", "css", "tailwind", "scss"],
+        "usage": "/design:convert <source> <target-format>",
+        "priority": "medium"
+      }
+    },
     "jira-orchestrator": {
       "jira:work": {
         "path": "jira-orchestrator/commands/work.md",
@@ -1059,6 +1117,16 @@
       ],
       "secrets": [
         "secrets"
+      ],
+      "design": [
+        "design:style",
+        "design:theme",
+        "design:tokens",
+        "design:component",
+        "design:palette",
+        "design:keycloak",
+        "design:audit",
+        "design:convert"
       ]
     },
     "byTask": {
@@ -1113,7 +1181,7 @@
     }
   },
   "stats": {
-    "totalCommands": 95,
+    "totalCommands": 103,
     "byCategory": {
       "core": 4,
       "development": 9,
@@ -1125,11 +1193,12 @@
       "plugin-management": 7,
       "ecosystem": 6,
       "intelligence": 4,
+      "frontend-design-system": 8,
       "jira-orchestrator": 35
     },
     "byPriority": {
-      "high": 31,
-      "medium": 50,
+      "high": 37,
+      "medium": 52,
       "low": 9
     }
   }

--- a/.claude/registry/commands.index.json
+++ b/.claude/registry/commands.index.json
@@ -1036,6 +1036,62 @@
         "keywords": ["jira", "worklog", "time", "track"],
         "usage": "/jira:process-worklogs [issue-key]",
         "priority": "low"
+      },
+      "jira:ship": {
+        "path": "jira-orchestrator/commands/ship.md",
+        "description": "One command to ship - prepare, code, PR, and council review",
+        "keywords": ["jira", "ship", "complete", "deliver", "end-to-end"],
+        "usage": "/jira:ship <issue-key> [--council] [--auto-merge]",
+        "priority": "high"
+      },
+      "jira:council": {
+        "path": "jira-orchestrator/commands/council.md",
+        "description": "Agent council review using blackboard pattern for comprehensive PR analysis",
+        "keywords": ["jira", "council", "review", "collective", "agents", "blackboard"],
+        "usage": "/jira:council <target> [--preset=standard] [--depth=standard]",
+        "priority": "high"
+      },
+      "jira:iterate": {
+        "path": "jira-orchestrator/commands/iterate.md",
+        "description": "Fix review feedback, update PR, re-review until approval",
+        "keywords": ["jira", "iterate", "fix", "feedback", "update"],
+        "usage": "/jira:iterate <issue-key> [--auto]",
+        "priority": "high"
+      },
+      "jira:enterprise": {
+        "path": "jira-orchestrator/commands/enterprise.md",
+        "description": "Enterprise features - notifications, approvals, portfolio, compliance",
+        "keywords": ["jira", "enterprise", "governance", "portfolio", "compliance"],
+        "usage": "/jira:enterprise <action> [options]",
+        "priority": "medium"
+      },
+      "jira:infra": {
+        "path": "jira-orchestrator/commands/infra.md",
+        "description": "Infrastructure management - Helm, Terraform, K8s, repo creation",
+        "keywords": ["jira", "infra", "infrastructure", "helm", "terraform", "k8s"],
+        "usage": "/jira:infra <action> [options]",
+        "priority": "medium"
+      },
+      "jira:sprint": {
+        "path": "jira-orchestrator/commands/sprint.md",
+        "description": "Sprint management - planning, metrics, quality, team capacity",
+        "keywords": ["jira", "sprint", "planning", "metrics", "capacity"],
+        "usage": "/jira:sprint <action> [options]",
+        "priority": "medium"
+      },
+      "jira:create-repo": {
+        "path": "jira-orchestrator/commands/create-repo.md",
+        "description": "Create modular Harness-ready repository with Helm, Terraform, K8s",
+        "keywords": ["jira", "create-repo", "repository", "harness", "scaffold"],
+        "usage": "/jira:create-repo <name> [--template=microservice]",
+        "priority": "medium"
+      },
+      "jira:harness-review": {
+        "path": "jira-orchestrator/commands/harness-review.md",
+        "description": "Review Harness pipeline configurations and deployments",
+        "keywords": ["jira", "harness", "review", "pipeline", "deployment"],
+        "usage": "/jira:harness-review <issue-key>",
+        "priority": "medium"
       }
     }
   },
@@ -1065,6 +1121,7 @@
         "jira-transition",
         "atlassian-sync",
         "jira:work",
+        "jira:ship",
         "jira:prepare",
         "jira:status",
         "jira:sync",
@@ -1073,7 +1130,14 @@
         "jira:commit",
         "jira:pr",
         "jira:review",
-        "jira:docs"
+        "jira:council",
+        "jira:iterate",
+        "jira:docs",
+        "jira:enterprise",
+        "jira:infra",
+        "jira:sprint",
+        "jira:create-repo",
+        "jira:harness-review"
       ],
       "review": [
         "review",
@@ -1181,7 +1245,7 @@
     }
   },
   "stats": {
-    "totalCommands": 103,
+    "totalCommands": 111,
     "byCategory": {
       "core": 4,
       "development": 9,
@@ -1194,11 +1258,11 @@
       "ecosystem": 6,
       "intelligence": 4,
       "frontend-design-system": 8,
-      "jira-orchestrator": 35
+      "jira-orchestrator": 43
     },
     "byPriority": {
-      "high": 37,
-      "medium": 52,
+      "high": 40,
+      "medium": 57,
       "low": 9
     }
   }

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -117,6 +117,26 @@
       }
     },
 
+    "frontend": {
+      "frontend-design-system": {
+        "path": "../../plugins/frontend-design-system/.claude-plugin/plugin.json",
+        "callsign": "Stylist",
+        "version": "1.0.0",
+        "description": "263+ design styles with multi-tenant Keycloak theming for AI-powered frontend development",
+        "provides": { "commands": 8, "agents": 6, "skills": 4, "hooks": 4 },
+        "status": "active",
+        "tier": "standard",
+        "features": [
+          "263+ curated design styles",
+          "Multi-tenant Keycloak theming",
+          "CSS/Tailwind generation",
+          "Accessibility validation",
+          "Design token management"
+        ],
+        "integrates": ["jira-orchestrator", "documentation-orchestrator"]
+      }
+    },
+
     "ai-advanced": {
       "cognitive-code-reasoner": {
         "path": "../plugins/cognitive-code-reasoner/plugin.json",
@@ -209,6 +229,7 @@
 
   "callsignRegistry": {
     "Arbiter": "jira-orchestrator",
+    "Stylist": "frontend-design-system",
     "Curator": "code-quality-orchestrator",
     "Sentinel": "git-workflow-orchestrator",
     "Herald": "release-orchestrator",
@@ -226,17 +247,17 @@
   },
 
   "stats": {
-    "totalPlugins": 15,
+    "totalPlugins": 16,
     "byTier": {
       "enterprise": 1,
-      "standard": 8,
+      "standard": 9,
       "advanced": 6
     },
-    "totalCommands": 217,
-    "totalAgents": 199,
+    "totalCommands": 225,
+    "totalAgents": 205,
     "totalTeams": 16,
-    "totalSkills": 91,
-    "totalHooks": 63,
+    "totalSkills": 95,
+    "totalHooks": 67,
     "totalWorkflows": 3,
     "innovativePlugins": 7,
     "deliberationProtocols": 20

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -10,8 +10,16 @@
         "path": "../../plugins/jira-orchestrator/.claude-plugin/plugin.json",
         "callsign": "Arbiter",
         "version": "7.1.0",
-        "provides": { "commands": 43, "agents": 68, "teams": 16, "skills": 11, "hooks": 7 },
-        "features": ["autogen-teams", "parent-child-orchestration", "domain-affinity-routing"],
+        "description": "Enterprise Jira orchestration with 69 agents, 16 teams, 43 commands, and hook-based automation",
+        "provides": { "commands": 43, "agents": 69, "teams": 16, "skills": 11, "hooks": 7 },
+        "features": [
+          "autogen-teams",
+          "parent-child-orchestration",
+          "domain-affinity-routing",
+          "harness-ci-cd-integration",
+          "agent-council-review",
+          "clean-architecture-enforcement"
+        ],
         "status": "active",
         "tier": "enterprise"
       },
@@ -253,10 +261,10 @@
       "standard": 9,
       "advanced": 6
     },
-    "totalCommands": 225,
-    "totalAgents": 205,
+    "totalCommands": 233,
+    "totalAgents": 206,
     "totalTeams": 16,
-    "totalSkills": 95,
+    "totalSkills": 106,
     "totalHooks": 67,
     "totalWorkflows": 3,
     "innovativePlugins": 7,

--- a/.claude/registry/skills.index.json
+++ b/.claude/registry/skills.index.json
@@ -617,6 +617,34 @@
       }
     },
     "frontend": {
+      "design-system": {
+        "path": "../skills/design-system/SKILL.md",
+        "triggers": [
+          "design-system",
+          "design system",
+          "theme",
+          "theming",
+          "style",
+          "styles",
+          "css",
+          "tailwind",
+          "tokens",
+          "design tokens",
+          "color palette",
+          "typography",
+          "keycloak theme",
+          "multi-tenant",
+          "accessibility",
+          "wcag",
+          "a11y"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "frontend-design-system",
+        "description": "Stylist - 263+ design styles with multi-tenant Keycloak theming"
+      },
       "react": {
         "path": "skills/react/SKILL.md",
         "triggers": [
@@ -731,7 +759,7 @@
     "allowedToolsSupport": true
   },
   "stats": {
-    "totalSkills": 34,
+    "totalSkills": 35,
     "format": "Claude Code Official SKILL.md",
     "byCategory": {
       "infrastructure": 4,
@@ -742,7 +770,7 @@
       "cloud": 2,
       "security": 1,
       "data": 4,
-      "frontend": 2,
+      "frontend": 3,
       "reasoning": 3
     },
     "note": "Includes ultrathink/extended-thinking skills for complex reasoning tasks, plus Anthropic API skills (prompt-caching, vision-multimodal, streaming, batch-processing, tool-use, citations-retrieval)."

--- a/.claude/registry/skills.index.json
+++ b/.claude/registry/skills.index.json
@@ -529,6 +529,166 @@
         "autoActivate": true
       }
     },
+    "harness": {
+      "harness-ci": {
+        "path": "../plugins/jira-orchestrator/skills/harness-ci/SKILL.md",
+        "triggers": [
+          "harness ci",
+          "build pipeline",
+          "ci pipeline",
+          "test intelligence",
+          "harness build",
+          "container-native"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Harness CI for container-native builds, test intelligence, and caching"
+      },
+      "harness-cd": {
+        "path": "../plugins/jira-orchestrator/skills/harness-cd/SKILL.md",
+        "triggers": [
+          "harness cd",
+          "deployment",
+          "gitops",
+          "rollback",
+          "harness deploy",
+          "continuous delivery"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Harness CD for Kubernetes, Helm, Terraform deployments with GitOps"
+      },
+      "harness-platform": {
+        "path": "../plugins/jira-orchestrator/skills/harness-platform/SKILL.md",
+        "triggers": [
+          "harness platform",
+          "delegate",
+          "rbac",
+          "connector",
+          "harness secret",
+          "harness admin"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Harness platform administration - delegates, RBAC, connectors, secrets"
+      },
+      "harness-mcp": {
+        "path": "../plugins/jira-orchestrator/skills/harness-mcp/SKILL.md",
+        "triggers": [
+          "harness code",
+          "harness repo",
+          "harness pr",
+          "harness git"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Harness Code repository and pull request management"
+      },
+      "clean-architecture": {
+        "path": "../plugins/jira-orchestrator/skills/clean-architecture/SKILL.md",
+        "triggers": [
+          "clean architecture",
+          "ddd",
+          "domain driven",
+          "hexagonal",
+          "dependency injection",
+          "solid principles",
+          "clean code"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Clean Architecture, DDD, hexagonal patterns, dependency injection"
+      },
+      "jira-orchestration": {
+        "path": "../plugins/jira-orchestrator/skills/jira-orchestration/SKILL.md",
+        "triggers": [
+          "jira orchestration",
+          "jira workflow",
+          "jira automation",
+          "issue orchestration"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Core Jira orchestration patterns and workflows"
+      },
+      "triage": {
+        "path": "../plugins/jira-orchestrator/skills/triage/SKILL.md",
+        "triggers": [
+          "triage",
+          "classify issue",
+          "prioritize",
+          "issue analysis"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Issue triage patterns, classification, and prioritization"
+      },
+      "code-review": {
+        "path": "../plugins/jira-orchestrator/skills/code-review/SKILL.md",
+        "triggers": [
+          "code review patterns",
+          "review automation",
+          "pr review patterns"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Code review patterns, best practices, and automation"
+      },
+      "pr-workflow": {
+        "path": "../plugins/jira-orchestrator/skills/pr-workflow/SKILL.md",
+        "triggers": [
+          "pr workflow",
+          "pull request workflow",
+          "merge strategy",
+          "pr automation"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Pull request workflow patterns and automation"
+      },
+      "task-details": {
+        "path": "../plugins/jira-orchestrator/skills/task-details/SKILL.md",
+        "triggers": [
+          "task details",
+          "task enrichment",
+          "acceptance criteria",
+          "subtask creation"
+        ],
+        "activationScore": 0,
+        "dependencies": [],
+        "conflicts": [],
+        "autoActivate": true,
+        "plugin": "jira-orchestrator",
+        "description": "Task enrichment and detail patterns"
+      }
+    },
     "security": {
       "authentication": {
         "path": "skills/authentication/SKILL.md",
@@ -759,7 +919,7 @@
     "allowedToolsSupport": true
   },
   "stats": {
-    "totalSkills": 35,
+    "totalSkills": 46,
     "format": "Claude Code Official SKILL.md",
     "byCategory": {
       "infrastructure": 4,
@@ -768,11 +928,12 @@
       "methodology": 2,
       "integration": 5,
       "cloud": 2,
+      "harness": 11,
       "security": 1,
       "data": 4,
       "frontend": 3,
       "reasoning": 3
     },
-    "note": "Includes ultrathink/extended-thinking skills for complex reasoning tasks, plus Anthropic API skills (prompt-caching, vision-multimodal, streaming, batch-processing, tool-use, citations-retrieval)."
+    "note": "Includes ultrathink/extended-thinking skills for complex reasoning tasks, plus Anthropic API skills (prompt-caching, vision-multimodal, streaming, batch-processing, tool-use, citations-retrieval). Harness category includes jira-orchestrator skills (harness-ci, harness-cd, harness-platform, harness-mcp, clean-architecture, jira-orchestration, triage, code-review, pr-workflow, task-details)."
   }
 }

--- a/plugins/jira-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/jira-orchestrator/.claude-plugin/plugin.json
@@ -362,11 +362,46 @@
     }
   },
 
+  "flagSystem": {
+    "version": "1.0.0",
+    "configFile": "../config/flags.json",
+    "presetsFile": "../config/presets.json",
+    "features": {
+      "globalFlags": true,
+      "orchestrationFlags": true,
+      "jiraFlags": true,
+      "reviewFlags": true,
+      "gitFlags": true,
+      "notificationFlags": true,
+      "reportFlags": true,
+      "harnessFlags": true,
+      "experimentalFlags": true
+    },
+    "presets": {
+      "count": 17,
+      "categories": ["speed", "quality", "security", "collaboration", "automation", "release"],
+      "recommended": ["speed-run", "thorough", "enterprise", "hotfix"]
+    },
+    "defaults": {
+      "model": "auto",
+      "agents": 5,
+      "depth": "standard",
+      "checkpoint": true,
+      "parallel": true
+    },
+    "validation": {
+      "strict": true,
+      "unknownFlagsError": true,
+      "conflictResolution": "error"
+    }
+  },
+
   "documentation": {
     "readme": "../README.md",
     "installation": "../INSTALLATION.md",
     "installationSystem": "../INSTALLATION-SYSTEM.md",
     "installChecklist": "../INSTALL-CHECKLIST.md",
+    "flagsGuide": "../docs/FLAGS.md",
     "hooksGuide": "../hooks/README.md",
     "harnessIndex": "../docs/harness/INDEX.md"
   }

--- a/plugins/jira-orchestrator/commands/work.md
+++ b/plugins/jira-orchestrator/commands/work.md
@@ -5,8 +5,25 @@ arguments:
   - name: issue_key
     description: The Jira issue key (e.g., ABC-123)
     required: true
-version: 2.0.0
+flags:
+  global: [--verbose, --quiet, --json, --dry-run, --interactive, --yes, --timeout, --config, --profile, --preset, --debug]
+  orchestration: [--agents, --model, --model-strategy, --parallel, --sequential, --phases, --skip-phases, --checkpoint, --resume]
+  jira: [--project, --assignee, --labels, --priority, --sprint, --epic]
+  review: [--depth, --focus, --council, --council-size, --council-protocol, --min-coverage, --auto-fix]
+  git: [--branch-prefix, --from-branch, --commit-style, --draft, --reviewers, --auto-merge]
+  notification: [--notify, --slack-channel, --notify-on-complete]
+  report: [--report, --report-format, --report-to-confluence, --report-to-obsidian]
+presets: [speed-run, thorough, enterprise, hotfix, prototype, pair-programming, security-audit]
+version: 2.1.0
 ---
+
+> **📚 Flag Documentation:** See [FLAGS.md](../docs/FLAGS.md) for complete flag reference
+>
+> **⚡ Quick Presets:**
+> - `--preset speed-run` - Fast execution for simple tasks
+> - `--preset thorough` - Deep analysis with council review
+> - `--preset enterprise` - Full compliance workflow
+> - `--preset hotfix` - Emergency rapid deployment
 
 # Jira Issue Orchestration (Enhanced v2.0)
 

--- a/plugins/jira-orchestrator/config/flags.json
+++ b/plugins/jira-orchestrator/config/flags.json
@@ -1,0 +1,801 @@
+{
+  "$schema": "../schemas/flags.schema.json",
+  "version": "1.0.0",
+  "description": "Comprehensive flag system for Jira Orchestrator commands",
+
+  "globalFlags": {
+    "output": {
+      "--verbose": {
+        "short": "-v",
+        "type": "boolean",
+        "default": false,
+        "description": "Enable verbose output with detailed logs",
+        "env": "JIRA_VERBOSE"
+      },
+      "--quiet": {
+        "short": "-q",
+        "type": "boolean",
+        "default": false,
+        "description": "Minimal output, errors only",
+        "conflicts": ["--verbose"]
+      },
+      "--json": {
+        "short": "-j",
+        "type": "boolean",
+        "default": false,
+        "description": "Output in JSON format for parsing"
+      },
+      "--yaml": {
+        "type": "boolean",
+        "default": false,
+        "description": "Output in YAML format"
+      },
+      "--no-color": {
+        "type": "boolean",
+        "default": false,
+        "description": "Disable colored output",
+        "env": "NO_COLOR"
+      },
+      "--log-file": {
+        "short": "-l",
+        "type": "string",
+        "description": "Write logs to specified file",
+        "example": "--log-file ./jira-session.log"
+      }
+    },
+
+    "execution": {
+      "--dry-run": {
+        "short": "-n",
+        "type": "boolean",
+        "default": false,
+        "description": "Show what would happen without executing",
+        "safe": true
+      },
+      "--interactive": {
+        "short": "-i",
+        "type": "boolean",
+        "default": false,
+        "description": "Prompt before each major action"
+      },
+      "--yes": {
+        "short": "-y",
+        "type": "boolean",
+        "default": false,
+        "description": "Auto-confirm all prompts",
+        "conflicts": ["--interactive"]
+      },
+      "--timeout": {
+        "short": "-t",
+        "type": "integer",
+        "default": 300,
+        "min": 30,
+        "max": 3600,
+        "description": "Command timeout in seconds",
+        "env": "JIRA_TIMEOUT"
+      },
+      "--retry": {
+        "type": "integer",
+        "default": 3,
+        "min": 0,
+        "max": 10,
+        "description": "Number of retries on failure"
+      },
+      "--fail-fast": {
+        "type": "boolean",
+        "default": false,
+        "description": "Stop on first error, don't continue"
+      }
+    },
+
+    "configuration": {
+      "--config": {
+        "short": "-c",
+        "type": "string",
+        "description": "Path to custom config file",
+        "example": "--config ~/.jira-orchestrator.yml"
+      },
+      "--profile": {
+        "short": "-p",
+        "type": "string",
+        "default": "default",
+        "description": "Use named configuration profile",
+        "example": "--profile enterprise"
+      },
+      "--preset": {
+        "type": "string",
+        "description": "Use predefined flag preset",
+        "example": "--preset speed-run"
+      },
+      "--env": {
+        "short": "-e",
+        "type": "string",
+        "enum": ["dev", "staging", "prod"],
+        "default": "dev",
+        "description": "Target environment"
+      }
+    },
+
+    "debugging": {
+      "--debug": {
+        "short": "-d",
+        "type": "boolean",
+        "default": false,
+        "description": "Enable debug mode with stack traces"
+      },
+      "--trace": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable full execution tracing"
+      },
+      "--profile-perf": {
+        "type": "boolean",
+        "default": false,
+        "description": "Profile performance and show timing"
+      }
+    }
+  },
+
+  "orchestrationFlags": {
+    "agents": {
+      "--agents": {
+        "short": "-a",
+        "type": "integer",
+        "default": 5,
+        "min": 1,
+        "max": 13,
+        "description": "Number of sub-agents to spawn"
+      },
+      "--model": {
+        "short": "-m",
+        "type": "string",
+        "enum": ["opus", "sonnet", "haiku", "auto"],
+        "default": "auto",
+        "description": "Default model for agents",
+        "env": "JIRA_DEFAULT_MODEL"
+      },
+      "--model-strategy": {
+        "type": "string",
+        "enum": ["cost-optimized", "speed-optimized", "quality-optimized", "balanced"],
+        "default": "balanced",
+        "description": "Multi-model routing strategy"
+      },
+      "--parallel": {
+        "type": "boolean",
+        "default": true,
+        "description": "Run agents in parallel where possible"
+      },
+      "--sequential": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run agents sequentially",
+        "conflicts": ["--parallel"]
+      },
+      "--max-concurrent": {
+        "type": "integer",
+        "default": 5,
+        "min": 1,
+        "max": 10,
+        "description": "Maximum concurrent agent executions"
+      }
+    },
+
+    "phases": {
+      "--phases": {
+        "type": "array",
+        "items": ["explore", "plan", "code", "test", "fix", "document"],
+        "default": ["explore", "plan", "code", "test", "fix", "document"],
+        "description": "Phases to execute"
+      },
+      "--skip-phases": {
+        "type": "array",
+        "items": ["explore", "plan", "code", "test", "fix", "document"],
+        "default": [],
+        "description": "Phases to skip"
+      },
+      "--start-phase": {
+        "type": "string",
+        "enum": ["explore", "plan", "code", "test", "fix", "document"],
+        "description": "Start from specific phase"
+      },
+      "--end-phase": {
+        "type": "string",
+        "enum": ["explore", "plan", "code", "test", "fix", "document"],
+        "description": "Stop after specific phase"
+      }
+    },
+
+    "checkpointing": {
+      "--checkpoint": {
+        "type": "boolean",
+        "default": true,
+        "description": "Save progress checkpoints"
+      },
+      "--checkpoint-interval": {
+        "type": "integer",
+        "default": 300,
+        "description": "Checkpoint interval in seconds"
+      },
+      "--resume": {
+        "short": "-r",
+        "type": "boolean",
+        "default": false,
+        "description": "Resume from last checkpoint"
+      },
+      "--resume-from": {
+        "type": "string",
+        "description": "Resume from specific checkpoint ID"
+      },
+      "--checkpoint-dir": {
+        "type": "string",
+        "default": ".jira-checkpoints",
+        "description": "Directory for checkpoint files"
+      }
+    },
+
+    "coordination": {
+      "--blackboard": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use blackboard pattern for agent coordination"
+      },
+      "--hierarchy": {
+        "type": "string",
+        "enum": ["flat", "tree", "mesh", "star"],
+        "default": "tree",
+        "description": "Agent hierarchy pattern"
+      },
+      "--domain-routing": {
+        "type": "boolean",
+        "default": true,
+        "description": "Route to agents by domain expertise"
+      }
+    }
+  },
+
+  "jiraFlags": {
+    "issue": {
+      "--project": {
+        "short": "-P",
+        "type": "string",
+        "description": "Override default Jira project",
+        "env": "JIRA_PROJECT"
+      },
+      "--assignee": {
+        "type": "string",
+        "description": "Assign to specific user"
+      },
+      "--reporter": {
+        "type": "string",
+        "description": "Set reporter"
+      },
+      "--labels": {
+        "type": "array",
+        "description": "Add labels to issue",
+        "example": "--labels bug,critical,frontend"
+      },
+      "--components": {
+        "type": "array",
+        "description": "Add components",
+        "example": "--components api,database"
+      },
+      "--priority": {
+        "type": "string",
+        "enum": ["lowest", "low", "medium", "high", "highest", "blocker"],
+        "description": "Set issue priority"
+      },
+      "--story-points": {
+        "type": "integer",
+        "min": 1,
+        "max": 100,
+        "description": "Set story points"
+      }
+    },
+
+    "sprint": {
+      "--sprint": {
+        "short": "-s",
+        "type": "string",
+        "description": "Target sprint name or ID"
+      },
+      "--sprint-active": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add to currently active sprint"
+      },
+      "--sprint-next": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add to next planned sprint"
+      },
+      "--backlog": {
+        "type": "boolean",
+        "default": false,
+        "description": "Move to backlog"
+      }
+    },
+
+    "linking": {
+      "--epic": {
+        "type": "string",
+        "description": "Link to epic by key"
+      },
+      "--parent": {
+        "type": "string",
+        "description": "Set parent issue"
+      },
+      "--blocks": {
+        "type": "array",
+        "description": "Issues this blocks"
+      },
+      "--blocked-by": {
+        "type": "array",
+        "description": "Issues blocking this"
+      },
+      "--relates-to": {
+        "type": "array",
+        "description": "Related issues"
+      },
+      "--duplicates": {
+        "type": "string",
+        "description": "Mark as duplicate of"
+      }
+    },
+
+    "transitions": {
+      "--transition": {
+        "type": "string",
+        "description": "Transition issue to status"
+      },
+      "--auto-transition": {
+        "type": "boolean",
+        "default": true,
+        "description": "Automatically transition based on actions"
+      },
+      "--transition-comment": {
+        "type": "string",
+        "description": "Comment to add on transition"
+      }
+    }
+  },
+
+  "reviewFlags": {
+    "depth": {
+      "--depth": {
+        "type": "string",
+        "enum": ["quick", "standard", "deep", "exhaustive"],
+        "default": "standard",
+        "description": "Review depth level"
+      },
+      "--quick": {
+        "type": "boolean",
+        "default": false,
+        "description": "Quick review (5 min)",
+        "sets": {"--depth": "quick"}
+      },
+      "--deep": {
+        "type": "boolean",
+        "default": false,
+        "description": "Deep analysis (30+ min)",
+        "sets": {"--depth": "deep"}
+      },
+      "--exhaustive": {
+        "type": "boolean",
+        "default": false,
+        "description": "Exhaustive review (1+ hour)",
+        "sets": {"--depth": "exhaustive"}
+      }
+    },
+
+    "focus": {
+      "--focus": {
+        "type": "array",
+        "items": ["security", "performance", "architecture", "testing", "documentation", "accessibility", "maintainability"],
+        "default": ["security", "performance", "architecture"],
+        "description": "Review focus areas"
+      },
+      "--security-only": {
+        "type": "boolean",
+        "default": false,
+        "description": "Focus only on security",
+        "sets": {"--focus": ["security"]}
+      },
+      "--perf-only": {
+        "type": "boolean",
+        "default": false,
+        "description": "Focus only on performance",
+        "sets": {"--focus": ["performance"]}
+      }
+    },
+
+    "council": {
+      "--council": {
+        "type": "boolean",
+        "default": false,
+        "description": "Use agent council for review"
+      },
+      "--council-size": {
+        "type": "integer",
+        "default": 5,
+        "min": 3,
+        "max": 11,
+        "description": "Number of council agents"
+      },
+      "--council-protocol": {
+        "type": "string",
+        "enum": ["adversarial", "socratic", "dialectic", "jury", "delphi", "devils-advocate", "six-thinking-hats", "red-blue-team"],
+        "default": "socratic",
+        "description": "Council deliberation protocol"
+      },
+      "--council-timeout": {
+        "type": "integer",
+        "default": 600,
+        "description": "Council deliberation timeout (seconds)"
+      },
+      "--require-consensus": {
+        "type": "boolean",
+        "default": false,
+        "description": "Require unanimous council decision"
+      },
+      "--majority-threshold": {
+        "type": "number",
+        "default": 0.6,
+        "min": 0.5,
+        "max": 1.0,
+        "description": "Majority threshold for decisions"
+      }
+    },
+
+    "quality": {
+      "--min-coverage": {
+        "type": "integer",
+        "default": 80,
+        "min": 0,
+        "max": 100,
+        "description": "Minimum test coverage percentage"
+      },
+      "--max-complexity": {
+        "type": "integer",
+        "default": 10,
+        "min": 1,
+        "max": 50,
+        "description": "Maximum cyclomatic complexity"
+      },
+      "--lint-strict": {
+        "type": "boolean",
+        "default": false,
+        "description": "Strict linting rules"
+      },
+      "--type-strict": {
+        "type": "boolean",
+        "default": true,
+        "description": "Strict type checking"
+      }
+    },
+
+    "autofix": {
+      "--auto-fix": {
+        "type": "boolean",
+        "default": false,
+        "description": "Automatically fix detected issues"
+      },
+      "--fix-style": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-fix style issues"
+      },
+      "--fix-imports": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-fix import ordering"
+      },
+      "--fix-types": {
+        "type": "boolean",
+        "default": false,
+        "description": "Auto-fix type issues (experimental)"
+      },
+      "--fix-security": {
+        "type": "boolean",
+        "default": false,
+        "description": "Auto-fix security issues (review required)"
+      }
+    }
+  },
+
+  "gitFlags": {
+    "branching": {
+      "--branch-prefix": {
+        "type": "string",
+        "default": "feature",
+        "enum": ["feature", "bugfix", "hotfix", "release", "chore", "refactor"],
+        "description": "Branch name prefix"
+      },
+      "--branch-pattern": {
+        "type": "string",
+        "default": "{prefix}/{issue-key}-{slug}",
+        "description": "Branch naming pattern"
+      },
+      "--from-branch": {
+        "type": "string",
+        "default": "main",
+        "description": "Branch to create from"
+      },
+      "--no-branch": {
+        "type": "boolean",
+        "default": false,
+        "description": "Don't create new branch"
+      }
+    },
+
+    "commits": {
+      "--commit-style": {
+        "type": "string",
+        "enum": ["conventional", "gitmoji", "simple", "detailed"],
+        "default": "conventional",
+        "description": "Commit message style"
+      },
+      "--sign-commits": {
+        "type": "boolean",
+        "default": false,
+        "description": "GPG sign commits"
+      },
+      "--co-authors": {
+        "type": "array",
+        "description": "Add co-authors to commits"
+      },
+      "--no-verify": {
+        "type": "boolean",
+        "default": false,
+        "description": "Skip pre-commit hooks (not recommended)"
+      }
+    },
+
+    "pr": {
+      "--draft": {
+        "type": "boolean",
+        "default": false,
+        "description": "Create as draft PR"
+      },
+      "--reviewers": {
+        "type": "array",
+        "description": "Request specific reviewers"
+      },
+      "--team-reviewers": {
+        "type": "array",
+        "description": "Request team reviews"
+      },
+      "--labels": {
+        "type": "array",
+        "description": "PR labels"
+      },
+      "--milestone": {
+        "type": "string",
+        "description": "Link to milestone"
+      },
+      "--auto-merge": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable auto-merge when checks pass"
+      },
+      "--merge-method": {
+        "type": "string",
+        "enum": ["merge", "squash", "rebase"],
+        "default": "squash",
+        "description": "Merge method preference"
+      },
+      "--pr-template": {
+        "type": "string",
+        "description": "PR template to use"
+      }
+    }
+  },
+
+  "notificationFlags": {
+    "channels": {
+      "--notify": {
+        "type": "array",
+        "items": ["slack", "teams", "discord", "email", "webhook"],
+        "description": "Notification channels"
+      },
+      "--slack-channel": {
+        "type": "string",
+        "description": "Slack channel for notifications",
+        "env": "JIRA_SLACK_CHANNEL"
+      },
+      "--teams-channel": {
+        "type": "string",
+        "description": "Teams channel for notifications"
+      },
+      "--email-to": {
+        "type": "array",
+        "description": "Email recipients"
+      },
+      "--webhook-url": {
+        "type": "string",
+        "description": "Webhook URL for notifications"
+      }
+    },
+
+    "triggers": {
+      "--notify-on-start": {
+        "type": "boolean",
+        "default": false,
+        "description": "Notify when work starts"
+      },
+      "--notify-on-complete": {
+        "type": "boolean",
+        "default": true,
+        "description": "Notify on completion"
+      },
+      "--notify-on-error": {
+        "type": "boolean",
+        "default": true,
+        "description": "Notify on errors"
+      },
+      "--notify-on-pr": {
+        "type": "boolean",
+        "default": true,
+        "description": "Notify when PR created"
+      },
+      "--notify-on-merge": {
+        "type": "boolean",
+        "default": true,
+        "description": "Notify when PR merged"
+      }
+    },
+
+    "content": {
+      "--notify-verbose": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include detailed info in notifications"
+      },
+      "--notify-mentions": {
+        "type": "array",
+        "description": "Users to mention in notifications"
+      },
+      "--notify-template": {
+        "type": "string",
+        "description": "Custom notification template"
+      }
+    }
+  },
+
+  "reportFlags": {
+    "generation": {
+      "--report": {
+        "type": "boolean",
+        "default": false,
+        "description": "Generate completion report"
+      },
+      "--report-format": {
+        "type": "string",
+        "enum": ["markdown", "html", "pdf", "json"],
+        "default": "markdown",
+        "description": "Report output format"
+      },
+      "--report-output": {
+        "type": "string",
+        "description": "Report output path"
+      },
+      "--report-template": {
+        "type": "string",
+        "description": "Custom report template"
+      }
+    },
+
+    "content": {
+      "--include-metrics": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include metrics in report"
+      },
+      "--include-timeline": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include execution timeline"
+      },
+      "--include-diffs": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include code diffs"
+      },
+      "--include-screenshots": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include screenshots (if available)"
+      }
+    },
+
+    "destination": {
+      "--report-to-confluence": {
+        "type": "boolean",
+        "default": false,
+        "description": "Publish report to Confluence"
+      },
+      "--confluence-space": {
+        "type": "string",
+        "description": "Confluence space key"
+      },
+      "--report-to-obsidian": {
+        "type": "boolean",
+        "default": false,
+        "description": "Save report to Obsidian vault"
+      }
+    }
+  },
+
+  "harnessFlags": {
+    "pipeline": {
+      "--harness-org": {
+        "type": "string",
+        "description": "Harness organization ID",
+        "env": "HARNESS_ORG_ID"
+      },
+      "--harness-project": {
+        "type": "string",
+        "description": "Harness project ID",
+        "env": "HARNESS_PROJECT_ID"
+      },
+      "--pipeline": {
+        "type": "string",
+        "description": "Pipeline ID to trigger"
+      },
+      "--pipeline-branch": {
+        "type": "string",
+        "description": "Branch for pipeline execution"
+      },
+      "--pipeline-inputs": {
+        "type": "object",
+        "description": "Pipeline input variables (JSON)"
+      }
+    },
+
+    "deployment": {
+      "--deploy-env": {
+        "type": "string",
+        "enum": ["dev", "qa", "staging", "prod"],
+        "description": "Deployment environment"
+      },
+      "--deploy-strategy": {
+        "type": "string",
+        "enum": ["rolling", "blue-green", "canary", "recreate"],
+        "default": "rolling",
+        "description": "Deployment strategy"
+      },
+      "--wait-for-deploy": {
+        "type": "boolean",
+        "default": true,
+        "description": "Wait for deployment to complete"
+      },
+      "--rollback-on-fail": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto rollback on deployment failure"
+      }
+    }
+  },
+
+  "experimentalFlags": {
+    "--experimental": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable experimental features"
+    },
+    "--ai-suggestions": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable AI-powered suggestions (experimental)"
+    },
+    "--predictive-analysis": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable predictive failure analysis"
+    },
+    "--auto-decompose": {
+      "type": "boolean",
+      "default": false,
+      "description": "Automatically decompose large tasks"
+    }
+  }
+}

--- a/plugins/jira-orchestrator/config/presets.json
+++ b/plugins/jira-orchestrator/config/presets.json
@@ -1,0 +1,400 @@
+{
+  "$schema": "../schemas/presets.schema.json",
+  "version": "1.0.0",
+  "description": "Pre-configured flag presets for common Jira orchestration workflows",
+
+  "presets": {
+    "speed-run": {
+      "name": "Speed Run",
+      "emoji": "⚡",
+      "description": "Quick execution with minimal overhead - for simple tasks",
+      "tags": ["fast", "minimal", "simple"],
+      "flags": {
+        "--agents": 3,
+        "--model": "haiku",
+        "--depth": "quick",
+        "--parallel": true,
+        "--skip-phases": ["document"],
+        "--checkpoint": false,
+        "--timeout": 120,
+        "--notify-on-complete": false
+      },
+      "bestFor": ["small bug fixes", "typo corrections", "config changes"]
+    },
+
+    "thorough": {
+      "name": "Thorough Review",
+      "emoji": "🔍",
+      "description": "Comprehensive analysis with deep review - for important changes",
+      "tags": ["complete", "detailed", "quality"],
+      "flags": {
+        "--agents": 7,
+        "--model": "sonnet",
+        "--depth": "deep",
+        "--council": true,
+        "--council-size": 5,
+        "--focus": ["security", "performance", "architecture", "testing"],
+        "--min-coverage": 80,
+        "--checkpoint": true,
+        "--report": true
+      },
+      "bestFor": ["new features", "refactoring", "security-sensitive code"]
+    },
+
+    "enterprise": {
+      "name": "Enterprise Mode",
+      "emoji": "🏢",
+      "description": "Full enterprise workflow with compliance and notifications",
+      "tags": ["compliance", "audit", "enterprise"],
+      "flags": {
+        "--agents": 9,
+        "--model": "opus",
+        "--depth": "exhaustive",
+        "--council": true,
+        "--council-size": 7,
+        "--council-protocol": "jury",
+        "--require-consensus": true,
+        "--checkpoint": true,
+        "--checkpoint-interval": 60,
+        "--report": true,
+        "--report-to-confluence": true,
+        "--notify": ["slack", "email"],
+        "--notify-on-start": true,
+        "--notify-on-complete": true,
+        "--sign-commits": true,
+        "--include-metrics": true,
+        "--include-timeline": true
+      },
+      "bestFor": ["production deployments", "compliance-required changes", "auditable workflows"]
+    },
+
+    "security-audit": {
+      "name": "Security Audit",
+      "emoji": "🔒",
+      "description": "Security-focused review with vulnerability scanning",
+      "tags": ["security", "audit", "compliance"],
+      "flags": {
+        "--agents": 5,
+        "--model": "opus",
+        "--depth": "exhaustive",
+        "--focus": ["security"],
+        "--council": true,
+        "--council-protocol": "red-blue-team",
+        "--security-only": true,
+        "--fix-security": false,
+        "--report": true,
+        "--report-format": "html",
+        "--include-diffs": true
+      },
+      "bestFor": ["security reviews", "penetration testing prep", "compliance audits"]
+    },
+
+    "performance-focus": {
+      "name": "Performance Focus",
+      "emoji": "🚀",
+      "description": "Performance-optimized analysis",
+      "tags": ["performance", "optimization"],
+      "flags": {
+        "--agents": 5,
+        "--model": "sonnet",
+        "--depth": "deep",
+        "--focus": ["performance"],
+        "--perf-only": true,
+        "--profile-perf": true,
+        "--report": true,
+        "--include-metrics": true
+      },
+      "bestFor": ["performance optimization", "bottleneck analysis", "scaling work"]
+    },
+
+    "stealth": {
+      "name": "Stealth Mode",
+      "emoji": "🥷",
+      "description": "Silent execution with no notifications or logging",
+      "tags": ["quiet", "minimal", "private"],
+      "flags": {
+        "--quiet": true,
+        "--no-color": true,
+        "--notify": [],
+        "--notify-on-complete": false,
+        "--notify-on-error": false,
+        "--report": false,
+        "--checkpoint": false
+      },
+      "bestFor": ["experimental work", "private investigations", "exploratory coding"]
+    },
+
+    "pair-programming": {
+      "name": "Pair Programming",
+      "emoji": "👥",
+      "description": "Interactive mode for pair programming sessions",
+      "tags": ["interactive", "collaborative"],
+      "flags": {
+        "--interactive": true,
+        "--verbose": true,
+        "--agents": 3,
+        "--model": "sonnet",
+        "--checkpoint": true,
+        "--checkpoint-interval": 120,
+        "--depth": "standard"
+      },
+      "bestFor": ["pair programming", "mentoring", "collaborative development"]
+    },
+
+    "hotfix": {
+      "name": "Emergency Hotfix",
+      "emoji": "🚨",
+      "description": "Rapid hotfix deployment with minimal checks",
+      "tags": ["emergency", "fast", "production"],
+      "flags": {
+        "--agents": 3,
+        "--model": "haiku",
+        "--depth": "quick",
+        "--branch-prefix": "hotfix",
+        "--skip-phases": ["document"],
+        "--auto-transition": true,
+        "--draft": false,
+        "--auto-merge": true,
+        "--notify": ["slack"],
+        "--notify-on-complete": true,
+        "--timeout": 60
+      },
+      "bestFor": ["production hotfixes", "critical bugs", "emergency patches"]
+    },
+
+    "documentation": {
+      "name": "Documentation Focus",
+      "emoji": "📚",
+      "description": "Focus on documentation generation and updates",
+      "tags": ["docs", "documentation"],
+      "flags": {
+        "--agents": 5,
+        "--model": "sonnet",
+        "--phases": ["explore", "document"],
+        "--focus": ["documentation"],
+        "--report": true,
+        "--report-to-confluence": true,
+        "--report-to-obsidian": true
+      },
+      "bestFor": ["documentation sprints", "README updates", "API docs"]
+    },
+
+    "refactor": {
+      "name": "Safe Refactor",
+      "emoji": "🔧",
+      "description": "Safe refactoring with comprehensive testing",
+      "tags": ["refactor", "safe", "testing"],
+      "flags": {
+        "--agents": 7,
+        "--model": "sonnet",
+        "--depth": "deep",
+        "--branch-prefix": "refactor",
+        "--focus": ["architecture", "maintainability", "testing"],
+        "--min-coverage": 90,
+        "--type-strict": true,
+        "--lint-strict": true,
+        "--council": true,
+        "--council-protocol": "socratic",
+        "--checkpoint": true
+      },
+      "bestFor": ["large refactors", "architecture changes", "code cleanup"]
+    },
+
+    "prototype": {
+      "name": "Prototype Mode",
+      "emoji": "🧪",
+      "description": "Experimental prototyping with relaxed constraints",
+      "tags": ["experimental", "prototype", "fast"],
+      "flags": {
+        "--agents": 3,
+        "--model": "haiku",
+        "--depth": "quick",
+        "--experimental": true,
+        "--ai-suggestions": true,
+        "--auto-decompose": true,
+        "--draft": true,
+        "--skip-phases": ["test", "document"],
+        "--lint-strict": false,
+        "--type-strict": false,
+        "--min-coverage": 0
+      },
+      "bestFor": ["proof of concept", "experiments", "rapid prototyping"]
+    },
+
+    "code-review": {
+      "name": "Code Review",
+      "emoji": "👀",
+      "description": "Focused code review without implementation",
+      "tags": ["review", "analysis"],
+      "flags": {
+        "--dry-run": true,
+        "--agents": 5,
+        "--model": "sonnet",
+        "--depth": "deep",
+        "--council": true,
+        "--council-size": 5,
+        "--council-protocol": "socratic",
+        "--focus": ["security", "performance", "architecture"],
+        "--report": true,
+        "--report-format": "markdown"
+      },
+      "bestFor": ["PR reviews", "code audits", "pre-merge checks"]
+    },
+
+    "ci-integration": {
+      "name": "CI Integration",
+      "emoji": "⚙️",
+      "description": "Optimized for CI/CD pipeline execution",
+      "tags": ["ci", "automation", "pipeline"],
+      "flags": {
+        "--json": true,
+        "--no-color": true,
+        "--quiet": true,
+        "--yes": true,
+        "--fail-fast": true,
+        "--timeout": 600,
+        "--agents": 5,
+        "--checkpoint": false,
+        "--notify": ["webhook"]
+      },
+      "bestFor": ["CI pipelines", "automated workflows", "GitHub Actions"]
+    },
+
+    "learning": {
+      "name": "Learning Mode",
+      "emoji": "📖",
+      "description": "Verbose explanations for learning purposes",
+      "tags": ["learning", "verbose", "educational"],
+      "flags": {
+        "--verbose": true,
+        "--interactive": true,
+        "--agents": 5,
+        "--model": "sonnet",
+        "--depth": "deep",
+        "--report": true,
+        "--include-timeline": true,
+        "--include-diffs": true
+      },
+      "bestFor": ["onboarding", "learning new codebases", "educational sessions"]
+    },
+
+    "release": {
+      "name": "Release Preparation",
+      "emoji": "🎉",
+      "description": "Full release workflow with changelog and versioning",
+      "tags": ["release", "versioning", "deployment"],
+      "flags": {
+        "--agents": 7,
+        "--model": "sonnet",
+        "--depth": "deep",
+        "--branch-prefix": "release",
+        "--council": true,
+        "--focus": ["security", "testing", "documentation"],
+        "--min-coverage": 85,
+        "--report": true,
+        "--report-to-confluence": true,
+        "--notify": ["slack", "email"],
+        "--notify-mentions": ["@team"],
+        "--harness-project": "${HARNESS_PROJECT_ID}",
+        "--deploy-strategy": "blue-green",
+        "--wait-for-deploy": true,
+        "--rollback-on-fail": true
+      },
+      "bestFor": ["release branches", "version bumps", "production deployments"]
+    },
+
+    "cost-optimized": {
+      "name": "Cost Optimized",
+      "emoji": "💰",
+      "description": "Minimize API costs while maintaining quality",
+      "tags": ["cost", "efficient", "budget"],
+      "flags": {
+        "--agents": 3,
+        "--model": "haiku",
+        "--model-strategy": "cost-optimized",
+        "--depth": "standard",
+        "--sequential": true,
+        "--max-concurrent": 1,
+        "--checkpoint": true,
+        "--timeout": 600
+      },
+      "bestFor": ["budget constraints", "non-critical tasks", "batch processing"]
+    },
+
+    "full-council": {
+      "name": "Full Agent Council",
+      "emoji": "👑",
+      "description": "Maximum deliberation with full council review",
+      "tags": ["council", "deliberation", "consensus"],
+      "flags": {
+        "--agents": 11,
+        "--model": "opus",
+        "--depth": "exhaustive",
+        "--council": true,
+        "--council-size": 11,
+        "--council-protocol": "jury",
+        "--council-timeout": 1200,
+        "--require-consensus": true,
+        "--majority-threshold": 0.8,
+        "--blackboard": true,
+        "--hierarchy": "mesh",
+        "--report": true
+      },
+      "bestFor": ["critical decisions", "architecture reviews", "major refactors"]
+    }
+  },
+
+  "presetGroups": {
+    "speed": ["speed-run", "hotfix", "prototype"],
+    "quality": ["thorough", "enterprise", "full-council"],
+    "security": ["security-audit"],
+    "collaboration": ["pair-programming", "learning"],
+    "automation": ["ci-integration", "cost-optimized"],
+    "release": ["release", "documentation"]
+  },
+
+  "recommendations": {
+    "byIssueType": {
+      "Bug": "speed-run",
+      "Story": "thorough",
+      "Epic": "enterprise",
+      "Task": "speed-run",
+      "Sub-task": "speed-run",
+      "Security": "security-audit",
+      "Performance": "performance-focus",
+      "Documentation": "documentation"
+    },
+    "byPriority": {
+      "Blocker": "hotfix",
+      "Critical": "hotfix",
+      "High": "thorough",
+      "Medium": "speed-run",
+      "Low": "cost-optimized"
+    },
+    "byLabels": {
+      "security": "security-audit",
+      "performance": "performance-focus",
+      "refactor": "refactor",
+      "prototype": "prototype",
+      "documentation": "documentation",
+      "release": "release"
+    }
+  },
+
+  "customization": {
+    "allowOverride": true,
+    "inheritFrom": true,
+    "validation": "strict",
+    "example": {
+      "comment": "Create custom presets by extending existing ones",
+      "customPreset": {
+        "extends": "thorough",
+        "name": "My Custom Preset",
+        "flags": {
+          "--agents": 9,
+          "--notify": ["slack"]
+        }
+      }
+    }
+  }
+}

--- a/plugins/jira-orchestrator/docs/FLAGS.md
+++ b/plugins/jira-orchestrator/docs/FLAGS.md
@@ -1,0 +1,377 @@
+# Jira Orchestrator Flag System
+
+> **⚡ Comprehensive command customization for every workflow**
+
+## Quick Start
+
+```bash
+# Use a preset for common workflows
+/jira:work PROJ-123 --preset speed-run
+/jira:ship PROJ-456 --preset enterprise
+
+# Mix presets with custom flags
+/jira:work PROJ-123 --preset thorough --agents 9
+
+# View available presets
+/jira:help presets
+```
+
+## Flag Categories
+
+### 🎛️ Global Flags (All Commands)
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--verbose` | `-v` | bool | false | Detailed output |
+| `--quiet` | `-q` | bool | false | Errors only |
+| `--json` | `-j` | bool | false | JSON output |
+| `--dry-run` | `-n` | bool | false | Preview without executing |
+| `--interactive` | `-i` | bool | false | Prompt before actions |
+| `--yes` | `-y` | bool | false | Auto-confirm prompts |
+| `--timeout` | `-t` | int | 300 | Timeout in seconds |
+| `--config` | `-c` | string | - | Custom config file |
+| `--profile` | `-p` | string | default | Named profile |
+| `--preset` | - | string | - | Use preset flags |
+| `--debug` | `-d` | bool | false | Debug mode |
+
+### 🤖 Orchestration Flags
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--agents` | `-a` | int | 5 | Number of sub-agents (1-13) |
+| `--model` | `-m` | string | auto | Model (opus/sonnet/haiku/auto) |
+| `--model-strategy` | - | string | balanced | Multi-model routing |
+| `--parallel` | - | bool | true | Run agents in parallel |
+| `--sequential` | - | bool | false | Run agents sequentially |
+| `--max-concurrent` | - | int | 5 | Max concurrent agents |
+
+#### Phase Control
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--phases` | array | all | Phases to execute |
+| `--skip-phases` | array | [] | Phases to skip |
+| `--start-phase` | string | explore | Start from phase |
+| `--end-phase` | string | document | Stop after phase |
+
+**Phases:** `explore` → `plan` → `code` → `test` → `fix` → `document`
+
+```bash
+# Skip documentation phase
+/jira:work PROJ-123 --skip-phases document
+
+# Only run explore and plan
+/jira:work PROJ-123 --phases explore,plan
+
+# Start from code phase (resume)
+/jira:work PROJ-123 --start-phase code
+```
+
+#### Checkpointing
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--checkpoint` | bool | true | Save checkpoints |
+| `--checkpoint-interval` | int | 300 | Interval (seconds) |
+| `--resume` | `-r` | bool | false | Resume from checkpoint |
+| `--resume-from` | string | - | Specific checkpoint ID |
+
+### 🎫 Jira Flags
+
+| Flag | Short | Type | Description |
+|------|-------|------|-------------|
+| `--project` | `-P` | string | Override project |
+| `--assignee` | - | string | Assign user |
+| `--labels` | - | array | Add labels |
+| `--components` | - | array | Add components |
+| `--priority` | - | string | Set priority |
+| `--story-points` | - | int | Set points |
+| `--sprint` | `-s` | string | Target sprint |
+| `--epic` | - | string | Link to epic |
+
+```bash
+# Full customization
+/jira:work PROJ-123 \
+  --labels bug,critical \
+  --priority high \
+  --sprint "Sprint 42" \
+  --assignee @username
+```
+
+### 🔍 Review Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--depth` | string | standard | Review depth |
+| `--quick` | bool | false | Quick review (5 min) |
+| `--deep` | bool | false | Deep analysis |
+| `--exhaustive` | bool | false | Exhaustive review |
+| `--focus` | array | [security,performance,architecture] | Focus areas |
+| `--security-only` | bool | false | Security focus only |
+
+#### Council Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--council` | bool | false | Use agent council |
+| `--council-size` | int | 5 | Council agents (3-11) |
+| `--council-protocol` | string | socratic | Deliberation protocol |
+| `--require-consensus` | bool | false | Require unanimous |
+| `--majority-threshold` | float | 0.6 | Majority threshold |
+
+**Council Protocols:**
+- `adversarial` - Devil's advocate approach
+- `socratic` - Question-driven exploration
+- `dialectic` - Thesis/antithesis synthesis
+- `jury` - Formal deliberation
+- `delphi` - Anonymous expert consensus
+- `red-blue-team` - Attack/defense simulation
+- `six-thinking-hats` - Multi-perspective analysis
+
+```bash
+# Security review with red-blue team
+/jira:council PR-URL --council-protocol red-blue-team --depth exhaustive
+
+# Full council consensus
+/jira:ship PROJ-123 --council --council-size 9 --require-consensus
+```
+
+#### Quality Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--min-coverage` | int | 80 | Min test coverage % |
+| `--max-complexity` | int | 10 | Max cyclomatic complexity |
+| `--lint-strict` | bool | false | Strict linting |
+| `--type-strict` | bool | true | Strict types |
+| `--auto-fix` | bool | false | Auto-fix issues |
+| `--fix-style` | bool | true | Fix style issues |
+| `--fix-security` | bool | false | Fix security (review required) |
+
+### 🌿 Git Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--branch-prefix` | string | feature | Branch prefix |
+| `--from-branch` | string | main | Base branch |
+| `--commit-style` | string | conventional | Commit style |
+| `--sign-commits` | bool | false | GPG sign |
+| `--draft` | bool | false | Draft PR |
+| `--reviewers` | array | - | PR reviewers |
+| `--auto-merge` | bool | false | Auto-merge |
+| `--merge-method` | string | squash | Merge method |
+
+**Branch Prefixes:** `feature`, `bugfix`, `hotfix`, `release`, `chore`, `refactor`
+
+**Commit Styles:** `conventional`, `gitmoji`, `simple`, `detailed`
+
+```bash
+# Hotfix with auto-merge
+/jira:ship PROJ-123 \
+  --branch-prefix hotfix \
+  --auto-merge \
+  --merge-method merge
+```
+
+### 📢 Notification Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--notify` | array | Channels (slack, teams, email, webhook) |
+| `--slack-channel` | string | Slack channel |
+| `--notify-on-start` | bool | Notify when starting |
+| `--notify-on-complete` | bool | Notify on completion |
+| `--notify-on-error` | bool | Notify on errors |
+| `--notify-mentions` | array | Users to mention |
+
+### 📊 Report Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--report` | bool | false | Generate report |
+| `--report-format` | string | markdown | Format (md/html/pdf/json) |
+| `--report-output` | string | - | Output path |
+| `--include-metrics` | bool | true | Include metrics |
+| `--include-timeline` | bool | true | Include timeline |
+| `--include-diffs` | bool | false | Include code diffs |
+| `--report-to-confluence` | bool | false | Publish to Confluence |
+| `--report-to-obsidian` | bool | false | Save to Obsidian |
+
+---
+
+## Presets
+
+Use `--preset <name>` to apply predefined flag combinations:
+
+### Speed Presets ⚡
+
+| Preset | Description | Best For |
+|--------|-------------|----------|
+| `speed-run` | Quick execution, minimal overhead | Small fixes, typos |
+| `hotfix` | Emergency deployment | Production issues |
+| `prototype` | Relaxed constraints, experimental | PoC, experiments |
+
+### Quality Presets 🔍
+
+| Preset | Description | Best For |
+|--------|-------------|----------|
+| `thorough` | Deep review, council enabled | New features |
+| `enterprise` | Full compliance workflow | Auditable changes |
+| `security-audit` | Security-focused analysis | Security reviews |
+| `full-council` | Maximum deliberation | Critical decisions |
+
+### Workflow Presets 🔧
+
+| Preset | Description | Best For |
+|--------|-------------|----------|
+| `code-review` | Review without changes | PR reviews |
+| `refactor` | Safe refactoring | Architecture changes |
+| `release` | Full release workflow | Deployments |
+| `documentation` | Docs focus | README updates |
+
+### Mode Presets 🎯
+
+| Preset | Description | Best For |
+|--------|-------------|----------|
+| `pair-programming` | Interactive, verbose | Collaboration |
+| `learning` | Educational explanations | Onboarding |
+| `ci-integration` | CI/CD optimized | Pipelines |
+| `cost-optimized` | Budget-friendly | Non-critical tasks |
+| `stealth` | Silent execution | Private work |
+
+```bash
+# Examples
+/jira:work PROJ-123 --preset speed-run
+/jira:ship PROJ-456 --preset enterprise
+/jira:council PR-URL --preset security-audit
+```
+
+---
+
+## Combining Flags
+
+Flags can be combined in any order. Later flags override earlier ones:
+
+```bash
+# Preset + custom overrides
+/jira:work PROJ-123 \
+  --preset thorough \
+  --agents 9 \
+  --model opus \
+  --notify slack
+
+# Multiple focus areas
+/jira:council PR-URL \
+  --focus security,performance,testing \
+  --depth deep
+
+# Full customization
+/jira:ship PROJ-123 \
+  --agents 7 \
+  --model sonnet \
+  --council \
+  --council-size 5 \
+  --council-protocol socratic \
+  --depth deep \
+  --focus security,architecture \
+  --min-coverage 85 \
+  --branch-prefix feature \
+  --commit-style conventional \
+  --draft false \
+  --reviewers @reviewer1,@reviewer2 \
+  --notify slack,email \
+  --report \
+  --report-to-confluence
+```
+
+---
+
+## Configuration Files
+
+### User Config (`~/.jira-orchestrator.yml`)
+
+```yaml
+defaults:
+  model: sonnet
+  agents: 5
+  depth: standard
+
+profiles:
+  work:
+    model: opus
+    agents: 7
+    notify:
+      - slack
+
+  personal:
+    model: haiku
+    agents: 3
+    notify: []
+```
+
+### Project Config (`.jira-orchestrator.yml`)
+
+```yaml
+project: PROJ
+defaults:
+  branch-prefix: feature
+  commit-style: conventional
+
+presets:
+  custom-review:
+    extends: thorough
+    flags:
+      agents: 9
+      notify:
+        - slack
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `JIRA_VERBOSE` | Default verbose mode |
+| `JIRA_TIMEOUT` | Default timeout |
+| `JIRA_PROJECT` | Default project |
+| `JIRA_DEFAULT_MODEL` | Default model |
+| `JIRA_SLACK_CHANNEL` | Slack channel |
+| `HARNESS_ORG_ID` | Harness org |
+| `HARNESS_PROJECT_ID` | Harness project |
+
+---
+
+## Auto-Recommendations
+
+The system automatically suggests presets based on:
+
+1. **Issue Type**: Bug → `speed-run`, Epic → `enterprise`
+2. **Priority**: Blocker → `hotfix`, Low → `cost-optimized`
+3. **Labels**: `security` → `security-audit`, `prototype` → `prototype`
+
+```bash
+# Let the system recommend
+/jira:work PROJ-123 --auto-preset
+```
+
+---
+
+## Help Commands
+
+```bash
+# List all flags
+/jira:help flags
+
+# Show specific flag details
+/jira:help flags --agents
+
+# List all presets
+/jira:help presets
+
+# Show preset details
+/jira:help presets thorough
+
+# Validate flag combination
+/jira:work PROJ-123 --dry-run --verbose
+```


### PR DESCRIPTION
The frontend-design-system plugin was not working because it was not
registered in the plugin, skill, and command registries. This adds:

- Plugin registration with callsign "Stylist" in plugins.index.json
- Design-system skill with triggers in skills.index.json
- 8 design commands (style, theme, tokens, component, palette, keycloak,
  audit, convert) in commands.index.json
- Updated stats in all registry files