### PR TITLE
Add Excel workbook quality toolkit and TAIA scoring gates

### DIFF
--- a/plugins/tvs-microsoft-deploy/commands/normalize-carriers.md
+++ b/plugins/tvs-microsoft-deploy/commands/normalize-carriers.md
@@ -94,6 +94,31 @@ echo "Carrier records must be present in a3_archive/ lakehouse"
 - Document mapping decisions and confidence levels
 - Export summary to taia-sale-prep workflow
 
+
+## Workbook quality gates (required)
+
+Before Phase 4 testing, score workbook quality gates for carrier mapping and commission reconciliation artifacts:
+
+```bash
+python scripts/excel/analyze_workbook.py \
+  --workbook data/carriers/carrier_mapping.xlsx \
+  --profile carrier_mapping \
+  --output plugins/tvs-microsoft-deploy/control-plane/out/carrier_mapping.quality.json
+
+python scripts/excel/analyze_workbook.py \
+  --workbook data/carriers/commission_reconciliation.xlsx \
+  --profile commission_reconciliation \
+  --output plugins/tvs-microsoft-deploy/control-plane/out/commission_reconciliation.quality.json
+```
+
+Normalize and export only when both workbook scores are >= 90 and all workbook gates pass:
+
+```bash
+python scripts/excel/normalize_workbook.py --input data/carriers/carrier_mapping.xlsx --output out/carrier_mapping.normalized.xlsx
+python scripts/excel/export_to_dataverse.py --workbook out/carrier_mapping.normalized.xlsx --sheet CarrierMap --table tvs_carriermap --output out/carrier_mapping.dataverse.ndjson
+python scripts/excel/export_to_fabric.py --workbook out/carrier_mapping.normalized.xlsx --sheet CarrierMap --output-dir out/fabric_carrier_mapping
+```
+
 ## Output
 
 ```

--- a/plugins/tvs-microsoft-deploy/commands/taia-readiness.md
+++ b/plugins/tvs-microsoft-deploy/commands/taia-readiness.md
@@ -50,7 +50,14 @@ python plugins/tvs-microsoft-deploy/scripts/taia_readiness_checks.py \
   --thresholds plugins/tvs-microsoft-deploy/fabric/quality/taia_thresholds.json
 ```
 
-The command fails readiness when carrier counts, commission variance, or agent hierarchy consistency breach policy thresholds.
+The command fails readiness when carrier counts, commission variance, agent hierarchy consistency, workbook quality score, or workbook gate pass-rate breach policy thresholds. The script emits an explicit 0-100 readiness score for review boards.
+
+Workbook gates should be generated first and summarized into metrics:
+
+```bash
+python scripts/excel/analyze_workbook.py --workbook data/carriers/commission_reconciliation.xlsx --profile commission_reconciliation --output plugins/tvs-microsoft-deploy/control-plane/out/commission_reconciliation.quality.json
+python scripts/excel/analyze_workbook.py --workbook data/carriers/carrier_mapping.xlsx --profile carrier_mapping --output plugins/tvs-microsoft-deploy/control-plane/out/carrier_mapping.quality.json
+```
 
 ## M365 operational output
 

--- a/plugins/tvs-microsoft-deploy/excel/README.md
+++ b/plugins/tvs-microsoft-deploy/excel/README.md
@@ -1,0 +1,9 @@
+# Excel Processing Toolkit
+
+Provides workbook schema profiles, chunked parsers, and a validation engine used by TAIA readiness gates.
+
+## Included modules
+
+- `schema_profiles.py` — profile definitions for `commission_reconciliation`, `carrier_mapping`, and `buyer_packet_support` workbook families.
+- `parsers.py` — read-only, chunked parsing utilities designed to avoid loading full sheets into memory.
+- `validation_engine.py` — validation checks for formulas, named ranges, hidden sheets, merged cells, and type drift with weighted scoring.

--- a/plugins/tvs-microsoft-deploy/excel/__init__.py
+++ b/plugins/tvs-microsoft-deploy/excel/__init__.py
@@ -1,0 +1,6 @@
+"""Excel quality toolkit for TVS Microsoft deploy workflows."""
+
+from .schema_profiles import PROFILES, get_profile
+from .validation_engine import validate_workbook
+
+__all__ = ["PROFILES", "get_profile", "validate_workbook"]

