### PR TITLE
Add control-plane manifest schema, planner, and command wiring for TVS deploys

### DIFF
--- a/plugins/tvs-microsoft-deploy/.claude-plugin/README.md
+++ b/plugins/tvs-microsoft-deploy/.claude-plugin/README.md
@@ -45,7 +45,7 @@ az login --tenant $TVS_TENANT_ID
 /tvs:status-check
 ```
 
-## Commands (12)
+## Commands (13)
 
 | Command | Description |
 |---------|-------------|
@@ -60,6 +60,7 @@ az login --tenant $TVS_TENANT_ID
 | `/tvs:deploy-teams` | Teams VA workspace with HIPAA config |
 | `/tvs:cost-report` | Cost analysis across all Rosa entities |
 | `/tvs:status-check` | Health check across all resources |
+| `/tvs:taia-readiness` | TAIA wind-down readiness from control-plane overlays |
 | `/tvs:browser-fallback` | Playwright fallback for portal operations |
 
 ## Agents (12)

--- a/plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json
+++ b/plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tvs-microsoft-deploy",
   "version": "1.0.0",
-  "description": "Consul (Forerunner) - Enterprise Microsoft ecosystem orchestrator for TVS (Trusted Virtual Solutions) multi-entity multi-tenant deployment. 12 agents, 12 commands, 7 skills, 5 hooks, 5 workflows.",
+  "description": "Consul (Forerunner) - Enterprise Microsoft ecosystem orchestrator for TVS (Trusted Virtual Solutions) multi-entity multi-tenant deployment. 12 agents, 13 commands, 7 skills, 5 hooks, 5 workflows.",
   "author": {
     "name": "Markus Ahling",
     "email": "markus@lobbi.io"
@@ -65,6 +65,7 @@
     "commands/deploy-teams.md",
     "commands/cost-report.md",
     "commands/status-check.md",
+    "commands/taia-readiness.md",
     "commands/browser-fallback.md"
   ],
   "hooks": {

--- a/plugins/tvs-microsoft-deploy/commands/deploy-all.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-all.md
@@ -1,6 +1,6 @@
 ---
 name: tvs:deploy-all
-description: Full platform deployment across all Rosa entities - orchestrates identity, dataverse, fabric, portal, azure, and teams in sequence
+description: Full platform deployment orchestrated from control-plane manifests and overlays
 allowed-tools:
   - Bash
   - Read
@@ -12,143 +12,53 @@ allowed-tools:
 
 # Full Platform Deployment
 
-Orchestrates the complete Rosa Holdings Microsoft platform deployment across all entities (TVS, Lobbi Consulting, Medicare Consulting, Media Company) in dependency order: identity, dataverse, fabric, portal, azure, teams.
+Deploy all tenant-scoped resources through the control-plane planner (no manual phase sequencing).
 
 ## Usage
 
-```
-/tvs:deploy-all [--entity tvs|consulting|media|all] [--skip-phase PHASE] [--dry-run]
+```bash
+/tvs:deploy-all [--env dev|test|prod] [--overlay <path>] [--dry-run] [--taia-wind-down]
 ```
 
