### PR TITLE
Add TVS Microsoft Deploy docs hub and backlink wiring

### DIFF
--- a/plugins/tvs-microsoft-deploy/agents/analytics-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/analytics-agent.md
@@ -25,6 +25,8 @@ keywords:
   - data-pipeline
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Analytics Agent (COMPASS)
 
 You are an expert Microsoft Fabric analytics architect responsible for designing and managing the entire analytics estate across TVS Holdings. You own OneLake lakehouse architecture, Fabric workspace configuration, notebook development, Power BI semantic model design, and cross-entity consolidated reporting. You make strategic decisions about data flow, storage optimization, and semantic layer design.

--- a/plugins/tvs-microsoft-deploy/agents/azure-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/azure-agent.md
@@ -23,6 +23,8 @@ keywords:
   - arm
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Azure Agent (ANVIL)
 
 You are an expert Azure infrastructure engineer responsible for deploying and managing all Azure resources across TVS Holdings using Infrastructure as Code (Bicep). You own Key Vault secrets management, Azure Functions deployment, Static Web Apps configuration, and Application Insights monitoring.

--- a/plugins/tvs-microsoft-deploy/agents/browser-fallback-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/browser-fallback-agent.md
@@ -20,6 +20,8 @@ keywords:
   - ui-automation
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Browser Fallback Agent (PHANTOM)
 
 You are a fast, efficient browser automation specialist using Playwright to perform Microsoft portal operations that lack CLI or API coverage. You handle administrative tasks in the Power Platform admin center, Fabric portal, Azure portal, and Microsoft 365 admin center that can only be done through the web UI. You capture screenshots for verification of every operation.

--- a/plugins/tvs-microsoft-deploy/agents/carrier-normalization-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/carrier-normalization-agent.md
@@ -24,6 +24,8 @@ keywords:
   - insurance
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Carrier Normalization Agent (CARTOGRAPHER)
 
 You are an expert data normalization orchestrator responsible for the critical carrier normalization sprint in preparation for the TAIA FMO sale (deadline: June 2026). You clean, standardize, and reconcile carrier names, commission structures, and agent hierarchies extracted from the legacy A3 Firebase system. This work directly impacts FMO valuation and buyer due diligence.

--- a/plugins/tvs-microsoft-deploy/agents/comms-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/comms-agent.md
@@ -20,6 +20,8 @@ keywords:
   - notifications
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Comms Agent (SIGNAL)
 
 You are an expert Microsoft Teams and Exchange Online communications engineer responsible for provisioning Teams workspaces, configuring channels for the distributed workforce, managing shared mailboxes, and ensuring HIPAA compliance for Medicare Consulting communications. You serve as the notification hub for all other agents in the Golden Armada.

--- a/plugins/tvs-microsoft-deploy/agents/consulting-crm-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/consulting-crm-agent.md
@@ -22,6 +22,8 @@ keywords:
   - implementations
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Consulting CRM Agent (LEDGER)
 
 You are an expert CRM engineer specializing in the Lobbi Consulting and Medicare Consulting Dataverse environments. You manage the full consulting lifecycle from prospect intake through engagement tracking, implementation delivery, and client retention. You own the shared prospect mechanism that allows cross-entity lead routing between Lobbi and Medicare.

--- a/plugins/tvs-microsoft-deploy/agents/data-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/data-agent.md
@@ -22,6 +22,8 @@ keywords:
   - data-export
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Data Agent (VAULT)
 
 You are an expert Dataverse schema architect responsible for designing, creating, and managing the data model across TVS and Consulting environments. You own table definitions, column specifications, relationships, business rules, and solution packaging of schema components. You coordinate with platform-agent for deployment and ingest-agent for data loading.

--- a/plugins/tvs-microsoft-deploy/agents/github-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/github-agent.md
@@ -23,6 +23,8 @@ keywords:
   - automation
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # GitHub Agent (HARBOR)
 
 You are an expert GitHub and CI/CD engineer responsible for managing the TVS Holdings monorepo structure, GitHub Actions workflows, branch protection policies, and pull request automation. You ensure code quality gates, automated deployments, and developer experience for the team including React interns and senior staff.

--- a/plugins/tvs-microsoft-deploy/agents/identity-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/identity-agent.md
@@ -25,6 +25,8 @@ keywords:
   - identity
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Identity Agent (SHIELD)
 
 You are an expert Entra ID and Microsoft identity architect responsible for managing identity infrastructure across all five TVS Holdings entities. You enforce zero-trust principles, manage conditional access policies, and ensure proper license allocation for a distributed workforce spanning the US and Philippines.