--- a/plugins/tvs-microsoft-deploy/excel/parsers.py
+++ b/plugins/tvs-microsoft-deploy/excel/parsers.py
@@ -1,0 +1,71 @@
+"""Chunked, memory-safe workbook parsing utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Generator, Iterable, List
+
+from openpyxl import load_workbook
+
+
+@dataclass
+class SheetChunk:
+    sheet_name: str
+    rows: List[Dict[str, object]]
+    row_offset: int
+
+
+def _normalize_headers(headers: Iterable[object]) -> List[str]:
+    normalized: List[str] = []
+    for idx, header in enumerate(headers):
+        label = str(header).strip() if header is not None else ""
+        normalized.append(label or f"column_{idx + 1}")
+    return normalized
+
+
+def parse_sheet_in_chunks(workbook_path: str | Path, sheet_name: str, chunk_size: int = 500) -> Generator[SheetChunk, None, None]:
+    """Yield row dictionaries in chunk-sized batches to avoid loading entire sheets."""
+    workbook = load_workbook(filename=str(workbook_path), read_only=True, data_only=False)
+    try:
+        sheet = workbook[sheet_name]
+        rows = sheet.iter_rows(values_only=True)
+        headers = _normalize_headers(next(rows, []))
+        batch: List[Dict[str, object]] = []
+        start_row = 2
+        row_cursor = 2
+
+        for row in rows:
+            record = {headers[idx]: row[idx] if idx < len(row) else None for idx in range(len(headers))}
+            batch.append(record)
+            if len(batch) >= chunk_size:
+                yield SheetChunk(sheet_name=sheet_name, rows=batch, row_offset=start_row)
+                batch = []
+                start_row = row_cursor + 1
+            row_cursor += 1
+
+        if batch:
+            yield SheetChunk(sheet_name=sheet_name, rows=batch, row_offset=start_row)
+    finally:
+        workbook.close()
+
+
+def profile_snapshot(workbook_path: str | Path) -> Dict[str, object]:
+    """Capture a workbook metadata snapshot without materializing all rows."""
+    workbook = load_workbook(filename=str(workbook_path), read_only=True, data_only=False)
+    try:
+        return {
+            "sheet_names": list(workbook.sheetnames),
+            "defined_names": sorted(name for name in workbook.defined_names.keys()),
+            "hidden_sheets": [
+                ws.title
+                for ws in workbook.worksheets
+                if getattr(ws, "sheet_state", "visible") != "visible"
+            ],
+            "merged_cell_ranges": {
+                ws.title: [str(rng) for rng in ws.merged_cells.ranges]
+                for ws in workbook.worksheets
+            },
+        }
+    finally:
+        workbook.close()

--- a/plugins/tvs-microsoft-deploy/excel/schema_profiles.py
+++ b/plugins/tvs-microsoft-deploy/excel/schema_profiles.py
@@ -1,0 +1,82 @@
+"""Schema profiles for common TAIA workbook types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class ColumnRule:
+    name: str
+    required: bool = True
+    expected_type: str = "string"
+
+
+@dataclass(frozen=True)
+class WorkbookProfile:
+    id: str
+    description: str
+    required_sheets: List[str]
+    required_named_ranges: List[str]
+    formula_columns: List[str]
+    columns_by_sheet: Dict[str, List[ColumnRule]]
+
+
+PROFILES: Dict[str, WorkbookProfile] = {
+    "commission_reconciliation": WorkbookProfile(
+        id="commission_reconciliation",
+        description="Commission source-to-modeled reconciliation workbook.",
+        required_sheets=["Reconciliation", "CarrierSummary", "Validation"],
+        required_named_ranges=["recon_period", "commission_total_source", "commission_total_modeled"],
+        formula_columns=["variance", "variance_pct"],
+        columns_by_sheet={
+            "Reconciliation": [
+                ColumnRule("carrier_id", expected_type="string"),
+                ColumnRule("policy_id", expected_type="string"),
+                ColumnRule("commission_source", expected_type="number"),
+                ColumnRule("commission_modeled", expected_type="number"),
+                ColumnRule("variance", expected_type="formula"),
+                ColumnRule("variance_pct", expected_type="formula"),
+            ]
+        },
+    ),
+    "carrier_mapping": WorkbookProfile(
+        id="carrier_mapping",
+        description="Canonical carrier mapping and fuzzy-merge decisions.",
+        required_sheets=["CarrierMap", "Exceptions"],
+        required_named_ranges=["effective_date", "owner"],
+        formula_columns=["confidence_score"],
+        columns_by_sheet={
+            "CarrierMap": [
+                ColumnRule("carrier_variant", expected_type="string"),
+                ColumnRule("carrier_canonical", expected_type="string"),
+                ColumnRule("mapping_method", expected_type="string"),
+                ColumnRule("confidence_score", expected_type="formula"),
+            ]
+        },
+    ),
+    "buyer_packet_support": WorkbookProfile(
+        id="buyer_packet_support",
+        description="Buyer packet workbook with due-diligence support tabs.",
+        required_sheets=["BuyerPacket", "Narrative", "Checks"],
+        required_named_ranges=["buyer_name", "snapshot_date", "prepared_by"],
+        formula_columns=["delta_to_target", "coverage_ratio"],
+        columns_by_sheet={
+            "BuyerPacket": [
+                ColumnRule("metric", expected_type="string"),
+                ColumnRule("actual", expected_type="number"),
+                ColumnRule("target", expected_type="number"),
+                ColumnRule("delta_to_target", expected_type="formula"),
+            ]
+        },
+    ),
+}
+
+
+def get_profile(profile_id: str) -> WorkbookProfile:
+    """Return a workbook profile by id."""
+    if profile_id not in PROFILES:
+        valid = ", ".join(sorted(PROFILES))
+        raise ValueError(f"Unknown profile '{profile_id}'. Expected one of: {valid}")
+    return PROFILES[profile_id]

