### PR TITLE
Add Claude Teams hierarchical decomposition marketplace plugin template

### DIFF
--- a/plugins/claude-teams-hierarchy-lab/.claude-plugin/plugin.json
+++ b/plugins/claude-teams-hierarchy-lab/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "claude-teams-hierarchy-lab",
+  "version": "0.1.0",
+  "description": "Experimental Claude Teams plugin template for hierarchical decomposition: Claude as orchestrator, teammate agents as managers, and specialist sub-agents for execution.",
+  "author": {
+    "name": "Marketplace Templates",
+    "email": "templates@example.com"
+  },
+  "keywords": [
+    "claude-teams",
+    "hierarchical-decomposition",
+    "multi-agent",
+    "orchestration",
+    "subagents",
+    "experimental"
+  ],
+  "license": "MIT",
+  "repository": "https://github.com/Lobbi-Docs/claude"
+}

--- a/plugins/claude-teams-hierarchy-lab/README.md
+++ b/plugins/claude-teams-hierarchy-lab/README.md
@@ -1,0 +1,99 @@
+# Claude Teams Hierarchy Lab
+
+Experimental marketplace plugin template for Claude Teams that bootstraps **hierarchical decomposition**:
+
+- **Claude** acts as the global orchestrator
+- **Teammate agents** act as domain managers
+- **Specialist sub-agents** execute leaf tasks with focused prompts and tools
+
+This template includes commands, hooks, skills, agents, and rules to help you prototype orchestrated team topologies quickly.
+
+## What This Template Provides
+
+- **4 manager/expert agents** for orchestration and governance
+- **3 decomposition-focused skills**
+- **3 slash commands** to scaffold, decompose, and govern team plans
+- **Hook automation** to enforce hierarchy contracts and closure summaries
+- **Rules pack** for role boundaries, delegation depth, and escalation paths
+
+---
+
+## Three Implementation Plans
+
+### Plan A — Fast MVP (1–2 days)
+Best for validating the idea quickly in the marketplace.
+
+1. **Install template as-is** and register the plugin card metadata.
+2. Use `/teams-bootstrap` to generate initial org chart:
+   - Orchestrator (Claude)
+   - 3 manager agents (product, engineering, quality)
+   - 6–9 specialist sub-agents
+3. Keep delegation depth to 2 levels and enforce a single shared task board.
+4. Add lightweight telemetry (task count, completion rate, handoff failures).
+5. Pilot on 1 workflow (e.g., feature spec -> implementation -> review).
+
+**Exit criteria:** team structure compiles, commands run, and one end-to-end workflow succeeds.
+
+### Plan B — Production-Ready Core (1–2 weeks)
+Best for teams wanting reliable repeatability and governance.
+
+1. Extend manager-agent prompts with strict I/O contracts.
+2. Introduce `/teams-decompose` policy profiles:
+   - conservative (few agents, low fan-out)
+   - balanced
+   - aggressive (max parallel specialist spawning)
+3. Add governance checks from hooks:
+   - role-boundary validation
+   - duplicate sub-agent detection
+   - unresolved dependency alerts
+4. Add scoring dashboard fields (cycle time, rework ratio, escalation count).
+5. Add rollback strategy: collapse to manager-only execution if specialist churn is high.
+
+**Exit criteria:** 3+ workflows run consistently with measurable quality improvements.
+
+### Plan C — Adaptive Autonomy (2–4 weeks)
+Best for advanced experiments with dynamic sub-agent creation.
+
+1. Add runtime agent factory logic that spawns specialists from capability gaps.
+2. Let managers request temporary sub-agents with TTL and explicit budget caps.
+3. Add hierarchical memory model:
+   - orchestrator memory (global priorities)
+   - manager memory (domain plans)
+   - specialist memory (short-lived execution context)
+4. Add conflict-resolution protocol for cross-manager dependencies.
+5. Add meta-agent review loop that tunes decomposition policy per sprint.
+
+**Exit criteria:** autonomous spawning improves throughput without reducing quality or controllability.
+
+---
+
+## Commands
+
+- `/teams-bootstrap` — scaffold a hierarchy from a project goal
+- `/teams-decompose` — convert backlog items into manager/sub-agent work plans
+- `/teams-govern` — run governance checks and escalation recommendations
+
+## Agents
+
+- `orchestrator-architect` — defines global orchestration strategy
+- `manager-agent-designer` — designs manager role boundaries and contracts
+- `specialist-spawner` — creates specialist sub-agent specs from leaf tasks
+- `hierarchy-governor` — audits delegation quality, risk, and policy compliance
+
+## Skills
+
+- `hierarchical-decomposition` — tree-of-work decomposition patterns
+- `manager-orchestration` — manager-agent coordination and handoff design
+- `specialist-subagents` — creation and lifecycle management of specialist agents
+
+## Rules
+
+See `rules/hierarchy-rules.md` for mandatory constraints around delegation depth, ownership, escalation, and shutdown behavior.
+
+## Suggested First Run
+
+```bash
+/teams-bootstrap Build a Claude Teams plugin for hierarchical decomposition
+/teams-decompose --profile balanced --max-depth 2
+/teams-govern --report
+```

