### PR TITLE
Add centralized identity policy engine, identity-as-code, drift detection, and attestations

### DIFF
--- a/plugins/tvs-microsoft-deploy/commands/deploy-all.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-all.md
@@ -43,6 +43,14 @@ node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
   --out plugins/tvs-microsoft-deploy/control-plane/out/deploy.execute.json
 ```
 
+## Identity guardrails (required before phase execution)
+
+```bash
+python3 plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py --json
+```
+
+If any deny findings are returned, deployment is blocked by `hooks/identity-policy-engine.sh`.
+
 ## Execution contract
 
 Execute strictly in planner phase order:

--- a/plugins/tvs-microsoft-deploy/commands/deploy-identity.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-identity.md
@@ -42,6 +42,16 @@ echo "$ROLES" | grep -q "Global Administrator" \
   || echo "WARN: Global Admin role recommended for full provisioning"
 ```
 
+## Mandatory Pre-Deploy Identity Policy Checks
+
+Run policy validation before starting any deploy phase:
+
+```bash
+python3 plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py --json
+```
+
+The centralized `hooks/identity-policy-engine.sh` also enforces these checks and blocks unsafe operations with machine-readable denial reasons.
+
 ## 6-Phase Protocol
 
 ### Phase 1: EXPLORE (2 agents)

--- a/plugins/tvs-microsoft-deploy/commands/identity-attestation.md
+++ b/plugins/tvs-microsoft-deploy/commands/identity-attestation.md
@@ -1,0 +1,32 @@
+---
+name: tvs:identity-attestation
+description: Generate periodic access attestation packets for TAIA transition governance and due diligence
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Identity Access Attestation
+
+Generates CSV + JSON audit artifacts for governance review and buyer due diligence.
+
+## Usage
+
+```bash
+/tvs:identity-attestation --input exports/role-assignments.json --period 2026-Q1
+```
+
+## Command
+
+```bash
+python3 plugins/tvs-microsoft-deploy/scripts/generate_access_attestation.py \
+  --input "${ROLE_ASSIGNMENT_EXPORT}" \
+  --period "${ATTESTATION_PERIOD:-2026-Q1}" \
+  --csv-output "${ATTESTATION_CSV:-reports/access-attestation.csv}" \
+  --json-output "${ATTESTATION_JSON:-reports/access-attestation.json}"
+```
+
+## Outputs
+
+- CSV attestation workbook (`pending` review state for each assignment)
+- JSON audit report with TAIA assignment totals and timestamps

--- a/plugins/tvs-microsoft-deploy/commands/identity-drift.md
+++ b/plugins/tvs-microsoft-deploy/commands/identity-drift.md
@@ -1,0 +1,32 @@
+---
+name: tvs:identity-drift
+description: Detect Entra identity drift and produce remediation recommendations
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Identity Drift Detection
+
+Runs tenant identity drift scans for stale app credentials, orphaned service principals, and over-privileged Graph scopes.
+
+## Usage
+
+```bash
+/tvs:identity-drift --inventory identity-inventory.json --output reports/identity-drift.json
+```
+
+## Command
+
+```bash
+python3 plugins/tvs-microsoft-deploy/scripts/identity_drift_detect.py \
+  --inventory "${IDENTITY_INVENTORY_FILE}" \
+  --output "${IDENTITY_DRIFT_REPORT:-reports/identity-drift.json}"
+```
+
+## Findings Categories
+
+- `stale_secret`: client secret age exceeds threshold (default 180 days)
+- `stale_certificate`: app certificate age exceeds threshold (default 365 days)
+- `orphaned_service_principal`: SP has no backing app registration
+- `overprivileged_scope`: Graph scopes ending in `.ReadWrite.All`