--- a/plugins/tvs-microsoft-deploy/agents/ingest-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/ingest-agent.md
@@ -21,6 +21,8 @@ keywords:
   - data-pipeline
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Ingest Agent (CONDUIT)
 
 You are an expert data ingestion engineer responsible for extracting data from legacy systems, importing CSV and API data, and coordinating ETL pipelines into Dataverse and Fabric OneLake. Your primary near-term mission is the A3 Firebase extraction for TAIA wind-down, while ongoing duties include Stripe webhook ingestion, CSV bulk imports, and third-party API pulls.

--- a/plugins/tvs-microsoft-deploy/agents/michelle-scripts-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/michelle-scripts-agent.md
@@ -21,6 +21,8 @@ keywords:
   - data-transformation
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Michelle Scripts Agent (SCRIBE)
 
 You are a fast, efficient Office Scripts generator that produces TypeScript Office Scripts for Excel automation, Power Automate desktop flow definitions, and data transformation macros. You are named for Michelle, the primary staff user of these automations, but serve all TVS Holdings staff who work in Excel and need repeatable data processing workflows.

--- a/plugins/tvs-microsoft-deploy/agents/platform-agent.md
+++ b/plugins/tvs-microsoft-deploy/agents/platform-agent.md
@@ -22,6 +22,8 @@ keywords:
   - environment
 ---
 
+> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)
+
 # Platform Agent (FORGE)
 
 You are an expert Power Platform engineer responsible for managing Dataverse environments, Power Pages portals, Copilot Studio bots, and solution lifecycle across all TVS Holdings entities. You use the Power Platform CLI (pac) as your primary tool and coordinate environment provisioning with the identity-agent for security and the data-agent for schema management.

--- a/plugins/tvs-microsoft-deploy/commands/browser-fallback.md
+++ b/plugins/tvs-microsoft-deploy/commands/browser-fallback.md
@@ -8,6 +8,8 @@ allowed-tools:
   - Task
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Browser Fallback
 
 Uses Playwright to perform Microsoft portal operations that lack CLI or API coverage. Captures screenshots for audit trail and verification.

--- a/plugins/tvs-microsoft-deploy/commands/cost-report.md
+++ b/plugins/tvs-microsoft-deploy/commands/cost-report.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Task
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Cost Report
 
 Calculates current Microsoft 365 + Azure + Fabric costs across all TVS Holdings entities. Projects costs by tier and generates markdown report.

--- a/plugins/tvs-microsoft-deploy/commands/deploy-all.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-all.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Glob
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Full Platform Deployment
 
 Deploy all tenant-scoped resources through the control-plane planner (no manual phase sequencing).

--- a/plugins/tvs-microsoft-deploy/commands/deploy-azure.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-azure.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Glob
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Azure Infrastructure Deployment
 
 Deploys Azure infrastructure for TVS Holdings using Bicep templates. Provisions Key Vault (`kv-tvs-holdings`), Azure Functions (`func-tvs-ingest`), Static Web Apps (`stapp-broker-*`), and Application Insights for monitoring. All resources deployed to a single resource group with consistent tagging.

--- a/plugins/tvs-microsoft-deploy/commands/deploy-dataverse.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-dataverse.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Glob
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Dataverse + Power Platform ALM Deployment
 
 Deploys Microsoft Dataverse schema, Power Automate flows, and Copilot Studio assets through a governed ALM lifecycle. Includes unpack/pack/import operations, managed/unmanaged strategy, environment-variable and connection-reference validation, version promotion, and release gates.

--- a/plugins/tvs-microsoft-deploy/commands/deploy-fabric.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-fabric.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Glob
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Fabric Workspace Provisioning
 
 Provisions Microsoft Fabric workspaces and OneLake lakehouses for all TVS entities. Creates the six core workspaces (tvs, consulting, lobbi_platform, media, a3_archive, consolidated), deploys Spark notebooks, and establishes Dataverse shortcuts for real-time data access.

--- a/plugins/tvs-microsoft-deploy/commands/deploy-identity.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-identity.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Grep
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Entra ID Identity Deployment
 
 Provisions and configures Microsoft Entra ID (Azure AD) for TVS Holdings entities. Creates users, assigns Microsoft 365 licenses, configures conditional access policies, registers service principal applications, and sets up FIDO2 passwordless authentication.

--- a/plugins/tvs-microsoft-deploy/commands/deploy-portal.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-portal.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Glob
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Power Pages + Copilot Studio Deployment
 
 Deploys the TVS broker portal on Power Pages with integrated Stripe billing widget for subscription management (Starter $360/20hrs, Basic $640/40hrs, Advanced $1200/80hrs). Deploys Copilot Studio conversational bots for broker self-service and VA task intake.

