### PR TITLE
Add typed plugin API module and migrate plugin hooks

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -33,3 +33,21 @@ export {
   getTemplatesByCategory,
   searchTemplatesByTags,
 } from './templates';
+
+export {
+  searchMarketplacePlugins,
+  getFeaturedPlugins,
+  getPopularPlugins,
+  getMarketplacePlugin,
+  getPluginReviews,
+  submitPluginReview,
+  getPluginCategories,
+  getInstalledPlugins,
+  getPluginInstallation,
+  installPlugin,
+  uninstallPlugin,
+  updatePluginConfiguration,
+  enablePlugin,
+  disablePlugin,
+  getPluginMetrics,
+} from './plugins';

--- a/src/lib/api/plugins.ts
+++ b/src/lib/api/plugins.ts
@@ -1,0 +1,117 @@
+import { apiClient } from './client';
+import type {
+  Plugin,
+  PluginCategory,
+  PluginInstallation,
+  PluginInstallationRequest,
+  PluginMetrics,
+  PluginMetricsPeriod,
+  PluginReview,
+  PluginReviewSubmission,
+  PluginSearchFilters,
+  PluginSearchResult,
+  PluginType,
+  PluginUpdateConfigurationRequest,
+} from '@/types/plugins';
+
+function buildSearchParams(filters: PluginSearchFilters = {}): string {
+  const params = new URLSearchParams();
+
+  if (filters.query) params.set('query', filters.query);
+  if (filters.type) params.set('type', filters.type);
+  if (filters.category) params.set('category', filters.category);
+  if (filters.tags?.length) params.set('tags', filters.tags.join(','));
+  if (filters.isVerified) params.set('is_verified', 'true');
+  if (filters.isOfficial) params.set('is_official', 'true');
+  if (filters.minRating) params.set('min_rating', String(filters.minRating));
+  if (filters.sortBy) params.set('sort_by', filters.sortBy);
+
+  return params.toString();
+}
+
+export async function searchMarketplacePlugins(
+  filters: PluginSearchFilters = {}
+): Promise<PluginSearchResult> {
+  const query = buildSearchParams(filters);
+  const endpoint = query
+    ? `/v1/marketplace/plugins?${query}`
+    : '/v1/marketplace/plugins';
+
+  return apiClient.get<PluginSearchResult>(endpoint);
+}
+
+export async function getFeaturedPlugins(): Promise<{ plugins: Plugin[] }> {
+  return apiClient.get<{ plugins: Plugin[] }>('/v1/marketplace/featured');
+}
+
+export async function getPopularPlugins(limit = 10): Promise<{ plugins: Plugin[] }> {
+  return apiClient.get<{ plugins: Plugin[] }>(`/v1/marketplace/popular?limit=${limit}`);
+}
+
+export async function getMarketplacePlugin(pluginId: string): Promise<Plugin> {
+  return apiClient.get<Plugin>(`/v1/marketplace/plugins/${pluginId}`);
+}
+
+export async function getPluginReviews(pluginId: string): Promise<{ reviews: PluginReview[] }> {
+  return apiClient.get<{ reviews: PluginReview[] }>(`/v1/marketplace/plugins/${pluginId}/reviews`);
+}
+
+export async function submitPluginReview(
+  pluginId: string,
+  review: PluginReviewSubmission
+): Promise<void> {
+  await apiClient.post<void>(`/v1/marketplace/plugins/${pluginId}/reviews`, review);
+}
+
+export async function getPluginCategories(
+  type?: PluginType
+): Promise<{ categories: PluginCategory[] }> {
+  const query = type ? `?type=${type}` : '';
+  return apiClient.get<{ categories: PluginCategory[] }>(`/v1/marketplace/categories${query}`);
+}
+
+export async function getInstalledPlugins(
+  type?: PluginType
+): Promise<{ installations: PluginInstallation[] }> {
+  const query = type ? `?type=${type}` : '';
+  return apiClient.get<{ installations: PluginInstallation[] }>(`/v1/plugins/installed${query}`);
+}
+
+export async function getPluginInstallation(
+  pluginId: string
+): Promise<PluginInstallation | null> {
+  return apiClient.get<PluginInstallation | null>(`/v1/plugins/${pluginId}/installation`);
+}
+
+export async function installPlugin(
+  pluginId: string,
+  payload: PluginInstallationRequest = {}
+): Promise<PluginInstallation> {
+  return apiClient.post<PluginInstallation>(`/v1/plugins/${pluginId}/install`, payload);
+}
+
+export async function uninstallPlugin(pluginId: string): Promise<void> {
+  await apiClient.post<void>(`/v1/plugins/${pluginId}/uninstall`);
+}
+
+export async function updatePluginConfiguration(
+  pluginId: string,
+  payload: PluginUpdateConfigurationRequest
+): Promise<PluginInstallation> {
+  return apiClient.put<PluginInstallation>(`/v1/plugins/${pluginId}/config`, payload);
+}
+
+export async function enablePlugin(pluginId: string): Promise<PluginInstallation> {
+  return apiClient.post<PluginInstallation>(`/v1/plugins/${pluginId}/enable`);
+}
+
+export async function disablePlugin(pluginId: string): Promise<PluginInstallation> {
+  return apiClient.post<PluginInstallation>(`/v1/plugins/${pluginId}/disable`);
+}
+
+export async function getPluginMetrics(
+  pluginId: string,
+  period: PluginMetricsPeriod = 'week'
+): Promise<PluginMetrics> {
+  return apiClient.get<PluginMetrics>(`/v1/plugins/${pluginId}/metrics?period=${period}`);
+}

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -130,6 +130,28 @@ export interface PluginSearchResult {
   hasMore: boolean;
 }
 