--- a/plugins/tvs-microsoft-deploy/hooks/identity-policy-engine.sh
+++ b/plugins/tvs-microsoft-deploy/hooks/identity-policy-engine.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Centralized PreToolUse identity policy engine.
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+ENGINE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$ENGINE_ROOT/scripts/identity_policy_checks.py"
+
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Read-only commands pass through.
+if echo "$COMMAND" | grep -qE '^\s*(az .* (show|list)|pac .* list|jq |cat |echo )'; then
+  exit 0
+fi
+
+JSON_RESULT=$(python3 "$CHECK_SCRIPT" --json --command "$COMMAND")
+DENY_COUNT=$(echo "$JSON_RESULT" | jq '[.findings[] | select(.severity == "deny")] | length')
+WARN_COUNT=$(echo "$JSON_RESULT" | jq '[.findings[] | select(.severity == "warn")] | length')
+
+if [ "$WARN_COUNT" -gt 0 ]; then
+  echo "IDENTITY POLICY WARNINGS:"
+  echo "$JSON_RESULT" | jq -c '.findings[] | select(.severity == "warn")' >&2
+fi
+
+if [ "$DENY_COUNT" -gt 0 ]; then
+  echo "BLOCKED: identity policy engine denied the operation." >&2
+  echo "$JSON_RESULT" | jq -c '.findings[] | select(.severity == "deny")' >&2
+  exit 2
+fi
+
+# Dynamic command-time checks for tenant/taia operations.
+if echo "$COMMAND" | grep -qE 'taia|TAIA'; then
+  if [ "${TAIA_WINDDOWN_APPROVED:-false}" != "true" ]; then
+    echo "BLOCKED: TAIA operations require TAIA_WINDDOWN_APPROVED=true" >&2
+    jq -n --arg policy "taia_winddown" --arg reason "missing TAIA_WINDDOWN_APPROVED=true" \
+      '{policy:$policy,severity:"deny",reason:$reason}' >&2
+    exit 2
+  fi
+fi
+
+if echo "$COMMAND" | grep -qE '^\s*(az |pac )'; then
+  if [ -z "${AZURE_TENANT_ID:-}" ]; then
+    echo "BLOCKED: AZURE_TENANT_ID must be set." >&2
+    jq -n '{policy:"tenant_isolation",severity:"deny",reason:"AZURE_TENANT_ID missing"}' >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/plugins/tvs-microsoft-deploy/hooks/taia-winddown-guard.sh
+++ b/plugins/tvs-microsoft-deploy/hooks/taia-winddown-guard.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Compatibility wrapper around centralized identity policy engine.
+# TAIA guard now routes through centralized identity policy engine.
 set -euo pipefail
 
 ENGINE_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/identity-policy-engine.sh"