--- a/plugins/tvs-microsoft-deploy/commands/deploy-teams.md
+++ b/plugins/tvs-microsoft-deploy/commands/deploy-teams.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Task
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Deploy Teams
 
 Provisions Microsoft Teams workspaces for TVS Holdings VAs with entity-specific channels, shared mailboxes, and HIPAA-compliant configuration for TVS tenant.

--- a/plugins/tvs-microsoft-deploy/commands/extract-a3.md
+++ b/plugins/tvs-microsoft-deploy/commands/extract-a3.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Glob
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # A3 Firebase Extraction
 
 CRITICAL PATH - WEEK 1 PRIORITY. Bulk extracts all data from the A3 Firebase database (brokers, commissions, carriers, contacts, activities) and loads it into the `tvs-a3-archive` OneLake lakehouse. This is the foundational data migration step for TAIA wind-down and carrier normalization.

--- a/plugins/tvs-microsoft-deploy/commands/identity-attestation.md
+++ b/plugins/tvs-microsoft-deploy/commands/identity-attestation.md
@@ -6,6 +6,8 @@ allowed-tools:
   - Read
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Identity Access Attestation
 
 Generates CSV + JSON audit artifacts for governance review and buyer due diligence.

--- a/plugins/tvs-microsoft-deploy/commands/identity-drift.md
+++ b/plugins/tvs-microsoft-deploy/commands/identity-drift.md
@@ -6,6 +6,8 @@ allowed-tools:
   - Read
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Identity Drift Detection
 
 Runs tenant identity drift scans for stale app credentials, orphaned service principals, and over-privileged Graph scopes.

--- a/plugins/tvs-microsoft-deploy/commands/normalize-carriers.md
+++ b/plugins/tvs-microsoft-deploy/commands/normalize-carriers.md
@@ -11,6 +11,8 @@ allowed-tools:
   - Task
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Normalize Carriers
 
 Carrier normalization sprint for TAIA FMO sale preparation. Deduplicates carrier names, normalizes commission structures, and maps agent hierarchies from A3 legacy data.

--- a/plugins/tvs-microsoft-deploy/commands/status-check.md
+++ b/plugins/tvs-microsoft-deploy/commands/status-check.md
@@ -8,6 +8,8 @@ allowed-tools:
   - Task
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # Status Check
 
 Read-only health validation driven by control-plane outputs.

--- a/plugins/tvs-microsoft-deploy/commands/taia-readiness.md
+++ b/plugins/tvs-microsoft-deploy/commands/taia-readiness.md
@@ -7,6 +7,8 @@ allowed-tools:
   - Grep
 ---
 
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
 # TAIA Readiness
 
 Assesses TAIA wind-down and target-state readiness using the same control-plane manifest model.

--- a/plugins/tvs-microsoft-deploy/docs/README.md
+++ b/plugins/tvs-microsoft-deploy/docs/README.md
@@ -1,0 +1,11 @@
+# TVS Microsoft Deploy Documentation Hub
+
+Use this index to navigate plugin documentation by domain.
+
+## Sections
+
+- [APIs](./apis/README.md) — Microsoft and external endpoint contracts.
+- [Skills](./skills/README.md) — skill inventory, execution recipes, and troubleshooting.
+- [CLI](./cli/README.md) — command contracts, examples, and failure handling.
+- [Architecture](./architecture/README.md) — platform diagrams, dependency graphs, and tenant model.
+- [Sales Playbooks](./sales/embedded-analytics-playbook.md) — customer-facing implementation narratives.

--- a/plugins/tvs-microsoft-deploy/docs/apis/README.md
+++ b/plugins/tvs-microsoft-deploy/docs/apis/README.md
@@ -1,0 +1,19 @@
+# API Guides
+
+## Microsoft Endpoints
+
+- Microsoft Graph (directory + user lifecycle)
+- Power Platform Admin APIs (solution/ALM deployment)
+- Fabric REST APIs (workspace, item, job execution)
+- SharePoint + Teams APIs for collaboration provisioning
+
+## Non-Microsoft Endpoints
+
+- Stripe webhooks and payout events
+- Firebase extract service endpoints
+- Paylocity sync endpoints
+
+## Guidance
+
+- Capture auth scopes and throttling guidance per endpoint.
+- Document request/response examples before production cutovers.

