### PR TITLE
Add Microsoft deployment skills with reference-driven deep docs

### DIFF
--- a/plugins/tvs-microsoft-deploy/skills/dataverse-architecture.md
+++ b/plugins/tvs-microsoft-deploy/skills/dataverse-architecture.md
@@ -1,0 +1,21 @@
+---
+name: Dataverse Architecture
+description: Use for Dataverse schema design, relationship modeling, security architecture, performance tuning, integration design, and data governance.
+version: 1.0.0
+---
+
+# Dataverse Architecture
+
+Use this skill when users need durable table design, enterprise integration patterns, and scalable operational controls in Dataverse.
+
+## Fast path
+1. Capture domain model boundaries and data ownership.
+2. Design tables, relationships, alternate keys, and audit strategy.
+3. Map security model (business units, teams, field/table access).
+4. Validate scale constraints, API limits, and archival approach.
+
+## References
+- Entity and metadata APIs: `references/dataverse-architecture/endpoints.md`
+- Security privileges and access scope matrix: `references/dataverse-architecture/scopes.md`
+- Schema/payload blueprints: `references/dataverse-architecture/payloads.md`
+- Common failures and remediation playbooks: `references/dataverse-architecture/remediation.md`

--- a/plugins/tvs-microsoft-deploy/skills/embedded-analytics-go-to-market.md
+++ b/plugins/tvs-microsoft-deploy/skills/embedded-analytics-go-to-market.md
@@ -1,0 +1,21 @@
+---
+name: Embedded Analytics Go-To-Market
+description: Use for commercializing embedded analytics solutions with packaging, pricing, tenancy strategy, governance controls, and delivery operations.
+version: 1.0.0
+---
+
+# Embedded Analytics Go-To-Market
+
+Use this skill when users need to design, launch, or optimize an embedded analytics offering from product definition through operating model.
+
+## Fast path
+1. Define buyer persona, use case value, and packaging model.
+2. Select embedding architecture and tenant/isolation strategy.
+3. Align licensing, security, and data governance controls.
+4. Operationalize launch metrics, support workflows, and expansion plays.
+
+## References
+- Platform/API integration endpoints: `references/embedded-analytics-go-to-market/endpoints.md`
+- Security scopes and commercial prerequisites: `references/embedded-analytics-go-to-market/scopes.md`
+- Embed/token/config payload schemas: `references/embedded-analytics-go-to-market/payloads.md`
+- Failure modes and remediation playbooks: `references/embedded-analytics-go-to-market/remediation.md`

--- a/plugins/tvs-microsoft-deploy/skills/excel-enterprise-automation.md
+++ b/plugins/tvs-microsoft-deploy/skills/excel-enterprise-automation.md
@@ -1,0 +1,21 @@
+---
+name: Excel Enterprise Automation
+description: Use for Excel API automation, workbook governance, enterprise data refresh workflows, and resilient spreadsheet-to-platform integrations.
+version: 1.0.0
+---
+
+# Excel Enterprise Automation
+
+Use this skill when users need repeatable Excel automation across Graph, Office Scripts, Power Automate, and enterprise integration pipelines.
+
+## Fast path
+1. Confirm workbook location, ownership, and concurrency model.
+2. Choose execution path (Graph workbook API, Office Script, Power Automate).
+3. Define range/table/chart operations with transactional safeguards.
+4. Mitigate locking, session expiry, and calc/refresh reliability issues.
+
+## References
+- Workbook and automation endpoints: `references/excel-enterprise-automation/endpoints.md`
+- Scopes and delegated/app-only constraints: `references/excel-enterprise-automation/scopes.md`
+- Workbook payload schemas and examples: `references/excel-enterprise-automation/payloads.md`
+- Failure patterns and remediation playbooks: `references/excel-enterprise-automation/remediation.md`

--- a/plugins/tvs-microsoft-deploy/skills/fabric-engineering.md
+++ b/plugins/tvs-microsoft-deploy/skills/fabric-engineering.md
@@ -1,0 +1,21 @@
+---
+name: Fabric Engineering
+description: Use for Microsoft Fabric workspace engineering, lakehouse/warehouse deployment, notebook orchestration, CI/CD, and platform reliability.
+version: 1.0.0
+---
+
+# Fabric Engineering
+
+Use this skill when requests involve implementing or operating Fabric data engineering assets from development through production.
+
+## Fast path
+1. Confirm workspace topology, capacities, and networking constraints.
+2. Choose artifact path (lakehouse, warehouse, notebook, pipeline, semantic model).
+3. Implement deployment automation with validation checkpoints.
+4. Troubleshoot refresh/job failures using run history and dependency diagnostics.
+
+## References
+- Fabric REST and admin endpoints: `references/fabric-engineering/endpoints.md`
+- Access, roles, and token scope requirements: `references/fabric-engineering/scopes.md`
+- Deployment and execution payload schemas: `references/fabric-engineering/payloads.md`
+- Failure catalog and recovery playbooks: `references/fabric-engineering/remediation.md`

