### PR TITLE
Add API contract tests and governance PreToolUse hooks for tvs-microsoft-deploy

### DIFF
--- a/docs/governance/control-matrix.md
+++ b/docs/governance/control-matrix.md
@@ -1,0 +1,18 @@
+# TVS Microsoft Deploy Governance Control Matrix
+
+This matrix maps governance controls to executable safeguards in the repository and defines required evidence artifacts for audits and client assurance.
+
+| Control ID | Risk Addressed | Implementation (scripts/hooks/commands) | Execution Command(s) | Required Evidence Artifacts |
+|---|---|---|---|---|
+| GOV-001 | Scope/permission misuse in Microsoft identity workflows | `plugins/tvs-microsoft-deploy/hooks/scope-permission-misuse-check.sh`, `plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py`, `plugins/tvs-microsoft-deploy/hooks/identity-policy-engine.sh` | `python3 plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py --json` | JSON findings output, CAB approval record for any high-privilege scope override, run timestamp |
+| GOV-002 | Tenant drift across Azure and Dataverse environments | `plugins/tvs-microsoft-deploy/hooks/tenant-drift-check.sh`, `plugins/tvs-microsoft-deploy/hooks/tenant-isolation-validator.sh`, `plugins/tvs-microsoft-deploy/scripts/identity_drift_detect.py` | `python3 plugins/tvs-microsoft-deploy/scripts/identity_drift_detect.py --help` (or operational runbook command) | Tenant diff report, approved target tenant list, deployment job logs |
+| GOV-003 | Unsafe destructive calls (data/resource deletion) | `plugins/tvs-microsoft-deploy/hooks/unsafe-destructive-call-check.sh`, `plugins/tvs-microsoft-deploy/commands/deploy-all.md`, `plugins/tvs-microsoft-deploy/commands/deploy-azure.md` | Guardrail enforced automatically through PreToolUse hooks during `az`/`pac`/`curl` operations | Change window approval, command transcript with guardrail pass/deny result, rollback plan reference |
+| GOV-004 | Missing audit metadata on mutating changes | `plugins/tvs-microsoft-deploy/hooks/audit-metadata-check.sh`, `plugins/tvs-microsoft-deploy/scripts/m365_operational_update.py`, `plugins/tvs-microsoft-deploy/scripts/power_platform_alm.py` | Include `--change-ticket`, `--run-id`, `--requested-by` and/or `X-Audit-*` headers in command invocations | Run metadata manifest, ticket reference, operator identity record |
+| GOV-005 | Contract drift in third-party APIs (Graph/Fabric/Dataverse/Planner/Stripe/Firebase) | `plugins/tvs-microsoft-deploy/tests/contract/test_api_contracts.py`, `plugins/tvs-microsoft-deploy/tests/contract/README.md` | `pytest plugins/tvs-microsoft-deploy/tests/contract/test_api_contracts.py -q` | CI test report, sanitized response samples, defect ticket IDs for failures |
+
+## Audit packaging checklist
+
+1. Export hook execution logs for all guarded deployment sessions.
+2. Preserve command transcripts showing metadata and tenant context.
+3. Attach contract-test reports to release records.
+4. Store all artifacts in immutable release evidence storage with retention per policy.

--- a/plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json
+++ b/plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tvs-microsoft-deploy",
   "version": "1.0.0",
-  "description": "Consul (Forerunner) - Enterprise Microsoft ecosystem orchestrator for TVS (Trusted Virtual Solutions) multi-entity multi-tenant deployment. 12 agents, 13 commands, 7 skills, 5 hooks, 5 workflows.",
+  "description": "Consul (Forerunner) - Enterprise Microsoft ecosystem orchestrator for TVS (Trusted Virtual Solutions) multi-entity multi-tenant deployment. 12 agents, 13 commands, 7 skills, 9 hooks, 5 workflows.",
   "author": {
     "name": "Markus Ahling",
     "email": "markus@lobbi.io"
@@ -89,6 +89,22 @@
       {
         "matcher": "Bash",
         "command": "hooks/hipaa-config-guard.sh"
+      },
+      {
+        "matcher": "Bash",
+        "command": "hooks/scope-permission-misuse-check.sh"
+      },
+      {
+        "matcher": "Bash",
+        "command": "hooks/tenant-drift-check.sh"
+      },
+      {
+        "matcher": "Bash",
+        "command": "hooks/unsafe-destructive-call-check.sh"
+      },
+      {
+        "matcher": "Bash",
+        "command": "hooks/audit-metadata-check.sh"
       }
     ]
   },