-## Prerequisites
-
-Before execution, validate ALL of the following:
+## Plan generation (required)
 
 ```bash
-# 1. PAC CLI authentication for both Dataverse environments
-pac auth list | grep -q "Active" || { echo "FAIL: No active pac auth"; exit 1; }
+BASE=plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml
+ENV_OVERLAY=plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/${ENV:-dev}.yaml
+TAIA_OVERLAY=plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/taia-wind-down.yaml
 
-# 2. Azure CLI authentication
-az account show --query "name" -o tsv || { echo "FAIL: az login required"; exit 1; }
+# Dry-run plan
+node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
+  --manifest "$BASE" \
+  --overlay "$ENV_OVERLAY" \
+  --mode dry-run \
+  --out plugins/tvs-microsoft-deploy/control-plane/out/deploy.dry-run.json
 
-# 3. Required environment variables
-REQUIRED_VARS=(
-  TVS_TENANT_ID TVS_DATAVERSE_ENV_URL CONSULTING_DATAVERSE_ENV_URL
-  GRAPH_TOKEN FABRIC_TOKEN FABRIC_CAPACITY_ID
-  AZURE_SUBSCRIPTION_ID STRIPE_SECRET_KEY
-  FIREBASE_SERVICE_ACCOUNT TVS_WS_ID
-)
-for var in "${REQUIRED_VARS[@]}"; do
-  [ -z "${!var}" ] && { echo "FAIL: $var not set"; exit 1; }
-done
-
-# 4. Fabric token validity
-curl -sf -H "Authorization: Bearer $FABRIC_TOKEN" \
-  "https://api.fabric.microsoft.com/v1/capacities" > /dev/null || { echo "FAIL: FABRIC_TOKEN expired"; exit 1; }
+# Execution plan
+node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
+  --manifest "$BASE" \
+  --overlay "$ENV_OVERLAY" \
+  ${TAIA_WIND_DOWN:+--overlay "$TAIA_OVERLAY"} \
+  --mode execute \
+  --out plugins/tvs-microsoft-deploy/control-plane/out/deploy.execute.json
 ```
 
-## 6-Phase Protocol
+## Execution contract
 
-### Phase 1: EXPLORE (2 agents)
+Execute strictly in planner phase order:
 
-**Agent 1 - Environment Scanner:**
-- Query `az account show` for active subscription details
-- Run `pac auth list` to confirm Dataverse auth for TVS and Consulting
-- Verify Fabric capacity status via REST API
-- Check Key Vault `kv-rosa-holdings` accessibility
-- Enumerate existing resources to determine delta deployment
+1. `identity`
+2. `data-platform`
+3. `app-platform`
+4. `collaboration-services`
 
-**Agent 2 - Dependency Mapper:**
-- Read `plugins/tvs-microsoft-deploy/schemas/` for entity relationship maps
-- Identify cross-entity dependencies (SharedProspects, consolidated lakehouse)
-- Map deployment order constraints: identity must precede dataverse, dataverse before fabric shortcuts
-- Check for in-progress deployments or locked resources
-- Validate TAIA wind-down status does not block TVS build
+Each step in `deploy.execute.json` maps to one resource action with explicit dependencies.
 
-### Phase 2: PLAN (1 agent)
+## Command wiring
 
-**Agent 3 - Deployment Planner:**
-- Build sequenced deployment manifest:
-  1. Identity (Entra ID users, apps, licenses)
-  2. Dataverse (TVS tables, Consulting tables, solutions)
-  3. Fabric (workspaces: tvs/, consulting/, lobbi_platform/, media/, a3_archive/, consolidated/)
-  4. Portal (Power Pages broker portal, Copilot Studio bots)
-  5. Azure (Key Vault, Functions, Static Web Apps, App Insights)
-  6. Teams (VA workspace, entity channels, shared mailboxes)
-- Calculate estimated cost impact per tier (Tier 1 ~$1,349, Tier 2 ~$2,610, Tier 3 ~$5,083)
-- Generate rollback checkpoints between each phase
-- Produce deployment manifest JSON at `/tmp/rosa-deploy-manifest.json`
+- Identity resources trigger `/tvs:deploy-identity` handlers.
+- Data platform resources trigger `/tvs:deploy-azure`, `/tvs:deploy-dataverse`, and `/tvs:deploy-fabric` handlers.
+- App platform resources trigger `/tvs:deploy-portal` and automation deployment scripts.
+- Collaboration resources trigger `/tvs:deploy-teams` handlers.
 