--- a/plugins/tvs-microsoft-deploy/identity/identity-as-code.json
+++ b/plugins/tvs-microsoft-deploy/identity/identity-as-code.json
@@ -1,0 +1,131 @@
+{
+  "version": 1,
+  "updated": "2026-02-24",
+  "defaults": {
+    "breakglass_max_accounts": 2,
+    "stale_secret_days": 180,
+    "stale_cert_days": 365,
+    "high_privilege_graph_scopes": [
+      "Directory.ReadWrite.All",
+      "Directory.AccessAsUser.All",
+      "RoleManagement.ReadWrite.Directory",
+      "Policy.ReadWrite.ConditionalAccess",
+      "AppRoleAssignment.ReadWrite.All",
+      "User.ReadWrite.All"
+    ]
+  },
+  "entities": {
+    "tvs": {
+      "tenantId": "${TVS_TENANT_ID}",
+      "displayName": "Trusted Virtual Solutions",
+      "users": [
+        {
+          "upn": "breakglass-tvs@trustedvirtual.solutions",
+          "displayName": "TVS Breakglass Account",
+          "accountType": "breakglass",
+          "enabled": true,
+          "groups": ["sg-tvs-breakglass"]
+        },
+        {
+          "upn": "svc-fabric@trustedvirtual.solutions",
+          "displayName": "TVS Fabric Service Identity",
+          "accountType": "workload",
+          "enabled": true,
+          "groups": ["sg-tvs-workloads"]
+        }
+      ],
+      "groups": [
+        {"name": "sg-tvs-breakglass", "type": "security"},
+        {"name": "sg-tvs-workloads", "type": "security"},
+        {"name": "sg-tvs-admins", "type": "security"}
+      ],
+      "appRegistrations": [
+        {"name": "app-tvs-fabric", "signInAudience": "AzureADMyOrg", "owners": ["sg-tvs-admins"]},
+        {"name": "app-tvs-dataverse", "signInAudience": "AzureADMyOrg", "owners": ["sg-tvs-admins"]}
+      ],
+      "servicePrincipals": [
+        {"app": "app-tvs-fabric", "name": "sp-tvs-fabric", "managedByEntity": "tvs"},
+        {"app": "app-tvs-dataverse", "name": "sp-tvs-dataverse", "managedByEntity": "tvs"}
+      ],
+      "permissions": {
+        "delegated": [
+          {"principal": "app-tvs-dataverse", "resourceAppId": "00000003-0000-0000-c000-000000000000", "scopes": ["User.Read", "Group.Read.All"]}
+        ],
+        "application": [
+          {"principal": "app-tvs-fabric", "resourceAppId": "00000003-0000-0000-c000-000000000000", "scopes": ["User.Read.All", "Group.Read.All"]}
+        ]
+      },
+      "roleAssignments": [
+        {"principal": "sg-tvs-admins", "role": "Privileged Role Administrator", "scope": "/"},
+        {"principal": "sp-tvs-fabric", "role": "Reader", "scope": "/subscriptions/${TVS_SUBSCRIPTION_ID}"}
+      ],
+      "conditionalAccess": {
+        "requiredPolicies": ["ca-require-mfa-all-users", "ca-block-legacy-auth", "ca-require-compliant-device-admins"],
+        "breakglassExclusions": ["breakglass-tvs@trustedvirtual.solutions"]
+      }
+    },
+    "consulting": {
+      "tenantId": "${CONSULTING_TENANT_ID}",
+      "displayName": "Lobbi Consulting",
+      "users": [
+        {
+          "upn": "breakglass-consulting@lobbiconsulting.com",
+          "displayName": "Consulting Breakglass Account",
+          "accountType": "breakglass",
+          "enabled": true,
+          "groups": ["sg-consulting-breakglass"]
+        }
+      ],
+      "groups": [
+        {"name": "sg-consulting-breakglass", "type": "security"},
+        {"name": "sg-consulting-admins", "type": "security"}
+      ],
+      "appRegistrations": [
+        {"name": "app-consulting-portal", "signInAudience": "AzureADMyOrg", "owners": ["sg-consulting-admins"]}
+      ],
+      "servicePrincipals": [
+        {"app": "app-consulting-portal", "name": "sp-consulting-portal", "managedByEntity": "consulting"}
+      ],
+      "permissions": {
+        "delegated": [
+          {"principal": "app-consulting-portal", "resourceAppId": "00000003-0000-0000-c000-000000000000", "scopes": ["User.Read"]}
+        ],
+        "application": []
+      },
+      "roleAssignments": [
+        {"principal": "sg-consulting-admins", "role": "User Administrator", "scope": "/"}
+      ],
+      "conditionalAccess": {
+        "requiredPolicies": ["ca-require-mfa-all-users", "ca-block-legacy-auth"],
+        "breakglassExclusions": ["breakglass-consulting@lobbiconsulting.com"]
+      }
+    },
+    "taia": {
+      "tenantId": "${TAIA_TENANT_ID}",
+      "displayName": "TAIA Transition",
+      "users": [],
+      "groups": [
+        {"name": "sg-taia-transition-readers", "type": "security"}
+      ],
+      "appRegistrations": [
+        {"name": "app-taia-transition-export", "signInAudience": "AzureADMyOrg", "owners": ["sg-taia-transition-readers"]}
+      ],
+      "servicePrincipals": [
+        {"app": "app-taia-transition-export", "name": "sp-taia-transition-export", "managedByEntity": "taia"}
+      ],
+      "permissions": {
+        "delegated": [],
+        "application": [
+          {"principal": "app-taia-transition-export", "resourceAppId": "00000003-0000-0000-c000-000000000000", "scopes": ["AuditLog.Read.All", "Reports.Read.All"]}
+        ]
+      },
+      "roleAssignments": [
+        {"principal": "sp-taia-transition-export", "role": "Reader", "scope": "/subscriptions/${TAIA_SUBSCRIPTION_ID}"}
+      ],
+      "conditionalAccess": {
+        "requiredPolicies": ["ca-require-mfa-all-users", "ca-block-legacy-auth"],
+        "breakglassExclusions": []
+      }
+    }
+  }
+}