--- a/plugins/tvs-microsoft-deploy/excel/validation_engine.py
+++ b/plugins/tvs-microsoft-deploy/excel/validation_engine.py
@@ -1,0 +1,136 @@
+"""Workbook validation engine for TAIA quality gates."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import asdict
+from pathlib import Path
+from typing import Dict, List
+
+from openpyxl import load_workbook
+
+from .parsers import parse_sheet_in_chunks, profile_snapshot
+from .schema_profiles import WorkbookProfile, get_profile
+
+
+CHECK_WEIGHTS = {
+    "required_sheets": 0.25,
+    "named_ranges": 0.2,
+    "formula_integrity": 0.2,
+    "hidden_sheet_policy": 0.1,
+    "merged_cell_policy": 0.1,
+    "type_drift": 0.15,
+}
+
+
+def _value_type(value) -> str:
+    if value is None:
+        return "empty"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str) and value.startswith("="):
+        return "formula"
+    return "string"
+
+
+def _validate_types(workbook_path: Path, profile: WorkbookProfile) -> List[str]:
+    failures: List[str] = []
+    for sheet_name, rules in profile.columns_by_sheet.items():
+        expected_by_col = {rule.name: rule.expected_type for rule in rules}
+        type_counts = defaultdict(lambda: defaultdict(int))
+
+        for chunk in parse_sheet_in_chunks(workbook_path, sheet_name, chunk_size=250):
+            for row in chunk.rows:
+                for col, expected in expected_by_col.items():
+                    value = row.get(col)
+                    observed = _value_type(value)
+                    if observed != "empty":
+                        type_counts[col][observed] += 1
+                    if expected != observed and observed != "empty":
+                        failures.append(
+                            f"type drift in {sheet_name}.{col} row~{chunk.row_offset}: expected {expected}, observed {observed}"
+                        )
+
+        for col, observed_counts in type_counts.items():
+            if not observed_counts:
+                continue
+            dominant = max(observed_counts, key=observed_counts.get)
+            if dominant != expected_by_col[col]:
+                failures.append(
+                    f"dominant type drift in {sheet_name}.{col}: expected {expected_by_col[col]}, observed {dominant}"
+                )
+    return failures
+
+
+def validate_workbook(workbook_path: str | Path, profile_id: str) -> Dict[str, object]:
+    path = Path(workbook_path)
+    profile = get_profile(profile_id)
+    snapshot = profile_snapshot(path)
+
+    workbook = load_workbook(filename=str(path), read_only=True, data_only=False)
+    try:
+        failures: Dict[str, List[str]] = defaultdict(list)
+        score_breakdown: Dict[str, float] = {}
+
+        missing_sheets = sorted(set(profile.required_sheets) - set(snapshot["sheet_names"]))
+        if missing_sheets:
+            failures["required_sheets"].append(f"missing sheets: {', '.join(missing_sheets)}")
+        score_breakdown["required_sheets"] = 1.0 if not missing_sheets else 0.0
+
+        missing_names = sorted(set(profile.required_named_ranges) - set(snapshot["defined_names"]))
+        if missing_names:
+            failures["named_ranges"].append(f"missing named ranges: {', '.join(missing_names)}")
+        score_breakdown["named_ranges"] = 1.0 if not missing_names else 0.0
+
+        formula_failures: List[str] = []
+        for sheet_name, rules in profile.columns_by_sheet.items():
+            if sheet_name not in workbook.sheetnames:
+                continue
+            expected_formula_cols = {r.name for r in rules if r.expected_type == "formula"}
+            ws = workbook[sheet_name]
+            header_cells = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+            header_index = {str(name): idx for idx, name in enumerate(header_cells) if name is not None}
+            for formula_col in expected_formula_cols:
+                idx = header_index.get(formula_col)
+                if idx is None:
+                    formula_failures.append(f"{sheet_name}.{formula_col} missing from header")
+                    continue
+                sample = next(ws.iter_rows(min_row=2, min_col=idx + 1, max_col=idx + 1, max_row=2), None)
+                if sample and (sample[0].value is None or not str(sample[0].value).startswith("=")):
+                    formula_failures.append(f"{sheet_name}.{formula_col} row 2 missing formula")
+        if formula_failures:
+            failures["formula_integrity"].extend(formula_failures)
+        score_breakdown["formula_integrity"] = 1.0 if not formula_failures else 0.0
+
+        hidden = snapshot["hidden_sheets"]
+        if hidden:
+            failures["hidden_sheet_policy"].append(f"hidden sheets present: {', '.join(hidden)}")
+        score_breakdown["hidden_sheet_policy"] = 1.0 if not hidden else 0.0
+
+        merged_failures = [
+            f"{sheet}: merged cells {', '.join(ranges)}"
+            for sheet, ranges in snapshot["merged_cell_ranges"].items()
+            if ranges
+        ]
+        if merged_failures:
+            failures["merged_cell_policy"].extend(merged_failures)
+        score_breakdown["merged_cell_policy"] = 1.0 if not merged_failures else 0.0
+
+        type_drift_failures = _validate_types(path, profile)
+        if type_drift_failures:
+            failures["type_drift"].extend(type_drift_failures[:50])
+        score_breakdown["type_drift"] = 1.0 if not type_drift_failures else 0.0
+
+        weighted_score = sum(score_breakdown[name] * CHECK_WEIGHTS[name] for name in CHECK_WEIGHTS)
+        return {
+            "profile": asdict(profile),
+            "checks": score_breakdown,
+            "weighted_score": round(weighted_score * 100, 2),
+            "failures": dict(failures),
+            "passed": not failures,
+            "snapshot": snapshot,
+        }
+    finally:
+        workbook.close()

--- a/plugins/tvs-microsoft-deploy/fabric/quality/current_metrics.sample.json
+++ b/plugins/tvs-microsoft-deploy/fabric/quality/current_metrics.sample.json
@@ -2,5 +2,7 @@
   "carrier_count": 29,
   "commission_total_source": 1823400.22,
   "commission_total_modeled": 1819950.10,
-  "agent_hierarchy_consistency": 0.998
+  "agent_hierarchy_consistency": 0.998,
+  "workbook_quality_score": 96.8,
+  "workbook_quality_gate_pass_rate": 1.0
 }

--- a/plugins/tvs-microsoft-deploy/fabric/quality/taia_thresholds.json
+++ b/plugins/tvs-microsoft-deploy/fabric/quality/taia_thresholds.json
@@ -1,5 +1,7 @@
 {
   "carrier_count_min": 25,
   "commission_total_variance_pct_max": 0.02,
-  "agent_hierarchy_consistency_min": 0.995
+  "agent_hierarchy_consistency_min": 0.995,
+  "workbook_quality_score_min": 90.0,
+  "workbook_quality_gate_pass_rate_min": 1.0
 }

--- a/plugins/tvs-microsoft-deploy/scripts/taia_readiness_checks.py
+++ b/plugins/tvs-microsoft-deploy/scripts/taia_readiness_checks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-fast TAIA readiness quality checks for Fabric outputs."""
+"""Fail-fast TAIA readiness quality checks for Fabric and workbook outputs."""
 
 import argparse
 import json