--- a/plugins/tvs-microsoft-deploy/skills/microsoft-graph-admin.md
+++ b/plugins/tvs-microsoft-deploy/skills/microsoft-graph-admin.md
@@ -1,0 +1,21 @@
+---
+name: Microsoft Graph Administration
+description: Use for tenant-level Microsoft Graph administration, identity governance automation, app consent hygiene, and operational troubleshooting across Entra ID, Exchange, and SharePoint workloads.
+version: 1.0.0
+---
+
+# Microsoft Graph Administration
+
+Use this skill when requests involve Graph API setup, permissioning, tenant objects, lifecycle operations, or Graph-related production incidents.
+
+## Fast path
+1. Confirm tenant, cloud (Global/GCC), and authentication pattern (delegated vs app-only).
+2. Select least-privilege scopes and consent workflow.
+3. Execute endpoint workflow and validate request/response contracts.
+4. Apply failure remediation and rerun with trace IDs captured.
+
+## References
+- Endpoints and operation map: `references/microsoft-graph-admin/endpoints.md`
+- Scopes and consent matrix: `references/microsoft-graph-admin/scopes.md`
+- Payload schemas and examples: `references/microsoft-graph-admin/payloads.md`
+- Failure modes and remediation playbooks: `references/microsoft-graph-admin/remediation.md`

--- a/plugins/tvs-microsoft-deploy/skills/planner-orchestration.md
+++ b/plugins/tvs-microsoft-deploy/skills/planner-orchestration.md
@@ -1,0 +1,21 @@
+---
+name: Planner Orchestration
+description: Use for Microsoft Planner provisioning, task orchestration, bucket governance, and cross-tool scheduling automation.
+version: 1.0.0
+---
+
+# Planner Orchestration
+
+Use this skill when users need task-plan automation, portfolio-level coordination, and operational reliability for Planner-backed workflows.
+
+## Fast path
+1. Confirm target M365 group, ownership model, and lifecycle expectations.
+2. Provision plans/buckets/tasks with idempotent patterns.
+3. Automate assignment, scheduling, and progress synchronization.
+4. Handle eTags, throttling, and permission drift during updates.
+
+## References
+- Planner Graph endpoints: `references/planner-orchestration/endpoints.md`
+- Permission scopes and consent patterns: `references/planner-orchestration/scopes.md`
+- Task/plan payload schemas: `references/planner-orchestration/payloads.md`
+- Failure modes and remediation workflows: `references/planner-orchestration/remediation.md`

--- a/plugins/tvs-microsoft-deploy/skills/power-platform-alm.md
+++ b/plugins/tvs-microsoft-deploy/skills/power-platform-alm.md
@@ -1,0 +1,21 @@
+---
+name: Power Platform ALM
+description: Use for solution lifecycle management, environment strategy, pipelines, managed/unmanaged transitions, and release governance for Power Apps, Power Automate, and Dataverse.
+version: 1.0.0
+---
+
+# Power Platform ALM
+
+Use this skill when users need to build, package, migrate, or release Power Platform assets with repeatable governance.
+
+## Fast path
+1. Classify request as build, migrate, hotfix, or rollback.
+2. Validate environment topology, solution segmentation, and connection references.
+3. Run pipeline-safe export/import with checks.
+4. Resolve import failures via dependency, privilege, and component diagnostics.
+
+## References
+- ALM endpoints and CLI operations: `references/power-platform-alm/endpoints.md`
+- Roles, scopes, and service principals: `references/power-platform-alm/scopes.md`
+- Solution/package payload patterns: `references/power-platform-alm/payloads.md`
+- Failure modes and remediation runbooks: `references/power-platform-alm/remediation.md`

--- a/plugins/tvs-microsoft-deploy/skills/references/dataverse-architecture/endpoints.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/dataverse-architecture/endpoints.md
@@ -1,0 +1,9 @@
+# API endpoints
+
+| Operation | Purpose |
+|---|---|
+| `GET /api/data/v9.2/EntityDefinitions` | Core workflow operation for this skill. |
+| `POST /api/data/v9.2/EntityDefinitions` | Core workflow operation for this skill. |
+| `POST /api/data/v9.2/RelationshipDefinitions` | Core workflow operation for this skill. |
+| `POST /api/data/v9.2/{table}` | Core workflow operation for this skill. |
+| `GET /api/data/v9.2/systemusers` | Core workflow operation for this skill. |

--- a/plugins/tvs-microsoft-deploy/skills/references/dataverse-architecture/payloads.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/dataverse-architecture/payloads.md
@@ -1,0 +1,9 @@
+# Payload schemas
+
+## Canonical payload guidance
+Table schema payload should include ownership type, primary name, alternate keys, and auditing flags before relationship creation.
+
+## Validation checklist
+- Ensure IDs are environment-specific and not hard-coded across tenants.
+- Enforce UTC timestamps and explicit locale handling where relevant.
+- Include correlation IDs in request headers for traceability.