-### Phase 3: CODE (3 agents)
-
-**Agent 4 - Identity + Dataverse Deployer:**
-- Execute `tvs:deploy-identity` for Entra ID provisioning
-- Execute `tvs:deploy-dataverse` for both TVS and Consulting environments
-- Wire Dataverse service principals created in identity phase
-- Validate cross-environment connections (SharedProspects link)
-
-**Agent 5 - Fabric + Azure Deployer:**
-- Execute `tvs:deploy-fabric` for all 6 workspace lakehouses
-- Execute `tvs:deploy-azure` for Bicep infrastructure
-- Create Dataverse shortcuts in OneLake pointing to deployed tables
-- Configure `func-rosa-ingest` with Key Vault references
-
-**Agent 6 - Portal + Teams Deployer:**
-- Execute `tvs:deploy-portal` for Power Pages and Copilot Studio
-- Execute `tvs:deploy-teams` for workspace and channel provisioning
-- Wire Stripe billing widget into broker portal
-- Configure Teams shared mailbox routing per entity
-
-### Phase 4: TEST (2 agents)
-
-**Agent 7 - Integration Tester:**
-- Verify Entra ID users can authenticate to Dataverse
-- Test Fabric Dataverse shortcuts return data from TVS tables
-- Confirm Azure Functions connect to Key Vault secrets
-- Validate broker portal loads and Stripe widget renders
-- Test Copilot Studio bot responds to sample queries
-
-**Agent 8 - Cross-Entity Validator:**
-- Verify SharedProspects flows between TVS and Consulting Dataverse
-- Confirm consolidated/ lakehouse receives data from all entity workspaces
-- Test Teams channel notifications fire on Dataverse record creation
-- Validate RBAC: TVS users cannot access Consulting data and vice versa
-- Run `tvs:status-check` for full health verification
-
-### Phase 5: FIX (1 agent)
-
-**Agent 9 - Remediation Agent:**
-- Collect all failures from Phase 4 test results
-- Categorize by severity: blocking (auth, connectivity) vs. cosmetic (UI, naming)
-- Execute targeted fixes: re-run failed sub-deployments with `--force`
-- For Fabric shortcut failures, refresh Dataverse connection credentials
-- For portal failures, invoke `tvs:browser-fallback` for manual steps
-- Re-run failed tests to confirm resolution
-- Reference `orchestration-protocol-enforcer` hook for retry policy
-
-### Phase 6: DOCUMENT (1 agent)
-
-**Agent 10 - Documentation Agent:**
-- Generate deployment report at `plugins/tvs-microsoft-deploy/reports/deploy-all-{timestamp}.md`
-- Include: resources created, cost projections, test results, known issues
-- Update entity status in deployment tracking
-- Record deployment event via `mcp__deploy-intelligence__deploy_record_build`
-- Log session activity via `mcp__project-metrics__metrics_session_log`
-
-## Orchestration Hook
-
-This command is governed by the `orchestration-protocol-enforcer` hook which ensures:
-- No phase is skipped without explicit `--skip-phase` flag
-- Sub-agent count meets minimum (8 for deploy-all)
-- Each phase completes before the next begins
-- Failures in Phase 4/5 trigger automatic retry before abort
-
-## Rollback
-
-If any phase fails catastrophically:
-1. Stop execution at current phase
-2. Run inverse operations for completed phases in reverse order
-3. Restore Entra ID to pre-deployment app registrations
-4. Delete newly created Dataverse tables (if schema-only, not data)
-5. Remove Fabric workspaces created in this run
-6. Generate failure report with remediation steps
+Do not run handlers outside resources enumerated by the execution plan.

--- a/plugins/tvs-microsoft-deploy/commands/status-check.md
+++ b/plugins/tvs-microsoft-deploy/commands/status-check.md
@@ -1,6 +1,6 @@
 ---
 name: tvs:status-check
-description: Health check across all deployed Rosa Holdings resources
+description: Health check using control-plane dry-run outputs as the verification source of truth
 allowed-tools:
   - Bash
   - Read
@@ -10,122 +10,35 @@ allowed-tools:
 
 # Status Check
 
-Read-only health check across all deployed Rosa Holdings resources. Verifies Entra, Dataverse, Fabric, Azure, Functions, Static Web Apps, and Teams status.
+Read-only health validation driven by control-plane outputs.
 
 ## Usage
 
 ```bash
-/tvs:status-check [--entity=tvs|consulting|taia|media|all] [--verbose]
+/tvs:status-check [--env dev|test|prod] [--taia-wind-down]
 ```
 