@@ -14,31 +14,63 @@ def load_json(path: Path):
 
 def evaluate(metrics: dict, thresholds: dict):
     failures = []
+    score = 0.0
+    max_score = 0.0
 
     carrier_count = metrics.get("carrier_count", 0)
+    max_score += 25
     if carrier_count < thresholds["carrier_count_min"]:
         failures.append(
             f"carrier_count {carrier_count} < min {thresholds['carrier_count_min']}"
         )
+    else:
+        score += 25
 
     commission_source = float(metrics.get("commission_total_source", 0.0))
     commission_modeled = float(metrics.get("commission_total_modeled", 0.0))
     variance = abs(commission_modeled - commission_source)
     variance_pct = (variance / commission_source) if commission_source else 1.0
+    max_score += 25
     if variance_pct > thresholds["commission_total_variance_pct_max"]:
         failures.append(
             "commission variance "
             f"{variance_pct:.4f} > max {thresholds['commission_total_variance_pct_max']:.4f}"
         )
+    else:
+        score += 25
 
     hierarchy_consistency = float(metrics.get("agent_hierarchy_consistency", 0.0))
+    max_score += 20
     if hierarchy_consistency < thresholds["agent_hierarchy_consistency_min"]:
         failures.append(
             "agent_hierarchy_consistency "
             f"{hierarchy_consistency:.4f} < min {thresholds['agent_hierarchy_consistency_min']:.4f}"
         )