--- a/plugins/tvs-microsoft-deploy/skills/references/dataverse-architecture/remediation.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/dataverse-architecture/remediation.md
@@ -1,0 +1,11 @@
+# Common failure modes and remediation playbooks
+
+- **SQL timeout on overly broad queries** → Add selective indexes and filter columns via $select.
+- **Business rule recursion causing plugin depth errors** → Refactor automation to avoid circular updates and use depth guards.
+- **Duplicate detection false positives on alternate keys** → Tune duplicate rules and use composite keys carefully.
+- **Access denied from business unit hierarchy mismatch** → Realign owner teams/business units and test effective privileges.
+
+## Escalation data to capture
+- Request/operation ID and timestamp (UTC).
+- Tenant/environment/workspace identifiers.
+- Last known successful deployment or configuration baseline.

--- a/plugins/tvs-microsoft-deploy/skills/references/dataverse-architecture/scopes.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/dataverse-architecture/scopes.md
@@ -1,0 +1,8 @@
+# Scope requirements
+
+| Scope / Role | Why it is needed |
+|---|---|
+| `Dataverse user security roles with table privileges` | Required to execute privileged operations safely. |
+| `Read/Write/Append/AppendTo for relational operations` | Required to execute privileged operations safely. |
+| `Field security profile assignment for protected columns` | Required to execute privileged operations safely. |
+| `Environment-level capacity admin for storage governance` | Required to execute privileged operations safely. |

--- a/plugins/tvs-microsoft-deploy/skills/references/embedded-analytics-go-to-market/endpoints.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/embedded-analytics-go-to-market/endpoints.md
@@ -1,0 +1,9 @@
+# API endpoints
+
+| Operation | Purpose |
+|---|---|
+| `POST /v1.0/myorg/groups/{groupId}/reports/{reportId}/GenerateToken` | Core workflow operation for this skill. |
+| `GET /v1.0/myorg/groups` | Core workflow operation for this skill. |
+| `POST /v1.0/myorg/groups/{groupId}/users` | Core workflow operation for this skill. |
+| `GET /v1.0/myorg/admin/capacities` | Core workflow operation for this skill. |
+| `POST /v1.0/myorg/groups/{groupId}/datasets/{datasetId}/Refreshes` | Core workflow operation for this skill. |

--- a/plugins/tvs-microsoft-deploy/skills/references/embedded-analytics-go-to-market/payloads.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/embedded-analytics-go-to-market/payloads.md
@@ -1,0 +1,9 @@
+# Payload schemas
+
+## Canonical payload guidance
+Embed token request includes accessLevel, identities (RLS), and datasets/reports list aligned to tenant isolation model.
+
+## Validation checklist
+- Ensure IDs are environment-specific and not hard-coded across tenants.
+- Enforce UTC timestamps and explicit locale handling where relevant.
+- Include correlation IDs in request headers for traceability.

--- a/plugins/tvs-microsoft-deploy/skills/references/embedded-analytics-go-to-market/remediation.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/embedded-analytics-go-to-market/remediation.md
@@ -1,0 +1,11 @@
+# Common failure modes and remediation playbooks
+
+- **Embed token generation denied for service principal** → Enable service principal tenant switch and workspace access.
+- **RLS identity mismatch shows blank visuals** → Validate username/roles mapping and dataset RLS definitions.
+- **Capacity overload increases render latency** → Autoscale capacity and move noisy tenants to dedicated workloads.
+- **Dataset refresh chain breaks downstream SLAs** → Introduce staged refresh windows and dependency monitoring alerts.
+
+## Escalation data to capture
+- Request/operation ID and timestamp (UTC).
+- Tenant/environment/workspace identifiers.
+- Last known successful deployment or configuration baseline.

--- a/plugins/tvs-microsoft-deploy/skills/references/embedded-analytics-go-to-market/scopes.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/embedded-analytics-go-to-market/scopes.md
@@ -1,0 +1,8 @@
+# Scope requirements
+
+| Scope / Role | Why it is needed |
+|---|---|
+| `https://analysis.windows.net/powerbi/api/.default` | Required to execute privileged operations safely. |
+| `Tenant setting: service principals can use Power BI APIs` | Required to execute privileged operations safely. |
+| `Capacity admin for SKU governance` | Required to execute privileged operations safely. |
+| `Workspace Admin for embed identity operations` | Required to execute privileged operations safely. |

--- a/plugins/tvs-microsoft-deploy/skills/references/excel-enterprise-automation/endpoints.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/excel-enterprise-automation/endpoints.md
@@ -1,0 +1,9 @@
+# API endpoints
+
+| Operation | Purpose |
+|---|---|
+| `POST /v1.0/me/drive/items/{id}/workbook/createSession` | Core workflow operation for this skill. |
+| `PATCH /v1.0/me/drive/items/{id}/workbook/worksheets/{id}/range(address=...)` | Core workflow operation for this skill. |
+| `POST /v1.0/me/drive/items/{id}/workbook/tables/{id}/rows/add` | Core workflow operation for this skill. |
+| `POST /v1.0/me/drive/items/{id}/workbook/refreshSession` | Core workflow operation for this skill. |
+| `POST /v1.0/me/drive/items/{id}/workbook/closeSession` | Core workflow operation for this skill. |