--- a/plugins/claude-teams-hierarchy-lab/agents/hierarchy-governor.md
+++ b/plugins/claude-teams-hierarchy-lab/agents/hierarchy-governor.md
@@ -1,0 +1,11 @@
+---
+name: hierarchy-governor
+description: Enforces hierarchy rules and monitors delegation quality.
+---
+
+You audit execution against policy, detect drift, and recommend structural corrections.
+
+Focus:
+- Policy conformance
+- Risk detection
+- Escalation quality

--- a/plugins/claude-teams-hierarchy-lab/agents/manager-agent-designer.md
+++ b/plugins/claude-teams-hierarchy-lab/agents/manager-agent-designer.md
@@ -1,0 +1,11 @@
+---
+name: manager-agent-designer
+description: Specifies manager agents, role boundaries, and handoff contracts.
+---
+
+You create clear manager scopes and prevent ownership collisions.
+
+Focus:
+- Domain boundaries
+- Input/output contracts
+- Approval and escalation interfaces

--- a/plugins/claude-teams-hierarchy-lab/agents/orchestrator-architect.md
+++ b/plugins/claude-teams-hierarchy-lab/agents/orchestrator-architect.md
@@ -1,0 +1,11 @@
+---
+name: orchestrator-architect
+description: Designs and coordinates the top-level multi-agent operating model with Claude as orchestrator.
+---
+
+You define the global objective stack, assign manager ownership, and ensure every delegation path is observable and reversible.
+
+Focus:
+- Orchestration topology
+- Cross-manager dependency negotiation
+- Fallback and rollback orchestration

--- a/plugins/claude-teams-hierarchy-lab/agents/specialist-spawner.md
+++ b/plugins/claude-teams-hierarchy-lab/agents/specialist-spawner.md
@@ -1,0 +1,11 @@
+---
+name: specialist-spawner
+description: Generates specialist sub-agent definitions for leaf tasks.
+---
+
+You propose specialist profiles with explicit objective, tools, constraints, and sunset conditions.
+
+Focus:
+- Specialist capability matching
+- Task-level decomposition
+- Lifecycle and termination criteria

--- a/plugins/claude-teams-hierarchy-lab/commands/teams-bootstrap.md
+++ b/plugins/claude-teams-hierarchy-lab/commands/teams-bootstrap.md
@@ -1,0 +1,19 @@
+# /teams-bootstrap
+
+Scaffold a Claude Teams hierarchy from a single project objective.
+
+## Inputs
+- `goal` (required): outcome to achieve
+- `domains` (optional): comma-separated manager domains
+- `maxSpecialistsPerManager` (optional, default: 3)
+
+## Behavior
+1. Create one orchestrator role owned by Claude.
+2. Create manager agents per domain.
+3. Propose specialist sub-agents under each manager.
+4. Emit a hierarchy map and initial task charter.
+
+## Output format
+- Team hierarchy tree
+- Responsibility matrix (RACI-lite)
+- First sprint backlog (top 10 tasks)

--- a/plugins/claude-teams-hierarchy-lab/commands/teams-decompose.md
+++ b/plugins/claude-teams-hierarchy-lab/commands/teams-decompose.md
@@ -1,0 +1,20 @@
+# /teams-decompose
+
+Turn an initiative backlog into hierarchical work packages.
+
+## Flags
+- `--profile`: `conservative | balanced | aggressive`
+- `--max-depth`: delegation depth (default: 2)
+- `--parallelism`: max concurrent specialist tasks per manager
+
+## Behavior
+1. Group work by manager domain.
+2. Split tasks into specialist-sized units.
+3. Mark dependencies and merge points.
+4. Generate escalation triggers when blockers exceed threshold.
+
+## Output format
+- Manager work queues
+- Specialist task bundles
+- Dependency graph
+- Escalation matrix

--- a/plugins/claude-teams-hierarchy-lab/commands/teams-govern.md
+++ b/plugins/claude-teams-hierarchy-lab/commands/teams-govern.md
@@ -1,0 +1,14 @@
+# /teams-govern
+
+Audit hierarchy health, policy compliance, and delivery risk.
+
+## Checks
+- Delegation depth violations
+- Role overlap and duplicate ownership
+- Blocked dependency chains
+- Escalation SLA breaches
+
+## Output format
+- Governance score (0-100)
+- Findings grouped by severity
+- Corrective action plan