--- a/plugins/tvs-microsoft-deploy/hooks/audit-metadata-check.sh
+++ b/plugins/tvs-microsoft-deploy/hooks/audit-metadata-check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# PreToolUse hook - requires audit metadata for mutating commands.
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ "$TOOL_NAME" != "Bash" ] || [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if echo "$COMMAND" | grep -qE '^\s*(az|pac|curl|python3\s+plugins/tvs-microsoft-deploy/scripts/)'; then
+  if ! echo "$COMMAND" | grep -qE '(--change-ticket|--run-id|--requested-by|X-Audit-Run-Id|X-Change-Ticket)'; then
+    if [ "${ALLOW_MISSING_AUDIT_METADATA:-false}" != "true" ]; then
+      echo "BLOCKED: missing audit metadata on mutating/infrastructure command." >&2
+      echo "Include --change-ticket/--run-id/--requested-by or required X-Audit-* headers." >&2
+      exit 2
+    fi
+  fi
+fi
+
+exit 0

--- a/plugins/tvs-microsoft-deploy/hooks/scope-permission-misuse-check.sh
+++ b/plugins/tvs-microsoft-deploy/hooks/scope-permission-misuse-check.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# PreToolUse hook - blocks broad scope/permission escalation patterns.
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ "$TOOL_NAME" != "Bash" ] || [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if echo "$COMMAND" | grep -qiE '(Directory\.ReadWrite\.All|RoleManagement\.ReadWrite\.Directory|User\.ReadWrite\.All|Application\.ReadWrite\.All|--allow-no-subscriptions|--consent-type\s+AllPrincipals)'; then
+  if [ "${ALLOW_HIGH_PRIVILEGE_SCOPES:-false}" != "true" ]; then
+    echo "BLOCKED: potential scope/permission misuse detected." >&2
+    echo "Set ALLOW_HIGH_PRIVILEGE_SCOPES=true only with CAB approval evidence." >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/plugins/tvs-microsoft-deploy/hooks/tenant-drift-check.sh
+++ b/plugins/tvs-microsoft-deploy/hooks/tenant-drift-check.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# PreToolUse hook - blocks tenant drift between configured and active tenant context.
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ "$TOOL_NAME" != "Bash" ] || [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if ! echo "$COMMAND" | grep -qE '^\s*(az|pac)\s'; then
+  exit 0
+fi
+
+TARGET_TENANT=$(echo "$COMMAND" | sed -nE 's/.*--tenant[= ]([^ ]+).*/\1/p' | head -n 1)
+EXPECTED_TENANT="${AZURE_TENANT_ID:-}"
+
+if [ -z "$EXPECTED_TENANT" ]; then
+  echo "BLOCKED: AZURE_TENANT_ID is required for tenant drift validation." >&2
+  exit 2
+fi
+
+if [ -n "$TARGET_TENANT" ] && [ "$TARGET_TENANT" != "$EXPECTED_TENANT" ]; then
+  echo "BLOCKED: tenant drift detected. command tenant=$TARGET_TENANT expected=$EXPECTED_TENANT" >&2
+  exit 2
+fi
+
+if [ -n "${DATAVERSE_ENV_ID:-}" ] && echo "$COMMAND" | grep -qE 'pac\s+(solution|org)'; then
+  if ! echo "$COMMAND" | grep -q -- "$DATAVERSE_ENV_ID"; then
+    echo "BLOCKED: Dataverse environment drift. expected environment $DATAVERSE_ENV_ID" >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/plugins/tvs-microsoft-deploy/hooks/unsafe-destructive-call-check.sh
+++ b/plugins/tvs-microsoft-deploy/hooks/unsafe-destructive-call-check.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PreToolUse hook - blocks destructive operations unless explicitly approved.
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ "$TOOL_NAME" != "Bash" ] || [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+DESTRUCTIVE_PATTERN='(az[[:space:]].*(delete|purge)|pac[[:space:]].*(solution[[:space:]]+delete|org[[:space:]]+delete)|curl[[:space:]].*-X[[:space:]]*(DELETE|PATCH).*(graph\.microsoft\.com|api\.stripe\.com|firebase)|rm[[:space:]]+-rf[[:space:]]+(plugins/tvs-microsoft-deploy|/prod|/production))'
+if echo "$COMMAND" | grep -qiE "$DESTRUCTIVE_PATTERN"; then
+  if [ "${ALLOW_DESTRUCTIVE_CALLS:-false}" != "true" ]; then
+    echo "BLOCKED: unsafe destructive call detected." >&2
+    echo "Set ALLOW_DESTRUCTIVE_CALLS=true only for approved change windows." >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/plugins/tvs-microsoft-deploy/tests/contract/README.md
+++ b/plugins/tvs-microsoft-deploy/tests/contract/README.md
@@ -1,0 +1,34 @@
+# API Contract Tests
+
+This suite validates high-level response contracts for the platform APIs consumed by `tvs-microsoft-deploy`:
+
+- Microsoft Graph
+- Microsoft Fabric
+- Dataverse Web API
+- Microsoft Planner
+- Stripe
+- Firebase
+
+## Run
+
+```bash
+pytest plugins/tvs-microsoft-deploy/tests/contract/test_api_contracts.py -q
+```
+
+## Required environment variables
+
+- `GRAPH_BASE_URL`, `GRAPH_TOKEN`
+- `FABRIC_BASE_URL`, `FABRIC_TOKEN`
+- `DATAVERSE_BASE_URL`, `DATAVERSE_TOKEN`
+- `PLANNER_BASE_URL`, `PLANNER_TOKEN`
+- `STRIPE_BASE_URL`, `STRIPE_TOKEN`
+- `FIREBASE_BASE_URL`, `FIREBASE_TOKEN`
+
+## Evidence artifacts
+
+For audit/client assurance, capture and archive:
+
+1. `pytest` console output (timestamped)
+2. CI run URL
+3. Sanitized API response samples (remove secrets/PII)
+4. Any contract failure triage ticket IDs

--- a/plugins/tvs-microsoft-deploy/tests/contract/test_api_contracts.py
+++ b/plugins/tvs-microsoft-deploy/tests/contract/test_api_contracts.py
@@ -1,0 +1,130 @@
+"""Contract tests for external APIs used by tvs-microsoft-deploy.
+
+These tests validate a narrow response shape for critical platform APIs:
+- Microsoft Graph
+- Microsoft Fabric
+- Dataverse Web API
+- Microsoft Planner
+- Stripe
+- Firebase
+
+To run these tests, export environment variables for each provider:
+  GRAPH_BASE_URL, GRAPH_TOKEN
+  FABRIC_BASE_URL, FABRIC_TOKEN
+  DATAVERSE_BASE_URL, DATAVERSE_TOKEN
+  PLANNER_BASE_URL, PLANNER_TOKEN
+  STRIPE_BASE_URL, STRIPE_TOKEN
+  FIREBASE_BASE_URL, FIREBASE_TOKEN
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+import pytest
+
+
+@dataclass(frozen=True)
+class Contract:
+    name: str
+    base_url_env: str
+    token_env: str
+    path: str
+    expected_any_keys: tuple[str, ...]
+
+
+CONTRACTS: tuple[Contract, ...] = (
+    Contract(
+        name="graph",
+        base_url_env="GRAPH_BASE_URL",
+        token_env="GRAPH_TOKEN",
+        path="/v1.0/organization",
+        expected_any_keys=("value",),
+    ),
+    Contract(
+        name="fabric",
+        base_url_env="FABRIC_BASE_URL",
+        token_env="FABRIC_TOKEN",
+        path="/v1/workspaces",
+        expected_any_keys=("value", "data", "items"),
+    ),
+    Contract(
+        name="dataverse",
+        base_url_env="DATAVERSE_BASE_URL",
+        token_env="DATAVERSE_TOKEN",
+        path="/api/data/v9.2/WhoAmI",
+        expected_any_keys=("UserId", "BusinessUnitId", "OrganizationId"),
+    ),
+    Contract(
+        name="planner",
+        base_url_env="PLANNER_BASE_URL",
+        token_env="PLANNER_TOKEN",
+        path="/v1.0/planner/plans",
+        expected_any_keys=("value",),
+    ),
+    Contract(
+        name="stripe",
+        base_url_env="STRIPE_BASE_URL",
+        token_env="STRIPE_TOKEN",
+        path="/v1/customers?limit=1",
+        expected_any_keys=("object", "data"),
+    ),
+    Contract(
+        name="firebase",
+        base_url_env="FIREBASE_BASE_URL",
+        token_env="FIREBASE_TOKEN",
+        path="/v1beta1/projects",
+        expected_any_keys=("results", "projects", "value"),
+    ),
+)
+
+
+def _read_env(contract: Contract) -> tuple[str, str]:
+    base_url = os.getenv(contract.base_url_env, "").strip()
+    token = os.getenv(contract.token_env, "").strip()
+    if not base_url or not token:
+        pytest.skip(
+            f"Missing {contract.base_url_env} or {contract.token_env}; "
+            f"skipping {contract.name} contract check."
+        )
+    return base_url.rstrip("/"), token
+
+
+def _auth_header(contract: Contract, token: str) -> str:
+    if contract.name == "stripe":
+        return f"Bearer {token}"
+    return f"Bearer {token}"
+
+
+@pytest.mark.parametrize("contract", CONTRACTS, ids=[c.name for c in CONTRACTS])
+def test_api_contract_response_shape(contract: Contract) -> None:
+    base_url, token = _read_env(contract)
+    request = urllib.request.Request(
+        url=f"{base_url}{contract.path}",
+        headers={
+            "Authorization": _auth_header(contract, token),
+            "Accept": "application/json",
+        },
+        method="GET",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            status_code = response.status
+            payload = json.loads(response.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="ignore")
+        pytest.fail(f"{contract.name} returned HTTP {exc.code}: {body}")
+    except urllib.error.URLError as exc:
+        pytest.fail(f"{contract.name} network error: {exc.reason}")
+
+    assert 200 <= status_code < 300, f"Unexpected status from {contract.name}: {status_code}"
+    assert isinstance(payload, dict), f"{contract.name} did not return a JSON object"
+    assert any(key in payload for key in contract.expected_any_keys), (
+        f"{contract.name} response missing expected keys {contract.expected_any_keys}; "
+        f"got keys={sorted(payload.keys())}"
+    )


### PR DESCRIPTION
### Motivation

- Provide automated API contract checks for external services used by the plugin to detect contract drift early (Graph, Fabric, Dataverse, Planner, Stripe, Firebase). 
- Harden PreToolUse guardrails to prevent scope/permission misuse, tenant drift, unsafe destructive calls, and missing audit metadata during deployment activities. 
- Document the mapping between governance controls, enforcement scripts/hooks, and required audit evidence for client assurance and audits.

### Description

- Added a contract test suite at `plugins/tvs-microsoft-deploy/tests/contract/test_api_contracts.py` and guidance `plugins/tvs-microsoft-deploy/tests/contract/README.md` that validate high-level response shapes for Graph, Fabric, Dataverse, Planner, Stripe, and Firebase and skip when provider env vars/tokens are not provided. 
- Added four PreToolUse hook scripts under `plugins/tvs-microsoft-deploy/hooks/`: `scope-permission-misuse-check.sh`, `tenant-drift-check.sh`, `unsafe-destructive-call-check.sh`, and `audit-metadata-check.sh`, each blocking risky commands unless explicit environment gated overrides are set. 
- Registered the new hooks in `plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json` and updated the plugin description hook count. 
- Added `docs/governance/control-matrix.md` that maps GOV controls to the new scripts/hooks/commands and lists required evidence artifacts for audits.

### Testing

- Compiled the new test module with `python3 -m compileall plugins/tvs-microsoft-deploy/tests/contract/test_api_contracts.py`, which succeeded. 
- Executed `pytest plugins/tvs-microsoft-deploy/tests/contract/test_api_contracts.py -q`, which completed successfully with tests skipped when provider env vars/tokens were not present (6 tests skipped). 
- Validated the updated plugin manifest JSON with `jq . plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json` which returned valid JSON.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7afb0c48832a8b377607889d974d)