+export type PluginMetricsPeriod = 'day' | 'week' | 'month';
+
+export interface PluginCategory {
+  name: string;
+  count: number;
+}
+
+export interface PluginReviewSubmission {
+  rating: number;
+  title?: string;
+  content?: string;
+}
+
+export interface PluginInstallationRequest {
+  configuration?: Record<string, unknown>;
+  grant_permissions?: string[];
+}
+
+export interface PluginUpdateConfigurationRequest {
+  configuration: Record<string, unknown>;
+}
+
 // Plugin type metadata
 export const PLUGIN_TYPE_INFO: Record<PluginType, {
   label: string;


### PR DESCRIPTION
### Motivation
- Centralize all plugin/marketplace API calls behind a typed API surface so hooks and other consumers can call strongly-typed functions instead of duplicating fetch/error logic.
- Replace the local `fetchApi` helper and duplicated request/error code in plugin hooks with the new `apiClient`-backed functions to improve maintainability and consistent error handling.
- Introduce request/endpoint payload types so API boundaries are strongly typed end-to-end.

### Description
- Added a new API module `src/lib/api/plugins.ts` that wraps marketplace search/listing, featured/popular endpoints, reviews, categories, installation lifecycle (install/uninstall/config/enable/disable), and metrics via the existing `apiClient` with typed signatures.
- Migrated `src/hooks/usePlugins.ts` to call the new functions from `src/lib/api/plugins.ts`, removed the local `fetchApi` helper, and unified error normalization into `getErrorMessage` and `ApiError` usage for typed 404 handling on installation checks.
- Extended `src/types/plugins.ts` with additional exported types: `PluginMetricsPeriod`, `PluginCategory`, `PluginReviewSubmission`, `PluginInstallationRequest`, and `PluginUpdateConfigurationRequest` to model request payloads and API responses.
- Re-exported the new plugin API surface from `src/lib/api/index.ts` so other modules can import plugin API functions from the central API barrel.

### Testing
- Ran `npm run type-check` which failed; failure is due to pre-existing unrelated syntax errors in `src/hooks/useNodeTypes.test.ts`, not introduced by these changes.
- Ran a targeted `npx tsc --noEmit ...` invocation for the modified files which failed due to project-specific path alias and `import.meta` typing expectations in this environment rather than errors from the new module.
- Ran `npx eslint` for the changed files which reported no project ESLint config in the environment; linting could not fully validate the changes here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd2e84ab0832a84909468cd307127)