--- a/plugins/claude-teams-hierarchy-lab/hooks/hooks.json
+++ b/plugins/claude-teams-hierarchy-lab/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "If this change affects agent definitions, verify manager/specialist boundaries remain explicit and no specialist is given orchestration authority. Report violations briefly."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Before ending, summarize open escalations, unresolved dependencies, and whether hierarchy depth and ownership rules were respected."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-teams-hierarchy-lab/rules/hierarchy-rules.md
+++ b/plugins/claude-teams-hierarchy-lab/rules/hierarchy-rules.md
@@ -1,0 +1,21 @@
+# Hierarchy Rules
+
+## Core Topology
+1. Claude remains the sole orchestrator.
+2. Manager agents coordinate domains; they do not perform specialist-only leaf execution unless in fallback mode.
+3. Specialist agents execute bounded leaf tasks only.
+
+## Delegation Constraints
+1. Default max delegation depth is 2 (`orchestrator -> manager -> specialist`).
+2. Any depth >2 requires explicit rationale and risk note.
+3. Each task must have exactly one owner at any level.
+
+## Escalation Rules
+1. Blockers older than one SLA window escalate specialist -> manager.
+2. Cross-domain blockers escalate manager -> orchestrator.
+3. Escalations must include context, options, and recommendation.
+
+## Governance Rules
+1. No duplicate specialist roles with overlapping ownership unless load balancing is intentional.
+2. Every spawned specialist must include objective, constraints, and retirement condition.
+3. Session close requires a brief unresolved dependency and escalation summary.

--- a/plugins/claude-teams-hierarchy-lab/skills/hierarchical-decomposition/SKILL.md
+++ b/plugins/claude-teams-hierarchy-lab/skills/hierarchical-decomposition/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: hierarchical-decomposition
+description: Breaks large initiatives into orchestrator -> manager -> specialist execution trees.
+---
+
+## Use when
+- A request is broad and multi-phase.
+- Multiple domains must run in parallel.
+
+## Workflow
+1. Define objective and success criteria.
+2. Assign manager domains.
+3. Decompose into specialist leaf tasks.
+4. Add dependency and escalation links.
+5. Validate max depth and ownership clarity.

--- a/plugins/claude-teams-hierarchy-lab/skills/manager-orchestration/SKILL.md
+++ b/plugins/claude-teams-hierarchy-lab/skills/manager-orchestration/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: manager-orchestration
+description: Establishes manager-level coordination contracts and cross-domain handoffs.
+---
+
+## Use when
+- Managers must coordinate shared milestones.
+- You need deterministic handoff criteria.
+
+## Checklist
+- Shared definitions of done
+- Input/output contracts
+- SLA for escalations
+- Merge/review checkpoints

--- a/plugins/claude-teams-hierarchy-lab/skills/specialist-subagents/SKILL.md
+++ b/plugins/claude-teams-hierarchy-lab/skills/specialist-subagents/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: specialist-subagents
+description: Designs specialist sub-agents with bounded scope, tools, and lifecycle.
+---
+
+## Use when
+- Leaf tasks require focused expertise.
+- Throughput benefits from short-lived specialists.
+
+## Template
+- Objective
+- Allowed tools
+- Constraints
+- Success signal
+- TTL / retirement trigger


### PR DESCRIPTION
### Motivation
- Provide a ready-to-install marketplace template that demonstrates an experimental Claude Teams topology where Claude is the orchestrator, manager agents coordinate domains, and specialist sub-agents execute leaf tasks. 
- Make it easy to prototype and integrate hierarchical decomposition patterns into the marketplace card/plug-in ecosystem by including commands, agents, skills, hooks, and governance rules.

### Description
- Added a new plugin directory `plugins/claude-teams-hierarchy-lab` and manifest at `plugins/claude-teams-hierarchy-lab/.claude-plugin/plugin.json` that defines the plugin metadata. 
- Added a comprehensive `README.md` that includes three implementation plans (Fast MVP, Production-Ready Core, Adaptive Autonomy) and suggested first-run commands. 
- Added command specifications for `/teams-bootstrap`, `/teams-decompose`, and `/teams-govern` under `commands/`. 
- Added agent definitions in `agents/`, skill packs in `skills/`, automated hooks in `hooks/hooks.json`, and governance rules in `rules/hierarchy-rules.md` to enforce delegation, escalation, and lifecycle patterns.

### Testing
- Validated JSON syntax for the manifest and hook configuration using `python -m json.tool plugins/claude-teams-hierarchy-lab/.claude-plugin/plugin.json` and `python -m json.tool plugins/claude-teams-hierarchy-lab/hooks/hooks.json`, both commands completed successfully. 
- No automated unit or integration tests were added as this PR is a documentation/template scaffold; runtime / integration tests should be executed in the Claude marketplace/CI environment to verify behavioral integration and agent orchestration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69994182e15c832a9424553c0515ed8d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new template/documentation files only and does not change existing runtime logic; risk is limited to potential plugin manifest/hook misconfiguration.
> 
> **Overview**
> Adds a new `claude-teams-hierarchy-lab` plugin template with manifest metadata and documentation for prototyping a hierarchical Claude Teams topology (orchestrator -> managers -> specialists).
> 
> Introduces template assets: agent role definitions, three slash-command specs (`/teams-bootstrap`, `/teams-decompose`, `/teams-govern`), three skills for decomposition/orchestration, hook prompts to enforce role boundaries and end-of-session summaries, and a rules pack covering delegation depth, ownership, escalation, and specialist lifecycle constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 268c526afc6548bd7d964041dc9cb0063a7e269b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->