--- a/plugins/tvs-microsoft-deploy/skills/references/excel-enterprise-automation/payloads.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/excel-enterprise-automation/payloads.md
@@ -1,0 +1,9 @@
+# Payload schemas
+
+## Canonical payload guidance
+Use persistent-session-id header and payloads for range values/formulas with dimension-safe arrays.
+
+## Validation checklist
+- Ensure IDs are environment-specific and not hard-coded across tenants.
+- Enforce UTC timestamps and explicit locale handling where relevant.
+- Include correlation IDs in request headers for traceability.

--- a/plugins/tvs-microsoft-deploy/skills/references/excel-enterprise-automation/remediation.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/excel-enterprise-automation/remediation.md
@@ -1,0 +1,11 @@
+# Common failure modes and remediation playbooks
+
+- **Workbook locked by interactive user session** → Retry with backoff or schedule off-hours automation windows.
+- **InvalidArgument from shape mismatch in range update** → Validate row/column dimensions before PATCH.
+- **SessionNotFound after idle timeout** → Recreate session and resume from checkpoint.
+- **Calc engine delay causing stale reads** → Trigger calculate endpoint and poll before readback.
+
+## Escalation data to capture
+- Request/operation ID and timestamp (UTC).
+- Tenant/environment/workspace identifiers.
+- Last known successful deployment or configuration baseline.

--- a/plugins/tvs-microsoft-deploy/skills/references/excel-enterprise-automation/scopes.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/excel-enterprise-automation/scopes.md
@@ -1,0 +1,8 @@
+# Scope requirements
+
+| Scope / Role | Why it is needed |
+|---|---|
+| `Files.ReadWrite.All (delegated/app)` | Required to execute privileged operations safely. |
+| `Sites.ReadWrite.All when workbook in SharePoint` | Required to execute privileged operations safely. |
+| `Workbook.ReadWrite.All where available` | Required to execute privileged operations safely. |
+| `offline_access for unattended workflows` | Required to execute privileged operations safely. |

--- a/plugins/tvs-microsoft-deploy/skills/references/fabric-engineering/endpoints.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/fabric-engineering/endpoints.md
@@ -1,0 +1,9 @@
+# API endpoints
+
+| Operation | Purpose |
+|---|---|
+| `GET /v1/workspaces` | Core workflow operation for this skill. |
+| `POST /v1/workspaces/{id}/lakehouses` | Core workflow operation for this skill. |
+| `POST /v1/workspaces/{id}/items/{itemId}/jobs/instances` | Core workflow operation for this skill. |
+| `GET /v1/capacities` | Core workflow operation for this skill. |
+| `POST /v1/workspaces/{id}/git/connect` | Core workflow operation for this skill. |

--- a/plugins/tvs-microsoft-deploy/skills/references/fabric-engineering/payloads.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/fabric-engineering/payloads.md
@@ -1,0 +1,9 @@
+# Payload schemas
+
+## Canonical payload guidance
+Notebook execution payload includes executionData.parameters and optional retry configuration for transient Spark failures.
+
+## Validation checklist
+- Ensure IDs are environment-specific and not hard-coded across tenants.
+- Enforce UTC timestamps and explicit locale handling where relevant.
+- Include correlation IDs in request headers for traceability.

--- a/plugins/tvs-microsoft-deploy/skills/references/fabric-engineering/remediation.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/fabric-engineering/remediation.md
@@ -1,0 +1,11 @@
+# Common failure modes and remediation playbooks
+
+- **Job stuck in Queued due to exhausted capacity** → Scale or pause competing workloads and tune SKU settings.
+- **Unauthorized on cross-workspace shortcut creation** → Grant both source and target workspace permissions plus connection access.
+- **Git sync conflicts on parallel deploys** → Enforce branch protection and serialized promotion windows.
+- **Semantic model refresh timeout** → Partition model and optimize incremental refresh policy.
+
+## Escalation data to capture
+- Request/operation ID and timestamp (UTC).
+- Tenant/environment/workspace identifiers.
+- Last known successful deployment or configuration baseline.

--- a/plugins/tvs-microsoft-deploy/skills/references/fabric-engineering/scopes.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/fabric-engineering/scopes.md
@@ -1,0 +1,8 @@
+# Scope requirements
+
+| Scope / Role | Why it is needed |
+|---|---|
+| `https://api.fabric.microsoft.com/.default` | Required to execute privileged operations safely. |
+| `Fabric Admin for tenant operations` | Required to execute privileged operations safely. |
+| `Workspace Contributor or above for artifact deploy` | Required to execute privileged operations safely. |
+| `Capacity Admin for assignment and scaling changes` | Required to execute privileged operations safely. |