-## Prerequisites
+## Control-plane first
 
 ```bash
-# Minimal: az login and Graph token
-az account show --query name -o tsv
+BASE=plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml
+OVERLAY=plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/${ENV:-dev}.yaml
+
+node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
+  --manifest "$BASE" \
+  --overlay "$OVERLAY" \
+  ${TAIA_WIND_DOWN:+--overlay plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/taia-wind-down.yaml} \
+  --mode dry-run \
+  --out plugins/tvs-microsoft-deploy/control-plane/out/status.dry-run.json
 ```
 
-## 6-Phase Protocol
+`status.dry-run.json` defines the exact resource set to check; skip ad hoc/manual discovery.
 
-> Hook: orchestration-protocol-enforcer.sh validates phase compliance
-> NOTE: Read-only command — no destructive operations
+## Verification sequence
 
-### Phase 1: EXPLORE (2 agents)
+1. Validate all `identity` resources.
+2. Validate all `data-platform` resources.
+3. Validate all `app-platform` resources.
+4. Validate all `collaboration-services` resources.
 
-**Agent 1: azure-agent** (sonnet)
-- Check Azure resource health (Key Vault, Functions, Static Web Apps, App Insights)
-- Verify resource group existence for each entity
-- Check Function App status and recent invocation errors
-
-**Agent 2: identity-agent** (opus)
-- Verify Entra ID tenant accessibility
-- Check license assignment status
-- Verify conditional access policy status
-- Check app registration health
-
-### Phase 2: PLAN (1 agent)
-
-**Agent: analytics-agent** (opus)
-- Compile checklist of all resources to verify
-- Define health criteria per resource type
-
-### Phase 3: CODE (2 agents)
-
-**Agent 1: platform-agent** (sonnet)
-- Check pac auth status for each Dataverse environment
-- Verify Dataverse environment health via API
-- Check solution versions deployed
-
-**Agent 2: analytics-agent** (opus)
-- Check Fabric workspace status via REST API
-- Verify lakehouse accessibility
-- Check notebook schedule status
-
-### Phase 4: TEST (2 agents)
-
-**Agent 1: comms-agent** (sonnet)
-- Verify Teams workspace accessibility
-- Check shared mailbox status
-
-**Agent 2: browser-fallback-agent** (haiku)
-- Screenshot key portal dashboards for visual verification
-
-### Phase 5: FIX (1 agent)
-
-**Agent: azure-agent** (sonnet)
-- Report issues found (does not auto-fix in status-check mode)
-- Suggest remediation commands for each issue
-
-### Phase 6: DOCUMENT (1 agent)
-
-**Agent: analytics-agent** (opus)
-- Generate health report with traffic-light indicators
-- Output resource inventory with versions
-
-## Output
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-   Rosa Holdings — Platform Status
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Entra ID
-  [OK] TVS tenant accessible
-  [OK] Consulting tenant accessible
-  [OK] 23/23 licenses assigned
-  [OK] Conditional access policies active
-  [OK] FIDO2 keys: 11/11 PH VAs registered
-
-Dataverse
-  [OK] TVS environment: Online
-  [OK] Consulting environment: Online
-  [OK] TVS tables: 7/7 deployed
-  [OK] Consulting tables: 6/6 deployed
-
-Fabric
-  [OK] TVS workspace: Active
-  [OK] Consulting workspace: Active
-  [OK] a3_archive workspace: Active
-  [OK] Consolidated workspace: Active
-  [--] Media workspace: Not provisioned
-  [OK] Capacity F2: Running
-
-Azure
-  [OK] kv-rosa-holdings: Accessible
-  [OK] func-rosa-ingest: Running
-  [OK] stapp-broker-portal: Deployed
-  [OK] appi-rosa-holdings: Collecting
-
-Teams
-  [OK] VA Workspace: Active
-  [OK] Channels: 6/6
-  [OK] Members: 11/11
-
-Overall: 22/23 checks passed
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```
-
-## See Also
-
-- `/tvs:cost-report` — Financial health view
-- `/tvs:deploy-all` — Deploy/redeploy components with issues
+Report health by resource ID from the plan output so deploy/status use the same contract.

--- a/plugins/tvs-microsoft-deploy/commands/taia-readiness.md
+++ b/plugins/tvs-microsoft-deploy/commands/taia-readiness.md
@@ -1,0 +1,41 @@
+---
+name: tvs:taia-readiness
+description: TAIA transition readiness check driven by control-plane wind-down overlay
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+---
+
+# TAIA Readiness
+
+Assesses TAIA wind-down and target-state readiness using the same control-plane manifest model.
+
+## Usage
+
+```bash
+/tvs:taia-readiness [--env dev|test|prod]
+```
+
+## Plan generation
+
+```bash
+BASE=plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml
+ENV_OVERLAY=plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/${ENV:-prod}.yaml
+WIND_DOWN=plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/taia-wind-down.yaml
+
+node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
+  --manifest "$BASE" \
+  --overlay "$ENV_OVERLAY" \
+  --overlay "$WIND_DOWN" \
+  --mode dry-run \
+  --out plugins/tvs-microsoft-deploy/control-plane/out/taia-readiness.json
+```
+
+## Readiness gates
+
+- All resources tagged/affected by wind-down have explicit `pause` or `decommission` operations.
+- Non-TAIA core resources remain in planned `create`/`update` operations.
+- No dependency cycles or cross-phase violations.
+
+Use `taia-readiness.json` as the readiness artifact for sale-prep reviews.

--- a/plugins/tvs-microsoft-deploy/control-plane/README.md
+++ b/plugins/tvs-microsoft-deploy/control-plane/README.md
@@ -1,0 +1,56 @@
+# TVS Control Plane
+
+Tenant-scoped control plane package that ingests Azure, Dataverse/Power Platform, Fabric, M365 collaboration, and automation manifests and emits dependency-ordered plans.
+
+## Manifest model
+
+- Schema: `schema/control-plane-manifest.schema.json`
+- Base manifest: `manifests/base.yaml`
+- Overlays: `manifests/overlays/{dev,test,prod,taia-wind-down}.yaml`
+
+Supported resource types:
+
+- Azure: `azure.subscription`
+- Dataverse/Power Platform: `dataverse.environment`, `powerplatform.solution`
+- Fabric: `fabric.workspace`, `fabric.lakehouse`, `fabric.notebook`
+- Entra ID: `entra.app`, `entra.group`
+- Collaboration: `teams.channel`, `sharepoint.site`
+- Automation: `automation.asset`
+
+## Planner
+
+`planner.mjs` computes ordered phases:
+
+1. `identity`
+2. `data-platform`
+3. `app-platform`
+4. `collaboration-services`
+
+### Dry-run plan
+
+```bash
+node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
+  --manifest plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml \
+  --overlay plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/dev.yaml \
+  --mode dry-run \
+  --out plugins/tvs-microsoft-deploy/control-plane/out/dry-run.dev.json
+```
+
+### Execution plan
+
+```bash
+node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
+  --manifest plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml \
+  --overlay plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/prod.yaml \
+  --mode execute \
+  --out plugins/tvs-microsoft-deploy/control-plane/out/execute.prod.json
+```
+
+### TAIA wind-down
+
+```bash
+node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
+  --manifest plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml \
+  --overlay plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/taia-wind-down.yaml \
+  --mode execute
+```

--- a/plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml
+++ b/plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml
@@ -1,0 +1,68 @@
+manifestVersion: v1
+tenant:
+  id: tvs-primary
+  name: Trusted Virtual Solutions
+  defaultEnvironment: dev
+settings:
+  taiaWindDown: false
+resources:
+  - id: sub-platform
+    type: azure.subscription
+    name: rg-rosa-platform
+    properties:
+      subscriptionId: 00000000-0000-0000-0000-000000000001
+  - id: entra-platform-admins
+    type: entra.group
+    name: TVS-Platform-Admins
+    dependsOn:
+      - sub-platform
+  - id: entra-fabric-app
+    type: entra.app
+    name: tvs-fabric-orchestrator
+    dependsOn:
+      - entra-platform-admins
+  - id: dv-tvs
+    type: dataverse.environment
+    name: tvs-dataverse
+    environment: dev
+    dependsOn:
+      - entra-fabric-app
+  - id: pps-broker-solution
+    type: powerplatform.solution
+    name: broker-portal-core
+    environment: dev
+    dependsOn:
+      - dv-tvs
+  - id: fabric-core
+    type: fabric.workspace
+    name: tvs-core-workspace
+    environment: dev
+    dependsOn:
+      - dv-tvs
+  - id: fabric-core-lakehouse
+    type: fabric.lakehouse
+    name: tvs-core-lakehouse
+    environment: dev
+    dependsOn:
+      - fabric-core
+  - id: fabric-curation-notebook
+    type: fabric.notebook
+    name: curated_transform
+    environment: dev
+    dependsOn:
+      - fabric-core-lakehouse
+  - id: teams-ops
+    type: teams.channel
+    name: operations
+    dependsOn:
+      - pps-broker-solution
+  - id: sp-broker-site
+    type: sharepoint.site
+    name: Broker Operations
+    dependsOn:
+      - teams-ops
+  - id: flow-taia-transition
+    type: automation.asset
+    name: taia-transition-flow
+    dependsOn:
+      - pps-broker-solution

--- a/plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/dev.yaml
+++ b/plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/dev.yaml
@@ -1,0 +1,7 @@
+settings:
+  taiaWindDown: false
+resources:
+  - id: dv-tvs
+    environment: dev
+  - id: pps-broker-solution
+    operation: update

--- a/plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/prod.yaml
+++ b/plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/prod.yaml
@@ -1,0 +1,9 @@
+settings:
+  taiaWindDown: false
+resources:
+  - id: dv-tvs
+    environment: prod
+  - id: pps-broker-solution
+    environment: prod
+  - id: fabric-core
+    environment: prod

--- a/plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/taia-wind-down.yaml
+++ b/plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/taia-wind-down.yaml
@@ -1,0 +1,9 @@
+settings:
+  taiaWindDown: true
+resources:
+  - id: flow-taia-transition
+    operation: decommission
+  - id: teams-ops
+    operation: pause
+    tags:
+      - taia-wind-down

--- a/plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/test.yaml
+++ b/plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/test.yaml
@@ -1,0 +1,7 @@
+settings:
+  taiaWindDown: false
+resources:
+  - id: dv-tvs
+    environment: test
+  - id: fabric-core
+    environment: test

--- a/plugins/tvs-microsoft-deploy/control-plane/planner.mjs
+++ b/plugins/tvs-microsoft-deploy/control-plane/planner.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PHASE_ORDER = [
+  'identity',
+  'data-platform',
+  'app-platform',
+  'collaboration-services'
+];
+
+const TYPE_TO_PHASE = {
+  'entra.app': 'identity',
+  'entra.group': 'identity',
+  'azure.subscription': 'data-platform',
+  'dataverse.environment': 'data-platform',
+  'fabric.workspace': 'data-platform',
+  'fabric.lakehouse': 'data-platform',
+  'fabric.notebook': 'data-platform',
+  'powerplatform.solution': 'app-platform',
+  'automation.asset': 'app-platform',
+  'teams.channel': 'collaboration-services',
+  'sharepoint.site': 'collaboration-services'
+};
+
+function parseScalar(value) {
+  const trimmed = value.trim();
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (trimmed === 'null') return null;
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseSimpleYaml(text) {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => ({ trimmed: line.trim(), indent: line.match(/^\s*/)[0].length }))
+    .filter((line) => line.trimmed && !line.trimmed.startsWith('#'));
+
+  const root = {};
+  const stack = [{ indent: -1, value: root }];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const { trimmed: line, indent } = lines[i];
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+      stack.pop();
+    }
+    const parent = stack[stack.length - 1].value;
+
+    if (line.startsWith('- ')) {
+      if (!Array.isArray(parent)) throw new Error(`Invalid YAML list item near: ${line}`);
+      const content = line.slice(2);
+      if (content.includes(':')) {
+        const [key, ...rest] = content.split(':');
+        const valRaw = rest.join(':').trim();
+        const item = {};
+        if (valRaw) {
+          item[key.trim()] = parseScalar(valRaw);
+          parent.push(item);
+          stack.push({ indent, value: item });
+        } else {
+          item[key.trim()] = {};
+          parent.push(item);
+          stack.push({ indent, value: item[key.trim()] });
+        }
+      } else {
+        parent.push(parseScalar(content));
+      }
+      continue;
+    }
+
+    const [key, ...rest] = line.split(':');
+    const valRaw = rest.join(':').trim();
+    if (valRaw) {
+      parent[key.trim()] = parseScalar(valRaw);
+      continue;
+    }
+
+    let container = {};
+    for (let j = i + 1; j < lines.length; j += 1) {
+      if (lines[j].indent <= indent) break;
+      if (lines[j].trimmed.startsWith('- ')) {
+        container = [];
+        break;
+      }
+      if (lines[j].indent > indent) {
+        container = {};
+        break;
+      }
+    }
+    parent[key.trim()] = container;
+    stack.push({ indent, value: container });
+  }
+  return root;
+}
+
+function readManifest(filePath) {
+  const text = fs.readFileSync(filePath, 'utf-8');
+  return filePath.endsWith('.json') ? JSON.parse(text) : parseSimpleYaml(text);
+}
+
+function mergeManifest(base, overlay) {
+  const merged = { ...base, settings: { ...(base.settings || {}), ...(overlay.settings || {}) } };
+  const byId = new Map((base.resources || []).map((r) => [r.id, { ...r }]));
+  for (const delta of overlay.resources || []) {
+    const existing = byId.get(delta.id) || {};
+    byId.set(delta.id, { ...existing, ...delta });
+  }
+  merged.resources = [...byId.values()];
+  return merged;
+}
+
+function topoSort(resources) {
+  const byId = new Map(resources.map((r) => [r.id, r]));
+  const pending = new Set(byId.keys());
+  const sorted = [];
+
+  while (pending.size) {
+    let progressed = false;
+    for (const id of [...pending]) {
+      const r = byId.get(id);
+      const deps = r.dependsOn || [];
+      if (deps.every((dep) => !pending.has(dep))) {
+        sorted.push(r);
+        pending.delete(id);
+        progressed = true;
+      }
+    }
+    if (!progressed) {
+      throw new Error('Cycle detected in manifest dependencies');
+    }
+  }
+
+  return sorted.sort((a, b) => PHASE_ORDER.indexOf(TYPE_TO_PHASE[a.type]) - PHASE_ORDER.indexOf(TYPE_TO_PHASE[b.type]));
+}
+
+function buildPlan(manifest, mode = 'dry-run') {
+  const ordered = topoSort(manifest.resources || []);
+  const phases = PHASE_ORDER.map((phase) => ({
+    name: phase,
+    resources: ordered.filter((r) => TYPE_TO_PHASE[r.type] === phase)
+  })).filter((p) => p.resources.length);
+
+  return {
+    mode,
+    tenant: manifest.tenant,
+    taiaWindDown: Boolean(manifest.settings?.taiaWindDown),
+    phases: phases.map((p, phaseIndex) => ({
+      phase: p.name,
+      sequence: phaseIndex + 1,
+      steps: p.resources.map((resource, stepIndex) => ({
+        order: stepIndex + 1,
+        id: resource.id,
+        type: resource.type,
+        action: resource.operation || (mode === 'execute' ? 'apply' : 'preview'),
+        dependsOn: resource.dependsOn || []
+      }))
+    }))
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const getArg = (name, fallback) => {
+    const index = args.indexOf(name);
+    return index >= 0 ? args[index + 1] : fallback;
+  };
+
+  const basePath = getArg('--manifest');
+  if (!basePath) {
+    console.error('Usage: node planner.mjs --manifest <base.(yaml|json)> [--overlay <overlay.(yaml|json)> ...] [--mode dry-run|execute] [--out file]');
+    process.exit(1);
+  }
+
+  const overlayPaths = [];
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === '--overlay' && args[i + 1]) overlayPaths.push(args[i + 1]);
+  }
+  const mode = getArg('--mode', 'dry-run');
+  const outPath = getArg('--out', null);
+
+  const base = readManifest(basePath);
+  const combined = overlayPaths.reduce((acc, overlayPath) => mergeManifest(acc, readManifest(overlayPath)), base);
+  const plan = buildPlan(combined, mode);
+  const serialized = JSON.stringify(plan, null, 2);
+
+  if (outPath) {
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, serialized + '\n');
+  }
+
+  console.log(serialized);
+}
+
+main();

--- a/plugins/tvs-microsoft-deploy/control-plane/schema/control-plane-manifest.schema.json
+++ b/plugins/tvs-microsoft-deploy/control-plane/schema/control-plane-manifest.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tvs.local/schemas/control-plane-manifest.schema.json",
+  "title": "TVS Microsoft Deploy Control Plane Manifest",
+  "type": "object",
+  "required": ["manifestVersion", "tenant", "resources"],
+  "properties": {
+    "manifestVersion": { "type": "string", "pattern": "^v[0-9]+$" },
+    "tenant": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "defaultEnvironment": { "type": "string", "enum": ["dev", "test", "prod"] }
+      },
+      "additionalProperties": true
+    },
+    "settings": {
+      "type": "object",
+      "properties": {
+        "taiaWindDown": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "resources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "type": {
+            "type": "string",
+            "enum": [
+              "azure.subscription",
+              "dataverse.environment",
+              "powerplatform.solution",
+              "fabric.workspace",
+              "fabric.lakehouse",
+              "fabric.notebook",
+              "entra.app",
+              "entra.group",
+              "teams.channel",
+              "sharepoint.site",
+              "automation.asset"
+            ]
+          },
+          "name": { "type": "string" },
+          "environment": { "type": "string", "enum": ["dev", "test", "prod"] },
+          "operation": {
+            "type": "string",
+            "enum": ["create", "update", "validate", "pause", "decommission"],
+            "default": "create"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "properties": { "type": "object" },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
### Motivation
- Provide a single source-of-truth manifest model for tenant-scoped resources spanning Azure, Dataverse/Power Platform, Fabric, Entra, M365 collaboration, and automation assets.  
- Replace ad hoc/manual sequencing with a planner that computes dependency-ordered execution phases to ensure correct ordering (identity → data platform → app platform → collaboration services).  
- Support environment overlays (dev/test/prod) and a TAIA wind-down overlay so transitional and target-state operations share the same manifest model.

### Description
- Added a new control-plane package at `plugins/tvs-microsoft-deploy/control-plane/` including a JSON schema at `schema/control-plane-manifest.schema.json` that models tenant, settings, and tenant-scoped resource types with `dependsOn` and `operation` intent.  
- Added a base manifest (`manifests/base.yaml`) and environment overlays (`manifests/overlays/{dev,test,prod,taia-wind-down}.yaml`) that express environment-specific overrides and TAIA wind-down operations.  
- Implemented `planner.mjs` which ingests YAML/JSON manifests, supports multiple `--overlay` merges, contains a simple YAML parser, performs topological sort by `dependsOn`, maps resource `type` to execution phases, and emits dry-run (`preview`) or execution (`apply`) plans.  
- Wired command docs and plugin metadata to consume control-plane outputs by updating `commands/deploy-all.md` and `commands/status-check.md`, adding `commands/taia-readiness.md`, and updating plugin docs/metadata to include the new command and usage examples; added package `README.md` with usage examples.

### Testing
- Ran the planner in dry-run mode with the dev overlay using `node planner.mjs --manifest manifests/base.yaml --overlay manifests/overlays/dev.yaml --mode dry-run --out control-plane/out/dry-run.dev.json` and verified the tenant and ordered phases were emitted.  
- Ran the planner in execute mode with the prod + TAIA overlays using `node planner.mjs --manifest manifests/base.yaml --overlay manifests/overlays/prod.yaml --overlay manifests/overlays/taia-wind-down.yaml --mode execute` and verified `taiaWindDown: true` and correct phase ordering.  
- Verified planner outputs contain ordered phase/step records (identity → data-platform → app-platform → collaboration-services) and that the new command docs reference the planner outputs as the source of truth; all automated planner runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d695c4f88832abaab690815ad16f0)