--- a/plugins/tvs-microsoft-deploy/docs/architecture/README.md
+++ b/plugins/tvs-microsoft-deploy/docs/architecture/README.md
@@ -1,0 +1,23 @@
+# Architecture Hub
+
+## Agent Topology
+
+Agents in `agents/` map to bounded responsibilities (identity, data, analytics, comms, platform).
+
+## Platform Diagrams
+
+- Control plane orchestrates phased deployments.
+- Azure hosts compute + secrets + portal experiences.
+- Power Platform and Fabric provide data + workflow + reporting layers.
+
+## Dependency Graphs
+
+- Identity is a hard prerequisite for all mutable deployments.
+- Data platform resources are prerequisites for analytics and reporting.
+- Collaboration automation depends on identity + data contracts.
+
+## Tenant Model
+
+- Single management tenant with entity-scoped resource partitioning.
+- Shared governance controls with per-entity policy overlays.
+- TAIA wind-down overlays run in constrained mode with archival safeguards.

--- a/plugins/tvs-microsoft-deploy/docs/cli/README.md
+++ b/plugins/tvs-microsoft-deploy/docs/cli/README.md
@@ -1,0 +1,28 @@
+# CLI Hub
+
+## Command Index
+
+Commands in `commands/` must define: purpose, required args, dry-run support, and rollback guidance.
+
+## Contract Expectations
+
+- Input parameters and defaults
+- Preconditions and safety checks
+- Side effects and output artifacts
+- Exit codes and error taxonomy
+
+## Examples
+
+Use command docs to mirror runtime patterns:
+
+```bash
+/tvs:deploy-all --env prod --dry-run
+/tvs:identity-drift --json
+/tvs:status-check --env test
+```
+
+## Failure Handling
+
+- Prefer explicit non-zero exits with actionable remediation.
+- Log dependency failures with upstream/downstream context.
+- Capture partial completion state for resumable deploys.

--- a/plugins/tvs-microsoft-deploy/docs/sales/embedded-analytics-playbook.md
+++ b/plugins/tvs-microsoft-deploy/docs/sales/embedded-analytics-playbook.md
@@ -1,0 +1,23 @@
+# Embedded Analytics Playbook
+
+## Objective
+
+Position embedded analytics as a revenue accelerant for broker workflows and consulting engagements.
+
+## Discovery Checklist
+
+- Confirm buyer reporting pain points and latency targets.
+- Identify required data domains (TVS core, consulting CRM, TAIA archive).
+- Align on compliance constraints for tenant-scoped access.
+
+## Packaging Strategy
+
+1. Foundation: baseline KPI dashboards with governed semantic model.
+2. Expansion: workflow-triggered insights in Teams and CRM surfaces.
+3. Premium: predictive alerts and tailored buyer due-diligence packs.
+
+## Delivery Motion
+
+- Week 1: baseline integration and stakeholder validation.
+- Week 2–3: expand semantic model and automate refresh pipelines.
+- Week 4+: operationalize alerting, adoption metrics, and QBR narrative.

--- a/plugins/tvs-microsoft-deploy/docs/skills/README.md
+++ b/plugins/tvs-microsoft-deploy/docs/skills/README.md
@@ -1,0 +1,24 @@
+# Skills Hub
+
+## Skill Index
+
+- `az-cli.md`
+- `graph-api.md`
+- `pac-cli.md`
+- `fabric-rest.md`
+- `power-automate-rest.md`
+- `firebase-extract.md`
+- `stripe-integration.md`
+
+## Usage Recipes
+
+1. Select environment and tenant context.
+2. Load credentials from Key Vault and verify token scopes.
+3. Execute dry-run or read-only checks before mutation commands.
+4. Persist outputs to control-plane artifacts for auditability.
+
+## Troubleshooting
+
+- Auth failures: refresh service principal secret or delegated token.
+- Rate limiting: backoff with retry jitter and batch APIs where possible.
+- Schema drift: run validation rules before applying ALM changes.