--- a/plugins/tvs-microsoft-deploy/skills/references/microsoft-graph-admin/endpoints.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/microsoft-graph-admin/endpoints.md
@@ -1,0 +1,9 @@
+# API endpoints
+
+| Operation | Purpose |
+|---|---|
+| `GET /v1.0/users/{id}` | Core workflow operation for this skill. |
+| `POST /v1.0/groups` | Core workflow operation for this skill. |
+| `GET /v1.0/auditLogs/signIns` | Core workflow operation for this skill. |
+| `POST /v1.0/servicePrincipals/{id}/appRoleAssignments` | Core workflow operation for this skill. |
+| `GET /v1.0/identityGovernance/entitlementManagement/accessPackages` | Core workflow operation for this skill. |

--- a/plugins/tvs-microsoft-deploy/skills/references/microsoft-graph-admin/payloads.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/microsoft-graph-admin/payloads.md
@@ -1,0 +1,9 @@
+# Payload schemas
+
+## Canonical payload guidance
+Create group with owners/members and assign app roles using object IDs; include consistencyLevel header for advanced filters.
+
+## Validation checklist
+- Ensure IDs are environment-specific and not hard-coded across tenants.
+- Enforce UTC timestamps and explicit locale handling where relevant.
+- Include correlation IDs in request headers for traceability.

--- a/plugins/tvs-microsoft-deploy/skills/references/microsoft-graph-admin/remediation.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/microsoft-graph-admin/remediation.md
@@ -1,0 +1,11 @@
+# Common failure modes and remediation playbooks
+
+- **403 insufficient privileges after consent changes** → Re-consent in tenant admin center and verify token claims.
+- **429 throttling on directory-wide scans** → Implement retry-after exponential backoff with jitter.
+- **400 invalid object reference for deleted principals** → Refresh IDs from source of truth before write operations.
+- **412 eTag conflicts on concurrent updates** → GET latest object then PATCH with fresh eTag.
+
+## Escalation data to capture
+- Request/operation ID and timestamp (UTC).
+- Tenant/environment/workspace identifiers.
+- Last known successful deployment or configuration baseline.

--- a/plugins/tvs-microsoft-deploy/skills/references/microsoft-graph-admin/scopes.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/microsoft-graph-admin/scopes.md
@@ -1,0 +1,9 @@
+# Scope requirements
+
+| Scope / Role | Why it is needed |
+|---|---|
+| `User.Read.All (delegated/app)` | Required to execute privileged operations safely. |
+| `Group.ReadWrite.All (app)` | Required to execute privileged operations safely. |
+| `AuditLog.Read.All (delegated/app)` | Required to execute privileged operations safely. |
+| `AppRoleAssignment.ReadWrite.All (app)` | Required to execute privileged operations safely. |
+| `EntitlementManagement.Read.All (delegated/app)` | Required to execute privileged operations safely. |

--- a/plugins/tvs-microsoft-deploy/skills/references/planner-orchestration/endpoints.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/planner-orchestration/endpoints.md
@@ -1,0 +1,9 @@
+# API endpoints
+
+| Operation | Purpose |
+|---|---|
+| `POST /v1.0/planner/plans` | Core workflow operation for this skill. |
+| `POST /v1.0/planner/tasks` | Core workflow operation for this skill. |
+| `PATCH /v1.0/planner/tasks/{id}` | Core workflow operation for this skill. |
+| `GET /v1.0/planner/plans/{id}/tasks` | Core workflow operation for this skill. |
+| `POST /v1.0/planner/tasks/{id}/details` | Core workflow operation for this skill. |

--- a/plugins/tvs-microsoft-deploy/skills/references/planner-orchestration/payloads.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/planner-orchestration/payloads.md
@@ -1,0 +1,9 @@
+# Payload schemas
+
+## Canonical payload guidance
+Task payload should include planId, bucketId, assignments map, percentComplete, and dueDateTime in UTC.
+
+## Validation checklist
+- Ensure IDs are environment-specific and not hard-coded across tenants.
+- Enforce UTC timestamps and explicit locale handling where relevant.
+- Include correlation IDs in request headers for traceability.

--- a/plugins/tvs-microsoft-deploy/skills/references/planner-orchestration/remediation.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/planner-orchestration/remediation.md
@@ -1,0 +1,11 @@
+# Common failure modes and remediation playbooks
+
+- **412 precondition failed due to stale eTag** → Read current task to fetch latest eTag before PATCH.
+- **403 when automation account is not group member** → Add service account as group owner/member with planner access.
+- **404 bucket not found after plan recreation** → Re-resolve plan/bucket IDs after lifecycle events.
+- **429 throttling during bulk updates** → Batch updates and apply retry-after handling.
+
+## Escalation data to capture
+- Request/operation ID and timestamp (UTC).
+- Tenant/environment/workspace identifiers.
+- Last known successful deployment or configuration baseline.

