### PR TITLE
fix(plugin): Remove unrecognized manifest keys from plugin.json files

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,30 +21,5 @@
     "docker",
     "ci-cd",
     "testing"
-  ],
-  "categories": ["orchestration", "agents", "devops"],
-  "provides": {
-    "agents": "dynamic",
-    "skills": "dynamic",
-    "commands": "dynamic",
-    "workflows": "dynamic",
-    "hooks": "dynamic"
-  },
-  "discovery": {
-    "agents": {
-      "enabled": true,
-      "directory": "../.claude/registry",
-      "pattern": "agents.index.json"
-    },
-    "skills": {
-      "enabled": true,
-      "directory": "../.claude/registry",
-      "pattern": "skills.index.json"
-    },
-    "commands": {
-      "enabled": true,
-      "directory": "../.claude/commands",
-      "pattern": "*.md"
-    }
-  }
+  ]
 }

--- a/.claude/plugins/analytics-dashboard/plugin.json
+++ b/.claude/plugins/analytics-dashboard/plugin.json
@@ -12,43 +12,12 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["analytics", "metrics", "reporting", "forecasting"],
   "keywords": [
     "analytics", "metrics", "dashboard", "velocity", "burndown",
     "forecasting", "trends", "kpi", "performance", "productivity",
     "cost-analysis", "time-tracking", "sprint-metrics", "cycle-time",
     "lead-time", "throughput", "dora-metrics", "four-keys"
   ],