+    else:
+        score += 20
 
-    return failures
+    workbook_quality_score = float(metrics.get("workbook_quality_score", 0.0))
+    workbook_gate_min = float(thresholds.get("workbook_quality_score_min", 90.0))
+    max_score += 20
+    if workbook_quality_score < workbook_gate_min:
+        failures.append(
+            f"workbook_quality_score {workbook_quality_score:.2f} < min {workbook_gate_min:.2f}"
+        )
+    else:
+        score += 20
+
+    workbook_gate_pass_rate = float(metrics.get("workbook_quality_gate_pass_rate", 0.0))
+    gate_pass_rate_min = float(thresholds.get("workbook_quality_gate_pass_rate_min", 1.0))
+    max_score += 10
+    if workbook_gate_pass_rate < gate_pass_rate_min:
+        failures.append(
+            "workbook_quality_gate_pass_rate "
+            f"{workbook_gate_pass_rate:.2f} < min {gate_pass_rate_min:.2f}"
+        )
+    else:
+        score += 10
+
+    return failures, round((score / max_score) * 100.0, 2)
 
 
 def main():
@@ -54,7 +86,9 @@ def main():
     metrics = load_json(Path(args.metrics))
     thresholds = load_json(Path(args.thresholds))
 
-    failures = evaluate(metrics, thresholds)
+    failures, readiness_score = evaluate(metrics, thresholds)
+    print(f"TAIA readiness score: {readiness_score:.2f}")
+
     if failures:
         print("TAIA readiness FAILED:")
         for failure in failures:

--- a/scripts/excel/analyze_workbook.py
+++ b/scripts/excel/analyze_workbook.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Analyze workbook quality using TVS excel validation profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugins" / "tvs-microsoft-deploy"
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from excel.validation_engine import validate_workbook
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workbook", required=True, help="Path to workbook .xlsx file")
+    parser.add_argument("--profile", required=True, help="Profile id")
+    parser.add_argument("--output", help="Optional JSON output path")
+    args = parser.parse_args()
+
+    result = validate_workbook(args.workbook, args.profile)
+    rendered = json.dumps(result, indent=2)
+    if args.output:
+        Path(args.output).write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    if not result["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/excel/export_to_dataverse.py
+++ b/scripts/excel/export_to_dataverse.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Export workbook chunks to Dataverse-ready NDJSON payloads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugins" / "tvs-microsoft-deploy"
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from excel.parsers import parse_sheet_in_chunks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workbook", required=True)
+    parser.add_argument("--sheet", required=True)
+    parser.add_argument("--table", required=True, help="Dataverse target table")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with out_path.open("w", encoding="utf-8") as handle:
+        for chunk in parse_sheet_in_chunks(args.workbook, args.sheet, chunk_size=300):
+            for row in chunk.rows:
+                handle.write(json.dumps({"table": args.table, "payload": row}) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/excel/export_to_fabric.py
+++ b/scripts/excel/export_to_fabric.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Export workbook chunks to Fabric staging JSON files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugins" / "tvs-microsoft-deploy"
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from excel.parsers import parse_sheet_in_chunks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workbook", required=True)
+    parser.add_argument("--sheet", required=True)
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for chunk in parse_sheet_in_chunks(args.workbook, args.sheet, chunk_size=500):
+        part_path = out_dir / f"{args.sheet.lower()}_part_{chunk.row_offset:06d}.json"
+        part_path.write_text(json.dumps(chunk.rows, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/excel/normalize_workbook.py
+++ b/scripts/excel/normalize_workbook.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Normalize workbook field names and string content for downstream export."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+
+def normalize_header(value: object) -> object:
+    if value is None:
+        return value
+    return str(value).strip().lower().replace(" ", "_")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    wb = load_workbook(args.input)
+    try:
+        for ws in wb.worksheets:
+            for cell in ws[1]:
+                cell.value = normalize_header(cell.value)
+            for row in ws.iter_rows(min_row=2):
+                for cell in row:
+                    if isinstance(cell.value, str):
+                        cell.value = cell.value.strip()
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        wb.save(args.output)
+    finally:
+        wb.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a reusable, memory-safe Excel processing toolkit to validate TAIA-related workbooks before normalization/export. 
- Make workbook quality explicit and enforceable as part of the `tvs:normalize-carriers` flow and overall TAIA readiness scoring. 

### Description

- Added `plugins/tvs-microsoft-deploy/excel/` with `schema_profiles.py` (profiles for `commission_reconciliation`, `carrier_mapping`, `buyer_packet_support`), `parsers.py` (chunked, read-only parsing and `profile_snapshot`), and `validation_engine.py` (checks for formulas, named ranges, hidden sheets, merged cells, type drift and weighted scoring). 
- Added operational scripts under `scripts/excel/`: `analyze_workbook.py`, `normalize_workbook.py`, `export_to_dataverse.py`, and `export_to_fabric.py` to analyze, normalize, and stream workbook data in memory-safe chunks. 
- Integrated workbook gates into `plugins/tvs-microsoft-deploy/commands/normalize-carriers.md` with explicit `analyze -> normalize -> export` commands and updated `plugins/tvs-microsoft-deploy/commands/taia-readiness.md` to require workbook metrics and emit a 0–100 readiness score. 
- Extended TAIA thresholding and sample metrics (`fabric/quality/taia_thresholds.json`, `fabric/quality/current_metrics.sample.json`) and updated `plugins/tvs-microsoft-deploy/scripts/taia_readiness_checks.py` to include workbook quality score and gate pass-rate in readiness evaluation.

### Testing

- Compiled Python modules with `python -m py_compile plugins/tvs-microsoft-deploy/excel/*.py scripts/excel/*.py plugins/tvs-microsoft-deploy/scripts/taia_readiness_checks.py` and there were no compile errors. 
- Executed the updated readiness script with the sample metrics using `python plugins/tvs-microsoft-deploy/scripts/taia_readiness_checks.py --metrics plugins/tvs-microsoft-deploy/fabric/quality/current_metrics.sample.json --thresholds plugins/tvs-microsoft-deploy/fabric/quality/taia_thresholds.json` which printed a readiness score and passed (exit 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7aec9978832aaeb7b075c0330c8b)