--- a/plugins/tvs-microsoft-deploy/skills/references/planner-orchestration/scopes.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/planner-orchestration/scopes.md
@@ -1,0 +1,8 @@
+# Scope requirements
+
+| Scope / Role | Why it is needed |
+|---|---|
+| `Tasks.ReadWrite (delegated)` | Required to execute privileged operations safely. |
+| `Group.ReadWrite.All (delegated/app for group context)` | Required to execute privileged operations safely. |
+| `User.ReadBasic.All for assignee resolution` | Required to execute privileged operations safely. |
+| `offline_access for long-running automation` | Required to execute privileged operations safely. |

--- a/plugins/tvs-microsoft-deploy/skills/references/power-platform-alm/endpoints.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/power-platform-alm/endpoints.md
@@ -1,0 +1,9 @@
+# API endpoints
+
+| Operation | Purpose |
+|---|---|
+| `pac solution export` | Core workflow operation for this skill. |
+| `pac solution import` | Core workflow operation for this skill. |
+| `POST /api/data/v9.2/PublishAllXml` | Core workflow operation for this skill. |
+| `GET /api/data/v9.2/solutions` | Core workflow operation for this skill. |
+| `POST /providers/Microsoft.BusinessAppPlatform/environments/{env}/deployments` | Core workflow operation for this skill. |

--- a/plugins/tvs-microsoft-deploy/skills/references/power-platform-alm/payloads.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/power-platform-alm/payloads.md
@@ -1,0 +1,9 @@
+# Payload schemas
+
+## Canonical payload guidance
+Managed import payload includes holding-solution and overwrite-unmanaged customizations flags plus connection reference mapping JSON.
+
+## Validation checklist
+- Ensure IDs are environment-specific and not hard-coded across tenants.
+- Enforce UTC timestamps and explicit locale handling where relevant.
+- Include correlation IDs in request headers for traceability.

--- a/plugins/tvs-microsoft-deploy/skills/references/power-platform-alm/remediation.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/power-platform-alm/remediation.md
@@ -1,0 +1,11 @@
+# Common failure modes and remediation playbooks
+
+- **Import failed: missing dependency** → Export dependency report and include required base solutions.
+- **Connection reference unresolved in target** → Pre-create or remap connection references in deployment settings.
+- **Plugin assembly version conflict** → Increment assembly version and publish plugin step order.
+- **Pipeline service principal lacks environment access** → Grant Environment Maker + Deployment Pipeline role to service principal.
+
+## Escalation data to capture
+- Request/operation ID and timestamp (UTC).
+- Tenant/environment/workspace identifiers.
+- Last known successful deployment or configuration baseline.

--- a/plugins/tvs-microsoft-deploy/skills/references/power-platform-alm/scopes.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/power-platform-alm/scopes.md
@@ -1,0 +1,8 @@
+# Scope requirements
+
+| Scope / Role | Why it is needed |
+|---|---|
+| `Power Platform Service Admin role` | Required to execute privileged operations safely. |
+| `Dataverse System Administrator in target env` | Required to execute privileged operations safely. |
+| `Azure DevOps service connection with environment access` | Required to execute privileged operations safely. |
+| `Application user with Deployment Pipeline permissions` | Required to execute privileged operations safely. |

--- a/plugins/tvs-microsoft-deploy/skills/references/sharepoint-governance/endpoints.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/sharepoint-governance/endpoints.md
@@ -1,0 +1,9 @@
+# API endpoints
+
+| Operation | Purpose |
+|---|---|
+| `GET /v1.0/sites?search=*` | Core workflow operation for this skill. |
+| `POST /v1.0/sites/{siteId}/permissions` | Core workflow operation for this skill. |
+| `GET /v1.0/sites/{siteId}/drives` | Core workflow operation for this skill. |
+| `POST /_api/sitepages/pages` | Core workflow operation for this skill. |
+| `POST /_api/SP.CompliancePolicy.SPPolicyStoreProxy.ApplyLabelOnBulkItems` | Core workflow operation for this skill. |

--- a/plugins/tvs-microsoft-deploy/skills/references/sharepoint-governance/payloads.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/sharepoint-governance/payloads.md
@@ -1,0 +1,9 @@
+# Payload schemas
+
+## Canonical payload guidance
+Site governance payloads include classification label, sharing capability, owner group, and retention policy bindings.
+
+## Validation checklist
+- Ensure IDs are environment-specific and not hard-coded across tenants.
+- Enforce UTC timestamps and explicit locale handling where relevant.
+- Include correlation IDs in request headers for traceability.

--- a/plugins/tvs-microsoft-deploy/skills/references/sharepoint-governance/remediation.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/sharepoint-governance/remediation.md
@@ -1,0 +1,11 @@
+# Common failure modes and remediation playbooks
+
+- **Sharing policy blocks external collaborator onboarding** → Align site setting with tenant external sharing baseline.
+- **Broken permission inheritance causing overexposure** → Reset unique permissions and reapply role assignments least-privilege.
+- **Retention label not published to target site** → Publish label to scope and wait for propagation before retry.
+- **429 from large list traversal** → Use delta queries/indexed columns and pagination.
+
+## Escalation data to capture
+- Request/operation ID and timestamp (UTC).
+- Tenant/environment/workspace identifiers.
+- Last known successful deployment or configuration baseline.