-
-  "provides": {
-    "commands": 16,
-    "agents": 10,
-    "skills": 6,
-    "hooks": 3
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Pulls sprint data, velocity, story points for analytics",
-      "data": ["sprints", "issues", "worklogs", "estimates"],
-      "bidirectional": false
-    },
-    "git-workflow-orchestrator": {
-      "description": "Analyzes commit patterns, PR metrics, code churn",
-      "data": ["commits", "prs", "reviews", "contributors"],
-      "bidirectional": false
-    },
-    "testing-orchestrator": {
-      "description": "Tracks test metrics, coverage trends, flaky test rates",
-      "data": ["coverage", "test-results", "failure-rates"],
-      "bidirectional": false
-    },
-    "release-orchestrator": {
-      "description": "Tracks deployment frequency, lead time, MTTR",
-      "data": ["deployments", "rollbacks", "release-frequency"],
-      "bidirectional": false
-    }
-  },
 
   "metricCategories": {
     "velocity": {

--- a/.claude/plugins/api-integration-helper/plugin.json
+++ b/.claude/plugins/api-integration-helper/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["api", "code-generation", "integration", "testing"],
   "keywords": [
     "api", "openapi", "swagger", "graphql", "rest", "client-generation",
     "typescript", "authentication", "oauth", "api-key", "jwt",
@@ -20,13 +19,6 @@
     "api-testing", "request-validation", "response-validation",
     "stripe", "api-integration", "sdk-generation", "typed-client"
   ],
-
-  "provides": {
-    "commands": 10,
-    "agents": 10,
-    "skills": 6,
-    "hooks": 3
-  },
 
   "integrationCapabilities": {
     "description": "End-to-end API integration pipeline with 6 core capabilities",

--- a/.claude/plugins/autonomous-sprint-ai/plugin.json
+++ b/.claude/plugins/autonomous-sprint-ai/plugin.json
@@ -12,44 +12,12 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["ai", "project-management", "automation", "autonomous"],
   "keywords": [
     "autonomous", "self-governing", "sprint", "agile", "planning",
     "workload-balancing", "blocker-prediction", "scope-negotiation",
     "capacity-optimization", "velocity-prediction", "risk-assessment",
     "decision-making", "adaptive", "learning", "autopilot"
   ],
-
-  "provides": {
-    "commands": 14,
-    "agents": 12,
-    "skills": 7,
-    "hooks": 6,
-    "decisionEngines": 5
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Core integration - manages Jira issues autonomously",
-      "capabilities": ["issue-assignment", "priority-adjustment", "scope-management"],
-      "autonomyRequired": true
-    },
-    "notification-hub": {
-      "description": "Communicates decisions and requests approvals",
-      "capabilities": ["decision-notification", "approval-request", "escalation"],
-      "required": true
-    },
-    "analytics-dashboard": {
-      "description": "Feeds decisions with real-time metrics",
-      "capabilities": ["velocity-data", "capacity-data", "trend-analysis"],
-      "realtime": true
-    },
-    "testing-orchestrator": {
-      "description": "Factors test status into sprint decisions",
-      "capabilities": ["test-status", "blocker-detection"],
-      "optional": true
-    }
-  },
 
   "autonomyLevels": {
     "advisor": {

--- a/.claude/plugins/code-knowledge-graph/plugin.json
+++ b/.claude/plugins/code-knowledge-graph/plugin.json
@@ -12,44 +12,12 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["ai", "knowledge", "analysis", "semantic"],
   "keywords": [
     "knowledge-graph", "semantic", "graph-database", "code-understanding",
     "impact-analysis", "dependency-graph", "call-graph", "data-flow",
     "architectural-patterns", "domain-model", "entity-relationship",
     "code-search", "semantic-search", "codebase-memory", "neo4j"
   ],
-
-  "provides": {
-    "commands": 15,
-    "agents": 11,
-    "skills": 7,
-    "hooks": 4,
-    "graphTypes": 8
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Links code entities to Jira issues for traceability",
-      "capabilities": ["issue-code-link", "impact-on-issues"],
-      "bidirectional": true
-    },
-    "documentation-orchestrator": {
-      "description": "Auto-generates documentation from knowledge graph",
-      "capabilities": ["graph-to-docs", "relationship-docs"],
-      "enhances": true
-    },
-    "testing-orchestrator": {
-      "description": "Identifies tests affected by code changes",
-      "capabilities": ["test-impact", "coverage-mapping"],
-      "required": false
-    },
-    "cognitive-code-reasoner": {
-      "description": "Provides context for deep reasoning",
-      "capabilities": ["context-enrichment", "relationship-context"],
-      "enhances": true
-    }
-  },
 
   "graphTypes": {
     "call-graph": {

--- a/.claude/plugins/code-quality-orchestrator/plugin.json
+++ b/.claude/plugins/code-quality-orchestrator/plugin.json
@@ -12,19 +12,11 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["devops", "testing", "security", "code-generation"],
   "keywords": [
     "code-quality", "linting", "eslint", "prettier", "static-analysis",
     "test-coverage", "security-scanning", "complexity", "dependencies",
     "pre-commit", "ci-cd", "quality-gates", "orchestration", "clean-code"
   ],
-
-  "provides": {
-    "commands": 12,
-    "agents": 8,
-    "skills": 5,
-    "hooks": 6
-  },
 
   "qualityGates": {
     "description": "5 integrated quality gates that enforce clean code production",

--- a/.claude/plugins/cognitive-code-reasoner/plugin.json
+++ b/.claude/plugins/cognitive-code-reasoner/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["ai", "debugging", "reasoning", "analysis"],
   "keywords": [
     "extended-thinking", "ultrathink", "cognitive", "reasoning",
     "hypothesis-driven", "causal-analysis", "root-cause", "debugging",
@@ -20,32 +19,6 @@
     "multi-step-reasoning", "chain-of-thought", "tree-of-thought",
     "abductive-reasoning", "counterfactual", "invariant-analysis"
   ],
-
-  "provides": {
-    "commands": 12,
-    "agents": 15,
-    "skills": 8,
-    "hooks": 4,
-    "reasoningPatterns": 12
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Generates root cause analysis reports linked to Jira bugs",
-      "commands": ["reason:jira-bug"],
-      "outputs": ["root-cause-report", "fix-hypothesis"]
-    },
-    "testing-orchestrator": {
-      "description": "Reasons about test failures, suggests targeted tests",
-      "commands": ["reason:test-failure"],
-      "bidirectional": true
-    },
-    "code-quality-orchestrator": {
-      "description": "Deep analysis of code quality issues",
-      "commands": ["reason:quality-issue"],
-      "enhances": true
-    }
-  },
 
   "thinkingModes": {
     "ultrathink": {

--- a/.claude/plugins/customer-data-migration-orchestrator/plugin.json
+++ b/.claude/plugins/customer-data-migration-orchestrator/plugin.json
@@ -12,8 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["data", "migration", "etl", "integration", "onboarding"],
-
   "architecture": {
     "pattern": "adapter-based",
     "description": "Like Terraformer/Terraform - source adapters (providers) extract data, universal IR transforms, target mapper outputs to YOUR schema",

--- a/.claude/plugins/database-schema-designer/plugin.json
+++ b/.claude/plugins/database-schema-designer/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["database", "backend", "devops", "performance"],
   "keywords": [
     "database", "schema", "migration", "prisma", "typeorm", "alembic",
     "sql", "postgres", "mysql", "mongodb", "index", "optimization",
@@ -21,13 +20,6 @@
     "foreign-key", "constraint", "trigger", "view", "materialized-view",
     "partition", "sharding", "replication", "backup", "restore"
   ],
-
-  "provides": {
-    "commands": 15,
-    "agents": 10,
-    "skills": 6,
-    "hooks": 5
-  },
 
   "databases": {
     "relational": {

--- a/.claude/plugins/debug-detective/plugin.json
+++ b/.claude/plugins/debug-detective/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["debugging", "analysis", "troubleshooting", "root-cause"],
   "keywords": [
     "debug", "debugging", "bug", "error", "crash", "null", "undefined",
     "stack-trace", "exception", "breakpoint", "console.log", "debugger",
@@ -23,36 +22,6 @@
     "why-is-this", "unexpected-behavior", "reproduce", "minimal-repro",
     "heisenbug", "edge-case", "corner-case", "boundary-condition"
   ],
-
-  "provides": {
-    "commands": 12,
-    "agents": 11,
-    "skills": 6,
-    "hooks": 4
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Links debugging sessions to bug tickets, updates with findings",
-      "commands": ["debug:jira-link", "debug:update-ticket"],
-      "bidirectional": true
-    },
-    "git-workflow-orchestrator": {
-      "description": "Automates git bisect for regression hunting",
-      "commands": ["debug:bisect-auto"],
-      "blocking": false
-    },
-    "testing-orchestrator": {
-      "description": "Generates reproduction tests from debugging sessions",
-      "commands": ["debug:generate-test"],
-      "blocking": false
-    },
-    "code-knowledge-graph": {
-      "description": "Traces data flow through call graphs",
-      "commands": ["debug:trace-flow"],
-      "blocking": false
-    }
-  },
 
   "debuggingStrategies": {
     "hypothesis-driven": {

--- a/.claude/plugins/dev-environment-bootstrap/plugin.json
+++ b/.claude/plugins/dev-environment-bootstrap/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["devops", "development", "tooling", "automation"],
   "keywords": [
     "setup", "environment", "dependencies", "docker", "docker-compose",
     "dotenv", "env-vars", "pre-commit", "hooks", "ide", "vscode", "cursor",
@@ -22,31 +21,6 @@
     "node", "python", "ruby", "go", "rust", "java", "gradle", "maven",
     "works-on-my-machine", "dev-container", "codespaces"
   ],
-
-  "provides": {
-    "commands": 12,
-    "agents": 10,
-    "skills": 7,
-    "hooks": 4
-  },
-
-  "integrations": {
-    "docker": {
-      "description": "Generates and manages Docker/docker-compose configurations",
-      "commands": ["bootstrap:dockerize", "bootstrap:setup"],
-      "bidirectional": false
-    },
-    "git-workflow-orchestrator": {
-      "description": "Sets up pre-commit hooks and git configuration",
-      "commands": ["bootstrap:hooks", "bootstrap:setup"],
-      "bidirectional": true
-    },
-    "code-quality-orchestrator": {
-      "description": "Integrates linters, formatters, and quality checks",
-      "commands": ["bootstrap:setup", "bootstrap:hooks"],
-      "blocking": false
-    }
-  },
 
   "workflows": {
     "quick-setup": {

--- a/.claude/plugins/documentation-orchestrator/plugin.json
+++ b/.claude/plugins/documentation-orchestrator/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["documentation", "knowledge", "api", "automation"],
   "keywords": [
     "documentation", "docs", "readme", "api-docs", "openapi",
     "swagger", "typedoc", "jsdoc", "sphinx", "mkdocs",
@@ -20,31 +19,6 @@
     "confluence", "wiki", "knowledge-base", "obsidian",
     "adr", "decision-records", "runbooks", "onboarding"
   ],
-
-  "provides": {
-    "commands": 16,
-    "agents": 11,
-    "skills": 7,
-    "hooks": 4
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Links documentation to Jira issues, auto-generates technical specs",
-      "commands": ["docs:jira", "docs:spec"],
-      "bidirectional": true
-    },
-    "code-quality-orchestrator": {
-      "description": "Enforces documentation coverage thresholds",
-      "commands": ["docs:coverage"],
-      "blocking": false
-    },
-    "release-orchestrator": {
-      "description": "Updates docs on release, generates release documentation",
-      "commands": ["docs:release"],
-      "optional": true
-    }
-  },
 
   "documentationTypes": {
     "api": {

--- a/.claude/plugins/fixer/plugin.json
+++ b/.claude/plugins/fixer/plugin.json
@@ -87,20 +87,6 @@
     "prevention-audit",
     "recurring-error-investigation"
   ],
-  "dependencies": {
-    "mcps": [
-      "github",
-      "obsidian"
-    ],
-    "skills": [
-      "debugging",
-      "testing"
-    ],
-    "external_apis": [
-      "stackoverflow",
-      "github_search"
-    ]
-  },
   "configuration": {
     "search_stackoverflow": true,
     "search_github_issues": true,

--- a/.claude/plugins/git-workflow-orchestrator/plugin.json
+++ b/.claude/plugins/git-workflow-orchestrator/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["devops", "development", "git", "automation"],
   "keywords": [
     "git", "branch", "merge", "rebase", "conflict-resolution",
     "gitflow", "trunk-based", "feature-flags", "pull-request",
@@ -20,26 +19,6 @@
     "commit-linting", "conventional-commits", "squash", "cherry-pick",
     "stash", "worktree", "bisect", "reflog", "hooks"
   ],
-
-  "provides": {
-    "commands": 15,
-    "agents": 10,
-    "skills": 6,
-    "hooks": 5
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Links branches to Jira issues, enforces smart commit messages",
-      "commands": ["git:branch", "git:commit", "git:pr"],
-      "bidirectional": true
-    },
-    "code-quality-orchestrator": {
-      "description": "Enforces quality gates before merge/commit",
-      "commands": ["git:commit", "git:merge", "git:pr"],
-      "blocking": true
-    }
-  },
 
   "workflows": {
     "trunk-based": {

--- a/.claude/plugins/jira-orchestrator/.claude-plugin/plugin.json
+++ b/.claude/plugins/jira-orchestrator/.claude-plugin/plugin.json
@@ -16,12 +16,6 @@
     "clean-architecture",
     "solid"
   ],
-  "categories": [
-    "orchestration",
-    "project-management",
-    "devops",
-    "integration"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/markus41/claude/tree/main/plugins/jira-orchestrator"

--- a/.claude/plugins/migration-wizard/plugin.json
+++ b/.claude/plugins/migration-wizard/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["code-generation", "refactoring", "automation", "devops"],
   "keywords": [
     "migration", "codemod", "refactor", "transform", "modernize",
     "react-hooks", "vue2-vue3", "express-fastify", "angular-react",
@@ -20,14 +19,6 @@
     "ast", "jscodeshift", "babel", "typescript", "eslint-codemod",
     "api-migration", "breaking-changes", "deprecation", "upgrade"
   ],
-
-  "provides": {
-    "commands": 15,
-    "agents": 12,
-    "skills": 6,
-    "hooks": 4,
-    "workflows": 8
-  },
 
   "migrationTypes": {
     "react": {

--- a/.claude/plugins/multi-model-orchestration/plugin.json
+++ b/.claude/plugins/multi-model-orchestration/plugin.json
@@ -12,39 +12,12 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["ai", "llm", "orchestration", "optimization"],
   "keywords": [
     "multi-model", "llm-routing", "model-selection", "ensemble",
     "claude", "gpt", "gemini", "llama", "mistral", "ollama",
     "cost-optimization", "latency-optimization", "capability-matching",
     "consensus", "voting", "model-cascade", "fallback", "load-balancing"
   ],
-
-  "provides": {
-    "commands": 14,
-    "agents": 10,
-    "skills": 6,
-    "hooks": 4,
-    "routingStrategies": 8
-  },
-
-  "integrations": {
-    "cognitive-code-reasoner": {
-      "description": "Routes complex reasoning to optimal model",
-      "capabilities": ["model-selection", "thinking-budget-allocation"],
-      "enhances": true
-    },
-    "testing-orchestrator": {
-      "description": "Uses fast models for test generation",
-      "capabilities": ["speed-optimization"],
-      "costOptimization": true
-    },
-    "documentation-orchestrator": {
-      "description": "Routes docs to cost-effective models",
-      "capabilities": ["cost-optimization"],
-      "costOptimization": true
-    }
-  },
 
   "supportedModels": {
     "anthropic": {

--- a/.claude/plugins/notification-hub/plugin.json
+++ b/.claude/plugins/notification-hub/plugin.json
@@ -12,43 +12,12 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["communication", "notifications", "automation", "workflow"],
   "keywords": [
     "notifications", "slack", "teams", "discord", "email",
     "webhooks", "alerts", "approvals", "escalation", "routing",
     "digest", "priority", "mute", "channels", "mentions",
     "on-call", "pagerduty", "opsgenie", "incident"
   ],
-
-  "provides": {
-    "commands": 14,
-    "agents": 9,
-    "skills": 5,
-    "hooks": 5
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Notifies on Jira issue updates, status changes, assignments",
-      "events": ["issue-created", "status-changed", "assigned", "commented"],
-      "bidirectional": true
-    },
-    "git-workflow-orchestrator": {
-      "description": "Notifies on PR events, merge, conflicts",
-      "events": ["pr-created", "pr-merged", "conflict-detected", "review-requested"],
-      "bidirectional": false
-    },
-    "release-orchestrator": {
-      "description": "Sends release announcements and deployment notifications",
-      "events": ["release-created", "deployed", "rollback"],
-      "priority": "high"
-    },
-    "testing-orchestrator": {
-      "description": "Alerts on test failures, coverage drops",
-      "events": ["tests-failed", "coverage-dropped", "regression-detected"],
-      "escalation": true
-    }
-  },
 
   "channels": {
     "slack": {

--- a/.claude/plugins/predictive-failure-engine/plugin.json
+++ b/.claude/plugins/predictive-failure-engine/plugin.json
@@ -12,44 +12,12 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["ai", "prediction", "quality", "prevention"],
   "keywords": [
     "prediction", "failure-prediction", "bug-prediction", "preventive",
     "machine-learning", "pattern-recognition", "code-smell", "risk-assessment",
     "probabilistic", "early-warning", "defect-prediction", "hotspot-detection",
     "change-risk", "historical-analysis", "trend-detection"
   ],
-
-  "provides": {
-    "commands": 14,
-    "agents": 11,
-    "skills": 7,
-    "hooks": 5,
-    "predictionModels": 8
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Links predictions to issues, creates preventive tickets",
-      "capabilities": ["create-prevention-tickets", "risk-labeling"],
-      "bidirectional": true
-    },
-    "code-knowledge-graph": {
-      "description": "Uses graph for impact and relationship analysis",
-      "capabilities": ["dependency-risk", "impact-scoring"],
-      "required": true
-    },
-    "testing-orchestrator": {
-      "description": "Recommends targeted tests for high-risk code",
-      "capabilities": ["test-recommendations", "risk-based-testing"],
-      "enhances": true
-    },
-    "cognitive-code-reasoner": {
-      "description": "Deep analysis of predicted issues",
-      "capabilities": ["root-cause-hypothesis"],
-      "onHighRisk": true
-    }
-  },
 
   "predictionModels": {
     "change-risk": {

--- a/.claude/plugins/release-orchestrator/plugin.json
+++ b/.claude/plugins/release-orchestrator/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["devops", "release", "deployment", "automation"],
   "keywords": [
     "release", "versioning", "semantic-version", "semver",
     "changelog", "release-notes", "deployment", "rollback",
@@ -20,31 +19,6 @@
     "tag", "github-release", "npm-publish", "docker-tag",
     "hotfix", "patch", "major", "minor"
   ],
-
-  "provides": {
-    "commands": 14,
-    "agents": 9,
-    "skills": 5,
-    "hooks": 4
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Links releases to Jira versions, updates fix versions on issues",
-      "commands": ["release:create", "release:publish", "release:notes"],
-      "bidirectional": true
-    },
-    "git-workflow-orchestrator": {
-      "description": "Creates release branches and tags",
-      "commands": ["release:branch", "release:tag"],
-      "required": true
-    },
-    "notification-hub": {
-      "description": "Sends release announcements to all channels",
-      "commands": ["release:announce"],
-      "optional": true
-    }
-  },
 
   "versioningStrategies": {
     "semver": {

--- a/.claude/plugins/testforge/plugin.json
+++ b/.claude/plugins/testforge/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["testing", "automation", "code-quality", "tdd"],
   "keywords": [
     "test-generation", "auto-test", "unit-test", "integration-test",
     "jest", "pytest", "vitest", "mocha", "jasmine",
@@ -23,36 +22,6 @@
     "assertion", "test-data", "factory-pattern",
     "regression-prevention", "bug-detection", "quality"
   ],
-
-  "provides": {
-    "commands": 10,
-    "agents": 12,
-    "skills": 7,
-    "hooks": 5
-  },
-
-  "integrations": {
-    "testing-orchestrator": {
-      "description": "Executes generated tests and validates coverage improvements",
-      "commands": ["testforge:validate", "testforge:run"],
-      "bidirectional": true
-    },
-    "code-quality-orchestrator": {
-      "description": "Ensures generated tests meet quality standards",
-      "commands": ["testforge:quality-check"],
-      "blocking": false
-    },
-    "git-workflow-orchestrator": {
-      "description": "Generates tests for changed files in PRs",
-      "commands": ["testforge:pr-generate"],
-      "blocking": false
-    },
-    "cognitive-code-reasoner": {
-      "description": "Deep code analysis for behavior understanding",
-      "commands": ["testforge:analyze"],
-      "bidirectional": true
-    }
-  },
 
   "testFrameworks": {
     "javascript": {

--- a/.claude/plugins/testing-orchestrator/plugin.json
+++ b/.claude/plugins/testing-orchestrator/plugin.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/Lobbi-Docs/claude",
-  "categories": ["testing", "qa", "automation", "ci-cd"],
   "keywords": [
     "testing", "unit-test", "integration-test", "e2e", "end-to-end",
     "pytest", "jest", "vitest", "playwright", "cypress",
@@ -20,36 +19,6 @@
     "performance", "load-test", "k6", "locust", "artillery",
     "snapshot", "visual-regression", "accessibility", "a11y"
   ],
-
-  "provides": {
-    "commands": 18,
-    "agents": 12,
-    "skills": 8,
-    "hooks": 6
-  },
-
-  "integrations": {
-    "jira-orchestrator": {
-      "description": "Links test cases to Jira issues, reports test results",
-      "commands": ["test:jira", "test:report"],
-      "bidirectional": true
-    },
-    "code-quality-orchestrator": {
-      "description": "Enforces test coverage thresholds",
-      "commands": ["test:coverage"],
-      "blocking": true
-    },
-    "release-orchestrator": {
-      "description": "Gates releases on test results",
-      "commands": ["test:release-gate"],
-      "blocking": true
-    },
-    "git-workflow-orchestrator": {
-      "description": "Runs tests on PR, prevents merge on failure",
-      "commands": ["test:pr"],
-      "blocking": true
-    }
-  },
 
   "testTypes": {
     "unit": {

--- a/plugins/aws-eks-helm-keycloak/.claude-plugin/plugin.json
+++ b/plugins/aws-eks-helm-keycloak/.claude-plugin/plugin.json
@@ -21,58 +21,5 @@
     "ci-cd",
     "gitops",
     "developer-experience"
-  ],
-  "categories": ["devops", "cloud", "authentication", "kubernetes"],
-  "provides": {
-    "commands": 7,
-    "agents": 4,
-    "skills": 6,
-    "hooks": 2
-  },
-  "discovery": {
-    "commands": {
-      "enabled": true,
-      "directory": "../commands",
-      "pattern": "*.md"
-    },
-    "agents": {
-      "enabled": true,
-      "directory": "../agents",
-      "pattern": "*.md"
-    },
-    "skills": {
-      "enabled": true,
-      "directory": "../skills",
-      "pattern": "**/SKILL.md"
-    },
-    "hooks": {
-      "enabled": true,
-      "directory": "../hooks",
-      "pattern": "hooks.json"
-    }
-  },
-  "dependencies": {
-    "required": [
-      "helm >= 3.0.0",
-      "kubectl >= 1.25.0",
-      "aws-cli >= 2.0.0"
-    ],
-    "optional": [
-      "kind >= 0.20.0",
-      "skaffold >= 2.0.0",
-      "telepresence >= 2.0.0"
-    ]
-  },
-  "integrations": {
-    "harness": {
-      "required": true,
-      "features": ["code", "cd", "connectors"]
-    },
-    "aws": {
-      "services": ["eks", "ecr", "secrets-manager", "iam"]
-    },
-    "keycloak": {
-      "minVersion": "22.0.0"
-    }
-  }
+  ]
 }

--- a/plugins/frontend-design-system/.claude-plugin/plugin.json
+++ b/plugins/frontend-design-system/.claude-plugin/plugin.json
@@ -17,34 +17,5 @@
     "ui-ux",
     "multi-tenant",
     "accessibility"
-  ],
-  "categories": ["frontend", "code-generation"],
-  "provides": {
-    "commands": 8,
-    "agents": 6,
-    "skills": 4,
-    "hooks": 4
-  },
-  "discovery": {
-    "commands": {
-      "enabled": true,
-      "directory": "../commands",
-      "pattern": "*.md"
-    },
-    "agents": {
-      "enabled": true,
-      "directory": "../agents",
-      "pattern": "*.md"
-    },
-    "skills": {
-      "enabled": true,
-      "directory": "../skills",
-      "pattern": "**/SKILL.md"
-    },
-    "hooks": {
-      "enabled": true,
-      "directory": "../hooks",
-      "pattern": "hooks.json"
-    }
-  }
+  ]
 }

--- a/plugins/iac-golden-architect/.claude-plugin/plugin.json
+++ b/plugins/iac-golden-architect/.claude-plugin/plugin.json
@@ -21,34 +21,5 @@
     "gcp",
     "soc2",
     "compliance"
-  ],
-  "categories": ["devops", "cloud", "security"],
-  "provides": {
-    "commands": 8,
-    "agents": 4,
-    "skills": 5,
-    "hooks": 2
-  },
-  "discovery": {
-    "commands": {
-      "enabled": true,
-      "directory": "../commands",
-      "pattern": "*.md"
-    },
-    "agents": {
-      "enabled": true,
-      "directory": "../agents",
-      "pattern": "*.md"
-    },
-    "skills": {
-      "enabled": true,
-      "directory": "../skills",
-      "pattern": "**/SKILL.md"
-    },
-    "hooks": {
-      "enabled": true,
-      "directory": "../hooks",
-      "pattern": "hooks.json"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Remove the following invalid keys from 25 plugin manifest files that were
causing installation failures with "Unrecognized keys" validation errors:
- categories
- provides
- discovery
- dependencies
- integrations

These keys were custom extensions not recognized by the Claude Code
plugin validator. The manifest files now conform to the expected schema.