--- a/plugins/tvs-microsoft-deploy/scripts/generate_access_attestation.py
+++ b/plugins/tvs-microsoft-deploy/scripts/generate_access_attestation.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Generate periodic access attestations and exportable TAIA governance audit reports."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def create_attestation_rows(data: dict[str, Any], period: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for row in data.get("assignments", []):
+        rows.append(
+            {
+                "period": period,
+                "entity": row.get("entity", "unknown"),
+                "principal": row.get("principal", ""),
+                "principalType": row.get("principalType", ""),
+                "role": row.get("role", ""),
+                "scope": row.get("scope", ""),
+                "attestationStatus": "pending",
+                "reviewer": row.get("reviewer", ""),
+                "notes": "",
+            }
+        )
+    return rows
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    fieldnames = [
+        "period",
+        "entity",
+        "principal",
+        "principalType",
+        "role",
+        "scope",
+        "attestationStatus",
+        "reviewer",
+        "notes",
+    ]
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="JSON identity role assignment export")
+    now=datetime.now(timezone.utc)
+    quarter=((now.month-1)//3)+1
+    parser.add_argument("--period", default=f"{now.year}-Q{quarter}")
+    parser.add_argument("--csv-output", required=True)
+    parser.add_argument("--json-output", required=True)
+    args = parser.parse_args()
+
+    data = load_json(Path(args.input))
+    rows = create_attestation_rows(data, args.period)
+    write_csv(Path(args.csv_output), rows)
+
+    report = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "period": args.period,
+        "totalAssignments": len(rows),
+        "taiaTransitionAssignments": len([r for r in rows if r["entity"].lower() == "taia"]),
+        "rows": rows,
+    }
+    Path(args.json_output).write_text(json.dumps(report, indent=2))
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/tvs-microsoft-deploy/scripts/identity_drift_detect.py
+++ b/plugins/tvs-microsoft-deploy/scripts/identity_drift_detect.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Identity drift detection and remediation recommendations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def parse_date(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def age_days(created: str) -> int:
+    return (datetime.now(timezone.utc) - parse_date(created)).days
+
+
+def load_inventory(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def detect_drift(inventory: dict[str, Any], secret_days: int, cert_days: int) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+
+    for app in inventory.get("appCredentials", []):
+        if app.get("type") == "secret" and age_days(app["createdDateTime"]) > secret_days:
+            findings.append({
+                "type": "stale_secret",
+                "appId": app["appId"],
+                "credentialId": app["credentialId"],
+                "recommendation": "Rotate client secret and remove prior credential after cutover.",
+            })
+        if app.get("type") == "certificate" and age_days(app["createdDateTime"]) > cert_days:
+            findings.append({
+                "type": "stale_certificate",
+                "appId": app["appId"],
+                "credentialId": app["credentialId"],
+                "recommendation": "Issue new cert, upload public key, then retire old certificate.",
+            })
+
+    for sp in inventory.get("servicePrincipals", []):
+        if not sp.get("appId"):
+            findings.append({
+                "type": "orphaned_service_principal",
+                "servicePrincipalId": sp["id"],
+                "recommendation": "Review ownership and disable/delete orphaned service principal.",
+            })
+
+    for perm in inventory.get("graphPermissions", []):
+        if perm.get("scope", "").endswith(".ReadWrite.All"):
+            findings.append({
+                "type": "overprivileged_scope",
+                "principalId": perm["principalId"],
+                "scope": perm["scope"],
+                "recommendation": "Replace write-all scope with least-privilege alternatives where possible.",
+            })
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--inventory", required=True, help="Path to exported identity inventory JSON")
+    parser.add_argument("--secret-days", type=int, default=180)
+    parser.add_argument("--cert-days", type=int, default=365)
+    parser.add_argument("--output", help="Optional output path for machine-readable report JSON")
+    args = parser.parse_args()
+
+    inventory = load_inventory(Path(args.inventory))
+    findings = detect_drift(inventory, args.secret_days, args.cert_days)
+    report = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "findingCount": len(findings),
+        "findings": findings,
+    }
+
+    print(json.dumps(report, indent=2))
+    if args.output:
+        Path(args.output).write_text(json.dumps(report, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py
+++ b/plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Automated identity policy checks for pre-deploy guardrails."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+DEPLOY_PATTERNS = (
+    "deploy-identity",
+    "deploy-all",
+    "az deployment",
+    "pac solution import",
+)
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def flatten_permissions(entity: dict[str, Any]) -> list[tuple[str, str, str]]:
+    entries: list[tuple[str, str, str]] = []
+    perms = entity.get("permissions", {})
+    for mode in ("delegated", "application"):
+        for row in perms.get(mode, []):
+            principal = row.get("principal", "")
+            for scope in row.get("scopes", []):
+                entries.append((mode, principal, scope))
+    return entries
+
+
+def run_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    entities = config.get("entities", {})
+    high_risk = set(config.get("defaults", {}).get("high_privilege_graph_scopes", []))
+    max_breakglass = int(config.get("defaults", {}).get("breakglass_max_accounts", 2))
+
+    tenant_ids: dict[str, str] = {}
+    for entity_name, entity in entities.items():
+        tenant_id = entity.get("tenantId", "")
+        if tenant_id in tenant_ids and tenant_id:
+            findings.append(
+                {
+                    "policy": "tenant_isolation",
+                    "severity": "deny",
+                    "entity": entity_name,
+                    "reason": f"tenantId collides with {tenant_ids[tenant_id]}",
+                }
+            )
+        tenant_ids[tenant_id] = entity_name
+
+        required_ca = set(entity.get("conditionalAccess", {}).get("requiredPolicies", []))
+        missing = {"ca-require-mfa-all-users", "ca-block-legacy-auth"} - required_ca
+        if missing:
+            findings.append(
+                {
+                    "policy": "conditional_access",
+                    "severity": "deny",
+                    "entity": entity_name,
+                    "reason": f"missing required CA policies: {sorted(missing)}",
+                }
+            )
+
+        breakglass_accounts = [u for u in entity.get("users", []) if u.get("accountType") == "breakglass"]
+        exclusions = set(entity.get("conditionalAccess", {}).get("breakglassExclusions", []))
+
+        if len(breakglass_accounts) > max_breakglass:
+            findings.append(
+                {
+                    "policy": "breakglass_control",
+                    "severity": "deny",
+                    "entity": entity_name,
+                    "reason": f"{len(breakglass_accounts)} breakglass accounts exceeds max {max_breakglass}",
+                }
+            )
+
+        for acct in breakglass_accounts:
+            if acct.get("upn") not in exclusions:
+                findings.append(
+                    {
+                        "policy": "breakglass_control",
+                        "severity": "deny",
+                        "entity": entity_name,
+                        "reason": f"breakglass account {acct.get('upn')} missing CA exclusion",
+                    }
+                )
+
+        for mode, principal, scope in flatten_permissions(entity):
+            if scope in high_risk:
+                findings.append(
+                    {
+                        "policy": "least_privilege",
+                        "severity": "deny",
+                        "entity": entity_name,
+                        "reason": f"{principal} requests high-risk {mode} Graph scope {scope}",
+                    }
+                )
+
+            if re.search(r"\.ReadWrite\.All$", scope):
+                findings.append(
+                    {
+                        "policy": "admin_consent_boundary",
+                        "severity": "warn",
+                        "entity": entity_name,
+                        "reason": f"{principal} has write-all scope {scope}; require CAB approval",
+                    }
+                )
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="plugins/tvs-microsoft-deploy/identity/identity-as-code.json")
+    parser.add_argument("--command", default="", help="Optional command being evaluated")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args()
+
+    config = load_config(Path(args.config))
+    findings = run_checks(config)
+
+    if args.command and any(p in args.command for p in DEPLOY_PATTERNS) and findings:
+        for finding in findings:
+            if finding["severity"] == "deny":
+                finding["deploy_block"] = True
+
+    if args.json:
+        print(json.dumps({"findings": findings}, indent=2))
+    else:
+        for finding in findings:
+            print(f"[{finding['severity'].upper()}] {finding['policy']}: {finding['entity']} - {finding['reason']}")
+
+    return 2 if any(f["severity"] == "deny" for f in findings) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Centralize and standardize pre-deploy identity guardrails to enforce tenant isolation, least privilege, admin consent boundaries, conditional access, and breakglass controls across TVS/Consulting/TAIA entities. 
- Provide an identity-as-code manifest to declare users, groups, app registrations, service principals, Graph permissions, and role assignments for repeatable, auditable provisioning. 
- Add automated drift detection and remediation guidance for stale credentials, orphaned service principals, and over-privileged Graph scopes to reduce operational risk. 
- Produce exportable access attestations and audit artifacts to support TAIA transition governance and buyer due diligence. 

### Description

- Added an identity-as-code manifest at `plugins/tvs-microsoft-deploy/identity/identity-as-code.json` modeling entities, users, groups, app registrations, service principals, delegated/application permissions, role assignments, conditional access requirements, and breakglass exclusions. 
- Implemented a pre-deploy policy validator `plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py` that emits machine-readable findings and enforces tenant isolation, least-privilege/Graph-scope checks, admin-consent boundary warnings, CA requirements, and breakglass controls. 
- Introduced a centralized hook `plugins/tvs-microsoft-deploy/hooks/identity-policy-engine.sh` that runs the validator, emits deny/warn JSON lines, blocks unsafe operations, and includes dynamic TAIA and tenant checks. 
- Reworked legacy guards to route through the engine by replacing `hooks/tenant-isolation-validator.sh` with a compatibility wrapper and adding `hooks/taia-winddown-guard.sh` to exec the centralized engine. 
- Added identity drift tooling `plugins/tvs-microsoft-deploy/scripts/identity_drift_detect.py` to detect stale secrets/certificates, orphaned service principals, and over-privileged Graph scopes, plus command docs `commands/identity-drift.md`. 
- Added attestation tooling `plugins/tvs-microsoft-deploy/scripts/generate_access_attestation.py` and command docs `commands/identity-attestation.md` to emit CSV + JSON attestation packets for governance/due diligence. 
- Updated documentation to require pre-deploy checks by adding calls to `python3 plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py --json` in `commands/deploy-identity.md` and `commands/deploy-all.md`. 

### Testing

- Compiled Python scripts with `python3 -m py_compile` for `identity_policy_checks.py`, `identity_drift_detect.py`, and `generate_access_attestation.py`, and compilation succeeded. 
- Executed `python3 plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py --json` against the shipped `identity-as-code.json` and received a valid machine-readable JSON result (no deny findings for the default manifest). 
- Ran drift detection with a sample inventory using `python3 plugins/tvs-microsoft-deploy/scripts/identity_drift_detect.py --inventory /tmp/identity_inventory.json --output /tmp/drift.json` which produced a JSON report containing stale secret/cert, orphaned service principal, and over-privileged-scope findings. 
- Generated an attestation package with `python3 plugins/tvs-microsoft-deploy/scripts/generate_access_attestation.py --input /tmp/role_assignments.json --period 2026-Q1 --csv-output /tmp/attest.csv --json-output /tmp/attest.json` which produced both CSV and JSON outputs as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d70f5dc3c832aa5d09bf6e35f8f8c)