--- a/plugins/tvs-microsoft-deploy/skills/references/sharepoint-governance/scopes.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/sharepoint-governance/scopes.md
@@ -1,0 +1,8 @@
+# Scope requirements
+
+| Scope / Role | Why it is needed |
+|---|---|
+| `Sites.ReadWrite.All (delegated/app)` | Required to execute privileged operations safely. |
+| `Files.ReadWrite.All for document operations` | Required to execute privileged operations safely. |
+| `Policy.ReadWrite.RecordsManagement for retention automation` | Required to execute privileged operations safely. |
+| `SharePoint Administrator role for tenant-level controls` | Required to execute privileged operations safely. |

--- a/plugins/tvs-microsoft-deploy/skills/references/teams-operations/endpoints.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/teams-operations/endpoints.md
@@ -1,0 +1,9 @@
+# API endpoints
+
+| Operation | Purpose |
+|---|---|
+| `POST /v1.0/teams` | Core workflow operation for this skill. |
+| `POST /v1.0/teams/{id}/channels` | Core workflow operation for this skill. |
+| `GET /v1.0/teams/{id}/members` | Core workflow operation for this skill. |
+| `POST /v1.0/policies/crossTenantAccessPolicy/partners` | Core workflow operation for this skill. |
+| `POST /v1.0/appCatalogs/teamsApps` | Core workflow operation for this skill. |

--- a/plugins/tvs-microsoft-deploy/skills/references/teams-operations/payloads.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/teams-operations/payloads.md
@@ -1,0 +1,9 @@
+# Payload schemas
+
+## Canonical payload guidance
+Team create payload should include template@odata.bind, visibility, member settings, and installed apps list.
+
+## Validation checklist
+- Ensure IDs are environment-specific and not hard-coded across tenants.
+- Enforce UTC timestamps and explicit locale handling where relevant.
+- Include correlation IDs in request headers for traceability.

--- a/plugins/tvs-microsoft-deploy/skills/references/teams-operations/remediation.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/teams-operations/remediation.md
@@ -1,0 +1,11 @@
+# Common failure modes and remediation playbooks
+
+- **Team provisioning delayed beyond SLA** → Poll async operation endpoint until succeeded; avoid duplicate creates.
+- **Private channel creation fails for unsupported owner set** → Ensure at least one eligible owner and compliance prechecks pass.
+- **App sideload blocked by org policy** → Update Teams app setup policy and app permission policy.
+- **Guest access inconsistencies across teams** → Harmonize Entra B2B + Teams guest policy and re-sync members.
+
+## Escalation data to capture
+- Request/operation ID and timestamp (UTC).
+- Tenant/environment/workspace identifiers.
+- Last known successful deployment or configuration baseline.

--- a/plugins/tvs-microsoft-deploy/skills/references/teams-operations/scopes.md
+++ b/plugins/tvs-microsoft-deploy/skills/references/teams-operations/scopes.md
@@ -1,0 +1,9 @@
+# Scope requirements
+
+| Scope / Role | Why it is needed |
+|---|---|
+| `Team.Create (delegated)` | Required to execute privileged operations safely. |
+| `TeamMember.ReadWrite.All (delegated/app)` | Required to execute privileged operations safely. |
+| `Channel.Create (delegated/app)` | Required to execute privileged operations safely. |
+| `AppCatalog.ReadWrite.All for app governance` | Required to execute privileged operations safely. |
+| `Teams Administrator role for policy management` | Required to execute privileged operations safely. |

--- a/plugins/tvs-microsoft-deploy/skills/sharepoint-governance.md
+++ b/plugins/tvs-microsoft-deploy/skills/sharepoint-governance.md
@@ -1,0 +1,21 @@
+---
+name: SharePoint Governance
+description: Use for SharePoint Online information architecture, site lifecycle controls, records management, permission governance, and compliance operations.
+version: 1.0.0
+---
+
+# SharePoint Governance
+
+Use this skill when requests involve SharePoint standards, compliance controls, access governance, or tenant-wide operational policy.
+
+## Fast path
+1. Determine governance objective (provision, secure, retain, audit, decommission).
+2. Map site model, hub strategy, and ownership/accountability.
+3. Apply permissions, sensitivity, retention, and sharing policies.
+4. Investigate drift and remediate inheritance, external sharing, or policy conflicts.
+
+## References
+- SharePoint + Graph endpoints: `references/sharepoint-governance/endpoints.md`
+- Role/scope requirement matrix: `references/sharepoint-governance/scopes.md`
+- Site/list/policy payload schemas: `references/sharepoint-governance/payloads.md`
+- Failure catalog and remediation playbooks: `references/sharepoint-governance/remediation.md`