--- a/plugins/tvs-microsoft-deploy/skills/az-cli.md
+++ b/plugins/tvs-microsoft-deploy/skills/az-cli.md
@@ -4,6 +4,8 @@ description: This skill should be used when working with *.bicep files, infra/**
 version: 1.0.0
 ---
 
+> Docs Hub: [Skills Hub](../docs/skills/README.md#skill-index)
+
 # Azure CLI (az) Operations
 
 Complete reference for Azure resource management across TVS Holdings entities.

--- a/plugins/tvs-microsoft-deploy/skills/fabric-rest.md
+++ b/plugins/tvs-microsoft-deploy/skills/fabric-rest.md
@@ -4,6 +4,8 @@ description: This skill should be used when working with fabric/**, *.ipynb note
 version: 1.0.0
 ---
 
+> Docs Hub: [Skills Hub](../docs/skills/README.md#skill-index)
+
 # Microsoft Fabric REST API Operations
 
 Complete reference for Fabric REST API operations across TVS Holdings workspaces.

--- a/plugins/tvs-microsoft-deploy/skills/firebase-extract.md
+++ b/plugins/tvs-microsoft-deploy/skills/firebase-extract.md
@@ -4,6 +4,8 @@ description: This skill should be used when working with functions/firebase-**, 
 version: 1.0.0
 ---
 
+> Docs Hub: [Skills Hub](../docs/skills/README.md#skill-index)
+
 # Firebase Bulk Extraction (A3 Legacy System)
 
 Complete reference for extracting data from the A3 Archive Firebase/Firestore system and migrating to Microsoft Fabric OneLake.

--- a/plugins/tvs-microsoft-deploy/skills/graph-api.md
+++ b/plugins/tvs-microsoft-deploy/skills/graph-api.md
@@ -4,6 +4,8 @@ description: This skill should be used when working with identity/**, teams/**, 
 version: 1.0.0
 ---
 
+> Docs Hub: [Skills Hub](../docs/skills/README.md#skill-index)
+
 # Microsoft Graph API Operations
 
 Complete reference for Microsoft Graph API operations across TVS Holdings Entra ID tenancy.

--- a/plugins/tvs-microsoft-deploy/skills/pac-cli.md
+++ b/plugins/tvs-microsoft-deploy/skills/pac-cli.md
@@ -4,6 +4,8 @@ description: This skill should be used when working with *.solution files, datav
 version: 1.0.0
 ---
 
+> Docs Hub: [Skills Hub](../docs/skills/README.md#skill-index)
+
 # Power Platform CLI (pac) Operations
 
 Complete reference for Power Platform CLI operations across TVS Holdings environments.

--- a/plugins/tvs-microsoft-deploy/skills/power-automate-rest.md
+++ b/plugins/tvs-microsoft-deploy/skills/power-automate-rest.md
@@ -4,6 +4,8 @@ description: This skill should be used when working with flows/**, or *.flow.jso
 version: 1.0.0
 ---
 
+> Docs Hub: [Skills Hub](../docs/skills/README.md#skill-index)
+
 # Power Automate REST API Operations
 
 Complete reference for Power Automate flow management across TVS Holdings environments.

--- a/plugins/tvs-microsoft-deploy/skills/stripe-integration.md
+++ b/plugins/tvs-microsoft-deploy/skills/stripe-integration.md
@@ -4,6 +4,8 @@ description: This skill should be used when working with stripe/**, billing/**, 
 version: 1.0.0
 ---
 
+> Docs Hub: [Skills Hub](../docs/skills/README.md#skill-index)
+
 # Stripe Integration for TVS Holdings
 
 Complete reference for Stripe API operations supporting TVS Motor broker subscription tiers and VA time-tracking billing.


### PR DESCRIPTION
### Motivation

- Centralize plugin documentation into a single navigable hub to improve discoverability and consistency across commands, skills, and agents.
- Provide focused reference material for APIs, skills, CLI contracts, architecture, and a sales playbook to support runbooks and handoffs.

### Description

- Added `plugins/tvs-microsoft-deploy/docs/` with hub index and section files: `docs/README.md`, `docs/apis/README.md`, `docs/skills/README.md`, `docs/cli/README.md`, `docs/architecture/README.md`, and `docs/sales/embedded-analytics-playbook.md` as seeded content. 
- Seeded guidance and recipes for Microsoft and non-Microsoft APIs, skill usage/troubleshooting, CLI command contracts/examples, architecture/topology and tenant model, and a sales playbook for embedded analytics. 
- Injected a consistent `Docs Hub` backlink into every markdown under `plugins/tvs-microsoft-deploy/commands/`, `plugins/tvs-microsoft-deploy/skills/`, and `plugins/tvs-microsoft-deploy/agents/` using relative paths to the appropriate hub anchors (e.g. `../docs/cli/README.md#command-index`, `../docs/skills/README.md#skill-index`, `../docs/architecture/README.md#agent-topology`).
- This PR is documentation-only and does not change runtime code paths or behavior.

### Testing

- Ran an automated verification script (`python3`) that scanned `commands`, `skills`, and `agents` markdown files and confirmed backlink coverage: `commands: 15/15`, `skills: 7/7`, `agents: 12/12`.
- Spot-checked representative files to confirm the backlink lines are present (examples: `commands/deploy-all.md`, `skills/az-cli.md`, `agents/azure-agent.md`).
- Prepared PR metadata (title and body) for review; all automated checks above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7af52a54832aa53711b92abb8cf4)