--- a/plugins/tvs-microsoft-deploy/skills/skill-index.md
+++ b/plugins/tvs-microsoft-deploy/skills/skill-index.md
@@ -1,0 +1,31 @@
+# Skill Dispatcher Index
+
+Use this index to route requests quickly by user intent.
+
+## Build
+- **Dataverse data model or security design** → `dataverse-architecture.md`
+- **Fabric workspace/artifact engineering** → `fabric-engineering.md`
+- **Excel-backed enterprise automations** → `excel-enterprise-automation.md`
+- **Planner-based work orchestration** → `planner-orchestration.md`
+
+## Migrate
+- **Power Apps/Flows/Solutions between environments** → `power-platform-alm.md`
+- **Teams/channel/workload operational transitions** → `teams-operations.md`
+- **SharePoint site/content governance transitions** → `sharepoint-governance.md`
+
+## Govern
+- **Tenant-wide Graph permissions and identity operations** → `microsoft-graph-admin.md`
+- **SharePoint compliance, retention, and sharing policy** → `sharepoint-governance.md`
+- **Teams policy, app governance, and lifecycle controls** → `teams-operations.md`
+- **Dataverse long-term architecture and security posture** → `dataverse-architecture.md`
+
+## Sell
+- **Packaging and monetizing embedded analytics** → `embedded-analytics-go-to-market.md`
+- **Commercial strategy tied to Fabric/Power BI delivery** → `embedded-analytics-go-to-market.md`
+
+## Troubleshoot
+- **Graph auth, consent, throttling, or directory errors** → `microsoft-graph-admin.md`
+- **Solution import/deployment pipeline failures** → `power-platform-alm.md`
+- **Fabric refresh, capacity, and job execution incidents** → `fabric-engineering.md`
+- **Planner concurrency/eTag and assignment failures** → `planner-orchestration.md`
+- **Excel workbook lock/session/calc failures** → `excel-enterprise-automation.md`

--- a/plugins/tvs-microsoft-deploy/skills/teams-operations.md
+++ b/plugins/tvs-microsoft-deploy/skills/teams-operations.md
@@ -1,0 +1,21 @@
+---
+name: Teams Operations
+description: Use for Microsoft Teams provisioning, policy administration, app governance, lifecycle operations, and service troubleshooting.
+version: 1.0.0
+---
+
+# Teams Operations
+
+Use this skill when users need to deploy, govern, or troubleshoot Teams at scale across collaboration, calling, and app surfaces.
+
+## Fast path
+1. Classify request (provisioning, policy, compliance, incident, migration).
+2. Validate team/channel model and associated M365 group dependencies.
+3. Execute lifecycle change with policy and app governance checks.
+4. Triage operational issues across membership, messaging, meetings, and app install paths.
+
+## References
+- Teams Graph/admin endpoints: `references/teams-operations/endpoints.md`
+- Permissions and role prerequisites: `references/teams-operations/scopes.md`
+- Provisioning/policy payload schemas: `references/teams-operations/payloads.md`
+- Failure modes and remediation runbooks: `references/teams-operations/remediation.md`


### PR DESCRIPTION
### Motivation
- Provide a concise skill surface for common Microsoft deployment and governance scenarios while moving operational depth into structured reference packs to keep core skill pages readable and actionable.
- Enable consistent troubleshooting and automation patterns by centralizing API endpoints, scope requirements, payload schemas, and failure/remediation playbooks per skill.

### Description
- Added nine new skill files under `plugins/tvs-microsoft-deploy/skills/`: `microsoft-graph-admin.md`, `power-platform-alm.md`, `dataverse-architecture.md`, `fabric-engineering.md`, `planner-orchestration.md`, `sharepoint-governance.md`, `teams-operations.md`, `excel-enterprise-automation.md`, and `embedded-analytics-go-to-market.md` with concise core guidance and a `References` section linking to deep docs.
- Created a `skills/references/<skill-name>/` pack for each skill containing `endpoints.md`, `scopes.md`, `payloads.md`, and `remediation.md` (36 reference markdown files total) that document API operations, scopes, canonical payload guidance, and remediation playbooks.
- Added `plugins/tvs-microsoft-deploy/skills/skill-index.md` as a dispatcher mapping user intent (`build`, `migrate`, `govern`, `sell`, `troubleshoot`) to the appropriate skill.
- Net change: 46 files added and ~555 lines of content across `plugins/tvs-microsoft-deploy/skills` and its `references/` tree, committed to the working branch.

### Testing
- Verified reference pack count with `rg --files plugins/tvs-microsoft-deploy/skills/references | wc -l` which returned `36` and succeeded.
- Inspected staged changes with `git diff --cached --stat` and `git status --short` to confirm all new files are present and tracked.
- Performed `git add` and `git commit` which completed successfully and produced a commit for the added files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7d7d19c8832aa79f989853235a6a)