### PR TITLE
Upgrade Planner orchestration to an operational end-to-end workflow tool

### DIFF
--- a/plugins/tvs-microsoft-deploy/commands/orchestrate-planner.md
+++ b/plugins/tvs-microsoft-deploy/commands/orchestrate-planner.md
@@ -1,0 +1,91 @@
+---
+name: tvs:orchestrate-planner
+description: Full lifecycle Planner orchestration for workflow templates and live plans
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+---
+
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
+# Orchestrate Planner
+
+Operational command for template-driven Planner orchestration, dependency validation,
+blocker tracking, and closeout evidence packaging.
+
+## Usage
+
+```bash
+/tvs:orchestrate-planner <operation> --workflow <path> [options]
+```
+
+Core runner:
+
+```bash
+python plugins/tvs-microsoft-deploy/scripts/orchestrate_planner.py <operation> --workflow <path> [...]
+```
+
+## Operations
+
+### `init-plan`
+Creates a plan, creates one bucket per workflow phase, and seeds phase task templates into Planner.
+
+```bash
+python plugins/tvs-microsoft-deploy/scripts/orchestrate_planner.py init-plan \
+  --workflow plugins/tvs-microsoft-deploy/workflows/templates/planner/taia-sale-prep.workflow.json \
+  --group-id <m365-group-id> \
+  --plan-title "TAIA Sale Prep" \
+  --output plugins/tvs-microsoft-deploy/control-plane/out/taia-sale-prep.initialized.json
+```
+
+### `sync-workflow`
+Pulls live task state from Planner and updates each phase to `pending|in-progress|blocked|completed`.
+Also writes dependency validation findings to `metadata.dependencyIssues`.
+
+```bash
+python plugins/tvs-microsoft-deploy/scripts/orchestrate_planner.py sync-workflow \
+  --workflow plugins/tvs-microsoft-deploy/control-plane/out/taia-sale-prep.initialized.json \
+  --output plugins/tvs-microsoft-deploy/control-plane/out/taia-sale-prep.synced.json
+```
+
+### `advance-phase`
+Sets the active phase and propagates task lifecycle (`percentComplete` + blocker label handling) across all phase buckets.
+
+```bash
+python plugins/tvs-microsoft-deploy/scripts/orchestrate_planner.py advance-phase \
+  --workflow plugins/tvs-microsoft-deploy/control-plane/out/taia-sale-prep.synced.json \
+  --phase TEST \
+  --output plugins/tvs-microsoft-deploy/control-plane/out/taia-sale-prep.test-phase.json
+```
+
+### `blocker-report`
+Builds a structured blocker report listing blocked tasks, owning groups/users, and SLA context.
+
+```bash
+python plugins/tvs-microsoft-deploy/scripts/orchestrate_planner.py blocker-report \
+  --workflow plugins/tvs-microsoft-deploy/control-plane/out/taia-sale-prep.synced.json \
+  --output plugins/tvs-microsoft-deploy/control-plane/out/taia-sale-prep.blockers.json
+```
+
+### `closeout-pack`
+Generates a delivery closeout pack with phase completion summary, dependency violations,
+SLA context, and evidence inventory per phase.
+
+```bash
+python plugins/tvs-microsoft-deploy/scripts/orchestrate_planner.py closeout-pack \
+  --workflow plugins/tvs-microsoft-deploy/control-plane/out/taia-sale-prep.synced.json \
+  --output plugins/tvs-microsoft-deploy/control-plane/out/taia-sale-prep.closeout.json
+```
+
+## Dry-run mode
+
+Use `--dry-run` to validate orchestration flows without modifying Planner.
+
+```bash
+python plugins/tvs-microsoft-deploy/scripts/orchestrate_planner.py init-plan \
+  --workflow plugins/tvs-microsoft-deploy/workflows/templates/planner/migration-wave.workflow.json \
+  --group-id 00000000-0000-0000-0000-000000000000 \
+  --plan-title "Migration Wave - Dry Run" \
+  --dry-run
+```

--- a/plugins/tvs-microsoft-deploy/planner-orchestrator/__init__.py
+++ b/plugins/tvs-microsoft-deploy/planner-orchestrator/__init__.py
@@ -1,0 +1,6 @@
+"""Planner orchestration package for TVS Microsoft Deploy plugin."""
+
+from .planner_client import PlannerClient, PlannerError
+from .state_manager import BLOCKER_LABEL, PHASE_ORDER, WorkflowStateManager
+
+__all__ = ["PlannerClient", "PlannerError", "WorkflowStateManager", "PHASE_ORDER", "BLOCKER_LABEL"]

--- a/plugins/tvs-microsoft-deploy/planner-orchestrator/planner_client.py
+++ b/plugins/tvs-microsoft-deploy/planner-orchestrator/planner_client.py
@@ -1,0 +1,127 @@
+"""Planner API adapter with optional dry-run mode.
+
+Provides helper methods for plans, buckets, tasks, task details, checklist,
+labels, and assignments for workflow orchestration.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+from urllib import error, request
+
+
+class PlannerError(RuntimeError):
+    """Planner adapter error."""
+
+
+@dataclass
+class PlannerClient:
+    token: str
+    base_url: str = "https://graph.microsoft.com/v1.0/planner"
+    timeout_s: int = 30
+    dry_run: bool = False
+
+    def _headers(self, etag: Optional[str] = None) -> Dict[str, str]:
+        headers = {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"}
+        if etag:
+            headers["If-Match"] = etag
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_payload: Optional[Mapping[str, Any]] = None,
+        etag: Optional[str] = None,
+    ) -> MutableMapping[str, Any]:
+        if self.dry_run and method.upper() != "GET":
+            return {"dryRun": True, "method": method.upper(), "path": path, "payload": dict(json_payload or {})}
+
+        url = f"{self.base_url}{path}"
+        body = None
+        if json_payload is not None:
+            body = json.dumps(dict(json_payload)).encode("utf-8")
+
+        req = request.Request(url=url, method=method.upper(), data=body, headers=self._headers(etag=etag))
+        try:
+            with request.urlopen(req, timeout=self.timeout_s) as resp:
+                raw = resp.read().decode("utf-8")
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8")
+            raise PlannerError(f"Planner API error {exc.code}: {detail}") from exc
+        except error.URLError as exc:
+            raise PlannerError(f"Planner API connection error: {exc}") from exc
+
+        if raw:
+            return json.loads(raw)
+        return {}
+
+    def create_plan(self, owner_group_id: str, title: str) -> MutableMapping[str, Any]:
+        return self._request("POST", "/plans", json_payload={"owner": owner_group_id, "title": title})
+
+    def get_plan(self, plan_id: str) -> MutableMapping[str, Any]:
+        return self._request("GET", f"/plans/{plan_id}")
+
+    def create_bucket(self, plan_id: str, name: str, order_hint: str) -> MutableMapping[str, Any]:
+        return self._request("POST", "/buckets", json_payload={"name": name, "planId": plan_id, "orderHint": order_hint})
+
+    def list_buckets(self, plan_id: str) -> MutableMapping[str, Any]:
+        return self._request("GET", f"/plans/{plan_id}/buckets")
+
+    def list_tasks(self, plan_id: str) -> MutableMapping[str, Any]:
+        return self._request("GET", f"/plans/{plan_id}/tasks")
+
+    def create_task(
+        self,
+        plan_id: str,
+        bucket_id: str,
+        title: str,
+        *,
+        assignments: Optional[Mapping[str, Any]] = None,
+        labels: Optional[Mapping[str, bool]] = None,
+        due_date_time: Optional[str] = None,
+    ) -> MutableMapping[str, Any]:
+        body: Dict[str, Any] = {"planId": plan_id, "bucketId": bucket_id, "title": title}
+        if assignments:
+            body["assignments"] = dict(assignments)
+        if labels:
+            body["appliedCategories"] = dict(labels)
+        if due_date_time:
+            body["dueDateTime"] = due_date_time
+        return self._request("POST", "/tasks", json_payload=body)
+
+    def get_task(self, task_id: str) -> MutableMapping[str, Any]:
+        return self._request("GET", f"/tasks/{task_id}")
+
+    def get_task_details(self, task_id: str) -> MutableMapping[str, Any]:
+        return self._request("GET", f"/tasks/{task_id}/details")
+
+    def update_task(self, task_id: str, etag: str, **fields: Any) -> MutableMapping[str, Any]:
+        return self._request("PATCH", f"/tasks/{task_id}", json_payload=fields, etag=etag)
+
+    def update_task_details(
+        self,
+        task_id: str,
+        etag: str,
+        *,
+        checklist: Optional[Mapping[str, Any]] = None,
+        references: Optional[Mapping[str, Any]] = None,
+        description: Optional[str] = None,
+    ) -> MutableMapping[str, Any]:
+        body: Dict[str, Any] = {}
+        if checklist is not None:
+            body["checklist"] = dict(checklist)
+        if references is not None:
+            body["references"] = dict(references)
+        if description is not None:
+            body["description"] = description
+        return self._request("PATCH", f"/tasks/{task_id}/details", json_payload=body, etag=etag)
+
+    def set_labels(self, task_id: str, etag: str, labels: Mapping[str, bool]) -> MutableMapping[str, Any]:
+        return self.update_task(task_id, etag, appliedCategories=dict(labels))
+
+    def set_assignments(self, task_id: str, etag: str, assignments: Mapping[str, Any]) -> MutableMapping[str, Any]:
+        return self.update_task(task_id, etag, assignments=dict(assignments))

--- a/plugins/tvs-microsoft-deploy/planner-orchestrator/state_manager.py
+++ b/plugins/tvs-microsoft-deploy/planner-orchestrator/state_manager.py
@@ -1,0 +1,163 @@
+"""Planner workflow state manager and operational reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, MutableMapping
+
+PHASE_ORDER: List[str] = ["EXPLORE", "PLAN", "CODE", "TEST", "FIX", "DOCUMENT"]
+TASK_PERCENT_COMPLETE = {"pending": 0, "in-progress": 50, "blocked": 50, "completed": 100}
+BLOCKER_LABEL = "category6"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class WorkflowStateManager:
+    planner_client: Any
+
+    def _phase_index(self, phase_name: str) -> int:
+        normalized = phase_name.upper()
+        if normalized not in PHASE_ORDER:
+            raise ValueError(f"Invalid phase '{phase_name}'.")
+        return PHASE_ORDER.index(normalized)
+
+    def _validate_dependencies(self, workflow: Mapping[str, Any]) -> List[str]:
+        phase_map = {phase["id"]: phase for phase in workflow.get("phases", [])}
+        issues: List[str] = []
+        for phase in workflow.get("phases", []):
+            current_index = self._phase_index(phase["name"])
+            for dep in phase.get("dependencies", []):
+                dep_id = dep["phaseId"]
+                if dep_id not in phase_map:
+                    issues.append(f"{phase['id']}: missing dependency {dep_id}")
+                    continue
+                dep_index = self._phase_index(phase_map[dep_id]["name"])
+                if dep_index >= current_index:
+                    issues.append(f"{phase['id']}: dependency {dep_id} is not earlier phase")
+        return issues
+
+    def evaluate_phase_state(self, tasks: List[Mapping[str, Any]]) -> str:
+        if not tasks:
+            return "pending"
+        if any(task.get("appliedCategories", {}).get(BLOCKER_LABEL) for task in tasks):
+            return "blocked"
+        completion = [task.get("percentComplete", 0) for task in tasks]
+        if all(v == 100 for v in completion):
+            return "completed"
+        if any(v > 0 for v in completion):
+            return "in-progress"
+        return "pending"
+
+    def _sync_phase_tasks(self, phase: Mapping[str, Any]) -> None:
+        desired = TASK_PERCENT_COMPLETE[phase["state"]]
+        for task_id in phase.get("planner", {}).get("taskIds", []):
+            task = self.planner_client.get_task(task_id)
+            etag = task.get("@odata.etag")
+            if not etag:
+                continue
+            labels: Dict[str, bool] = dict(task.get("appliedCategories") or {})
+            labels[BLOCKER_LABEL] = phase["state"] == "blocked"
+            self.planner_client.update_task(task_id, etag, percentComplete=desired, appliedCategories=labels)
+
+    def init_plan(self, workflow: MutableMapping[str, Any], group_id: str, title: str) -> MutableMapping[str, Any]:
+        plan = self.planner_client.create_plan(group_id, title)
+        plan_id = plan.get("id", "")
+        workflow.setdefault("planner", {})["planId"] = plan_id
+        workflow["planner"]["groupId"] = group_id
+
+        for idx, phase in enumerate(workflow.get("phases", []), start=1):
+            bucket = self.planner_client.create_bucket(plan_id, phase["name"], order_hint=f" !{idx}")
+            bucket_id = bucket.get("id", "")
+            phase.setdefault("planner", {})["bucketId"] = bucket_id
+            phase["planner"]["taskIds"] = []
+
+            for task_tpl in phase.get("taskTemplates", []):
+                task = self.planner_client.create_task(plan_id, bucket_id, task_tpl["title"])
+                task_id = task.get("id")
+                if not task_id:
+                    continue
+                phase["planner"]["taskIds"].append(task_id)
+                details = self.planner_client.get_task_details(task_id)
+                details_etag = details.get("@odata.etag")
+                if details_etag and (task_tpl.get("checklist") or task_tpl.get("description")):
+                    checklist = {
+                        f"item-{i}": {"title": item, "isChecked": False, "orderHint": f" !{i}"}
+                        for i, item in enumerate(task_tpl.get("checklist", []), start=1)
+                    }
+                    self.planner_client.update_task_details(
+                        task_id,
+                        details_etag,
+                        checklist=checklist,
+                        description=task_tpl.get("description"),
+                    )
+
+        return workflow
+
+    def sync_workflow(self, workflow: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        for phase in workflow.get("phases", []):
+            task_ids = phase.get("planner", {}).get("taskIds", [])
+            tasks = [self.planner_client.get_task(task_id) for task_id in task_ids]
+            phase["state"] = self.evaluate_phase_state(tasks)
+
+        workflow.setdefault("metadata", {})["lastSyncedAt"] = utc_now_iso()
+        workflow["metadata"]["dependencyIssues"] = self._validate_dependencies(workflow)
+        return workflow
+
+    def advance_phase(self, workflow: MutableMapping[str, Any], phase_name: str) -> MutableMapping[str, Any]:
+        target_index = self._phase_index(phase_name)
+        for phase in workflow.get("phases", []):
+            idx = self._phase_index(phase["name"])
+            phase["state"] = "completed" if idx < target_index else "in-progress" if idx == target_index else "pending"
+            self._sync_phase_tasks(phase)
+        workflow.setdefault("metadata", {})["advancedAt"] = utc_now_iso()
+        workflow["metadata"]["activePhase"] = phase_name.upper()
+        return workflow
+
+    def blocker_report(self, workflow: Mapping[str, Any]) -> Dict[str, Any]:
+        blocked_phases: List[Dict[str, Any]] = []
+        for phase in workflow.get("phases", []):
+            task_ids = phase.get("planner", {}).get("taskIds", [])
+            blocked_tasks = []
+            for task_id in task_ids:
+                task = self.planner_client.get_task(task_id)
+                if task.get("appliedCategories", {}).get(BLOCKER_LABEL):
+                    blocked_tasks.append({"id": task_id, "title": task.get("title", ""), "percentComplete": task.get("percentComplete", 0)})
+            if blocked_tasks:
+                blocked_phases.append(
+                    {
+                        "phaseId": phase["id"],
+                        "phase": phase["name"],
+                        "owners": phase.get("owners", []),
+                        "sla": phase.get("sla", {}),
+                        "blockedTasks": blocked_tasks,
+                    }
+                )
+
+        return {"workflowId": workflow.get("workflowId"), "generatedAt": utc_now_iso(), "blockedPhases": blocked_phases}
+
+    def closeout_pack(self, workflow: MutableMapping[str, Any]) -> Dict[str, Any]:
+        synced = self.sync_workflow(workflow)
+        phase_summary = []
+        for phase in synced.get("phases", []):
+            phase_summary.append(
+                {
+                    "phase": phase["name"],
+                    "state": phase["state"],
+                    "sla": phase.get("sla", {}),
+                    "evidenceLinks": phase.get("evidenceLinks", []),
+                    "taskCount": len(phase.get("planner", {}).get("taskIds", [])),
+                }
+            )
+
+        return {
+            "workflowId": synced.get("workflowId"),
+            "workflowName": synced.get("name"),
+            "generatedAt": utc_now_iso(),
+            "dependencyIssues": synced.get("metadata", {}).get("dependencyIssues", []),
+            "phaseSummary": phase_summary,
+            "allPhasesCompleted": all(item["state"] == "completed" for item in phase_summary),
+        }

--- a/plugins/tvs-microsoft-deploy/planner-orchestrator/workflow.schema.json
+++ b/plugins/tvs-microsoft-deploy/planner-orchestrator/workflow.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tvs.local/schemas/planner-workflow.schema.json",
+  "title": "Planner Workflow Orchestration Schema",
+  "description": "Operational workflow model for Planner orchestration across EXPLORE/PLAN/CODE/TEST/FIX/DOCUMENT phases.",
+  "type": "object",
+  "required": ["workflowId", "name", "owners", "phases"],
+  "properties": {
+    "workflowId": {"type": "string", "pattern": "^[a-zA-Z0-9._:-]{3,128}$"},
+    "name": {"type": "string", "minLength": 3},
+    "description": {"type": "string"},
+    "version": {"type": "string", "default": "1.0.0"},
+    "planner": {
+      "type": "object",
+      "properties": {
+        "planId": {"type": "string"},
+        "groupId": {"type": "string"},
+        "labelMap": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        }
+      },
+      "additionalProperties": false
+    },
+    "owners": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/owner"}},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {"type": ["string", "number", "boolean", "null"]}
+    },
+    "phases": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/phase"}}
+  },
+  "$defs": {
+    "owner": {
+      "type": "object",
+      "required": ["type", "id", "displayName"],
+      "properties": {
+        "type": {"type": "string", "enum": ["user", "group", "service"]},
+        "id": {"type": "string", "minLength": 2},
+        "displayName": {"type": "string", "minLength": 2},
+        "email": {"type": "string", "format": "email"}
+      },
+      "additionalProperties": false
+    },
+    "sla": {
+      "type": "object",
+      "required": ["targetHours"],
+      "properties": {
+        "targetHours": {"type": "integer", "minimum": 1},
+        "warningHours": {"type": "integer", "minimum": 1},
+        "breachHours": {"type": "integer", "minimum": 1}
+      },
+      "additionalProperties": false
+    },
+    "evidenceLink": {
+      "type": "object",
+      "required": ["name", "url", "type"],
+      "properties": {
+        "name": {"type": "string", "minLength": 2},
+        "url": {"type": "string", "format": "uri"},
+        "type": {"type": "string", "enum": ["document", "dashboard", "ticket", "recording", "artifact"]},
+        "notes": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "dependency": {
+      "type": "object",
+      "required": ["phaseId"],
+      "properties": {
+        "phaseId": {"type": "string", "minLength": 2},
+        "kind": {"type": "string", "enum": ["blocks", "relates-to", "requires-evidence"], "default": "blocks"},
+        "notes": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "taskTemplate": {
+      "type": "object",
+      "required": ["title"],
+      "properties": {
+        "title": {"type": "string", "minLength": 3},
+        "description": {"type": "string"},
+        "ownerIds": {"type": "array", "items": {"type": "string"}, "default": []},
+        "labels": {"type": "array", "items": {"type": "string"}, "default": []},
+        "checklist": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 2},
+          "default": []
+        },
+        "evidenceRequired": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/evidenceLink"},
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "phase": {
+      "type": "object",
+      "required": ["id", "name", "state", "owners", "sla"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-zA-Z0-9._:-]{2,64}$"},
+        "name": {"type": "string", "enum": ["EXPLORE", "PLAN", "CODE", "TEST", "FIX", "DOCUMENT"]},
+        "state": {"type": "string", "enum": ["pending", "in-progress", "blocked", "completed"]},
+        "owners": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/owner"}},
+        "sla": {"$ref": "#/$defs/sla"},
+        "dependencies": {"type": "array", "items": {"$ref": "#/$defs/dependency"}, "default": []},
+        "evidenceLinks": {"type": "array", "items": {"$ref": "#/$defs/evidenceLink"}, "default": []},
+        "taskTemplates": {"type": "array", "items": {"$ref": "#/$defs/taskTemplate"}, "default": []},
+        "planner": {
+          "type": "object",
+          "properties": {
+            "bucketId": {"type": "string"},
+            "taskIds": {"type": "array", "items": {"type": "string"}, "default": []}
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/plugins/tvs-microsoft-deploy/scripts/orchestrate_planner.py
+++ b/plugins/tvs-microsoft-deploy/scripts/orchestrate_planner.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Operational CLI for Planner workflow orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+BASE = Path(__file__).resolve().parents[1]
+ORCH = BASE / "planner-orchestrator"
+
+
+def _load_module(name: str, file_name: str):
+    spec = importlib.util.spec_from_file_location(name, ORCH / file_name)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+client_module = _load_module("planner_client", "planner_client.py")
+state_module = _load_module("state_manager", "state_manager.py")
+PlannerClient = client_module.PlannerClient
+WorkflowStateManager = state_module.WorkflowStateManager
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Planner workflow orchestrator")
+    parser.add_argument("operation", choices=["init-plan", "sync-workflow", "advance-phase", "blocker-report", "closeout-pack"])
+    parser.add_argument("--workflow", required=True, help="Workflow JSON path")
+    parser.add_argument("--output", help="Output JSON path (defaults to overwrite workflow for sync/advance)")
+    parser.add_argument("--phase", help="Phase name for advance-phase")
+    parser.add_argument("--group-id", help="M365 group for init-plan")
+    parser.add_argument("--plan-title", help="Planner plan title for init-plan")
+    parser.add_argument("--token-env", default="GRAPH_TOKEN")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    workflow_path = Path(args.workflow)
+    workflow = _load_json(workflow_path)
+
+    token = os.getenv(args.token_env, "dry-run-token")
+    client = PlannerClient(token=token, dry_run=args.dry_run)
+    manager = WorkflowStateManager(client)
+
+    if args.operation == "init-plan":
+        if not args.group_id or not args.plan_title:
+            raise SystemExit("init-plan requires --group-id and --plan-title")
+        result = manager.init_plan(workflow, args.group_id, args.plan_title)
+    elif args.operation == "sync-workflow":
+        result = manager.sync_workflow(workflow)
+    elif args.operation == "advance-phase":
+        if not args.phase:
+            raise SystemExit("advance-phase requires --phase")
+        result = manager.advance_phase(workflow, args.phase)
+    elif args.operation == "blocker-report":
+        result = manager.blocker_report(workflow)
+    else:
+        result = manager.closeout_pack(workflow)
+
+    output = Path(args.output) if args.output else workflow_path
+    _write_json(output, result)
+    print(f"Wrote {args.operation} output to {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/tvs-microsoft-deploy/workflows/templates/planner/client-onboarding.workflow.json
+++ b/plugins/tvs-microsoft-deploy/workflows/templates/planner/client-onboarding.workflow.json
@@ -1,0 +1,15 @@
+{
+  "workflowId": "client-onboarding",
+  "name": "Client Onboarding",
+  "description": "Client onboarding from discovery through implementation handoff.",
+  "version": "1.1.0",
+  "owners": [{"type":"group","id":"client-success","displayName":"Client Success"}],
+  "phases": [
+    {"id":"explore","name":"EXPLORE","state":"pending","owners":[{"type":"group","id":"solutions","displayName":"Solutions Team"}],"sla":{"targetHours":16},"dependencies":[],"evidenceLinks":[],"taskTemplates":[{"title":"Capture business and technical discovery","checklist":["Use cases prioritized","System constraints captured"]}]},
+    {"id":"plan","name":"PLAN","state":"pending","owners":[{"type":"group","id":"client-success","displayName":"Client Success"}],"sla":{"targetHours":24},"dependencies":[{"phaseId":"explore"}],"evidenceLinks":[],"taskTemplates":[{"title":"Finalize onboarding blueprint","checklist":["Milestones aligned with client","Resource plan approved"]}]},
+    {"id":"code","name":"CODE","state":"pending","owners":[{"type":"group","id":"implementation","displayName":"Implementation Team"}],"sla":{"targetHours":56},"dependencies":[{"phaseId":"plan"}],"evidenceLinks":[],"taskTemplates":[{"title":"Configure solution baseline","checklist":["Environments provisioned","Initial integrations connected"]}]},
+    {"id":"test","name":"TEST","state":"pending","owners":[{"type":"group","id":"client-uat","displayName":"Client UAT"}],"sla":{"targetHours":24},"dependencies":[{"phaseId":"code"}],"evidenceLinks":[],"taskTemplates":[{"title":"Execute client UAT plan","checklist":["Critical flows signed off","Defects triaged"]}]},
+    {"id":"fix","name":"FIX","state":"pending","owners":[{"type":"group","id":"implementation","displayName":"Implementation Team"}],"sla":{"targetHours":16},"dependencies":[{"phaseId":"test"}],"evidenceLinks":[],"taskTemplates":[{"title":"Resolve UAT issues","checklist":["Defects remediated","Retest passed"]}]},
+    {"id":"document","name":"DOCUMENT","state":"pending","owners":[{"type":"group","id":"enablement","displayName":"Enablement"}],"sla":{"targetHours":16},"dependencies":[{"phaseId":"fix"}],"evidenceLinks":[],"taskTemplates":[{"title":"Deliver onboarding closeout pack","checklist":["Runbook delivered","Training complete","Hypercare schedule agreed"]}]}
+  ]
+}

--- a/plugins/tvs-microsoft-deploy/workflows/templates/planner/incident-response.workflow.json
+++ b/plugins/tvs-microsoft-deploy/workflows/templates/planner/incident-response.workflow.json
@@ -1,0 +1,15 @@
+{
+  "workflowId": "incident-response",
+  "name": "Incident Response",
+  "description": "Incident workflow for triage, restoration, hardening, and postmortem evidence.",
+  "version": "1.1.0",
+  "owners": [{"type":"group","id":"incident-command","displayName":"Incident Command"}],
+  "phases": [
+    {"id":"explore","name":"EXPLORE","state":"pending","owners":[{"type":"group","id":"soc","displayName":"Security Operations"}],"sla":{"targetHours":2},"dependencies":[],"evidenceLinks":[],"taskTemplates":[{"title":"Confirm incident scope and severity","checklist":["Severity assigned","Affected services listed"]}]},
+    {"id":"plan","name":"PLAN","state":"pending","owners":[{"type":"group","id":"incident-command","displayName":"Incident Command"}],"sla":{"targetHours":2},"dependencies":[{"phaseId":"explore"}],"evidenceLinks":[],"taskTemplates":[{"title":"Approve containment plan","checklist":["Containment owner assigned","Comms cadence established"]}]},
+    {"id":"code","name":"CODE","state":"pending","owners":[{"type":"group","id":"platform","displayName":"Platform Engineering"}],"sla":{"targetHours":8},"dependencies":[{"phaseId":"plan"}],"evidenceLinks":[],"taskTemplates":[{"title":"Implement mitigations","checklist":["Hotfix deployed","Threat indicators blocked"]}]},
+    {"id":"test","name":"TEST","state":"pending","owners":[{"type":"group","id":"qa-team","displayName":"Validation Team"}],"sla":{"targetHours":4},"dependencies":[{"phaseId":"code"}],"evidenceLinks":[],"taskTemplates":[{"title":"Validate service restoration","checklist":["Monitoring healthy for 30m","Core journeys verified"]}]},
+    {"id":"fix","name":"FIX","state":"pending","owners":[{"type":"group","id":"platform","displayName":"Platform Engineering"}],"sla":{"targetHours":6},"dependencies":[{"phaseId":"test"}],"evidenceLinks":[],"taskTemplates":[{"title":"Apply hardening remediations","checklist":["Root cause addressed","Compensating controls in place"]}]},
+    {"id":"document","name":"DOCUMENT","state":"pending","owners":[{"type":"group","id":"comms","displayName":"Comms + Postmortem"}],"sla":{"targetHours":12},"dependencies":[{"phaseId":"fix"}],"evidenceLinks":[],"taskTemplates":[{"title":"Publish post-incident review","checklist":["Timeline documented","Action items assigned","Leadership readout sent"]}]}
+  ]
+}

--- a/plugins/tvs-microsoft-deploy/workflows/templates/planner/migration-wave.workflow.json
+++ b/plugins/tvs-microsoft-deploy/workflows/templates/planner/migration-wave.workflow.json
@@ -1,0 +1,15 @@
+{
+  "workflowId": "migration-wave",
+  "name": "Migration Wave",
+  "description": "Tenant migration wave for data, automations, and enablement cutover.",
+  "version": "1.1.0",
+  "owners": [{"type":"group","id":"migration-office","displayName":"Migration Office"}],
+  "phases": [
+    {"id":"explore","name":"EXPLORE","state":"pending","owners":[{"type":"user","id":"arch-lead","displayName":"Architecture Lead"}],"sla":{"targetHours":40},"dependencies":[],"evidenceLinks":[],"taskTemplates":[{"title":"Inventory source systems","checklist":["Systems catalog complete","Data owners confirmed"]}]},
+    {"id":"plan","name":"PLAN","state":"pending","owners":[{"type":"group","id":"pm-team","displayName":"Program Management"}],"sla":{"targetHours":48},"dependencies":[{"phaseId":"explore"}],"evidenceLinks":[],"taskTemplates":[{"title":"Sequence migration wave backlog","checklist":["Dependency chains mapped","Rollback strategy drafted"]}]},
+    {"id":"code","name":"CODE","state":"pending","owners":[{"type":"group","id":"delivery-squad","displayName":"Delivery Squad"}],"sla":{"targetHours":96},"dependencies":[{"phaseId":"plan"}],"evidenceLinks":[],"taskTemplates":[{"title":"Build migration pipelines","checklist":["Pipeline templates committed","Secrets and identities configured"]}]},
+    {"id":"test","name":"TEST","state":"pending","owners":[{"type":"group","id":"uat-team","displayName":"UAT Team"}],"sla":{"targetHours":40},"dependencies":[{"phaseId":"code"}],"evidenceLinks":[],"taskTemplates":[{"title":"Run parallel validation","checklist":["Source-target reconciliation <1% variance","User acceptance approved"]}]},
+    {"id":"fix","name":"FIX","state":"pending","owners":[{"type":"group","id":"hypercare","displayName":"Hypercare"}],"sla":{"targetHours":32},"dependencies":[{"phaseId":"test"}],"evidenceLinks":[],"taskTemplates":[{"title":"Triage migration defects","checklist":["Priority defects resolved","Residual risk accepted"]}]},
+    {"id":"document","name":"DOCUMENT","state":"pending","owners":[{"type":"group","id":"change-mgmt","displayName":"Change Management"}],"sla":{"targetHours":24},"dependencies":[{"phaseId":"fix"}],"evidenceLinks":[],"taskTemplates":[{"title":"Publish wave handover","checklist":["Runbook finalized","Support model accepted"]}]}
+  ]
+}

--- a/plugins/tvs-microsoft-deploy/workflows/templates/planner/taia-sale-prep.workflow.json
+++ b/plugins/tvs-microsoft-deploy/workflows/templates/planner/taia-sale-prep.workflow.json
@@ -1,0 +1,25 @@
+{
+  "workflowId": "taia-sale-prep",
+  "name": "TAIA Sale Prep",
+  "description": "Prepare TAIA assets, compliance posture, and due-diligence evidence for buyer readiness.",
+  "version": "1.1.0",
+  "owners": [{ "type": "group", "id": "sales-readiness", "displayName": "Sales Readiness Team" }],
+  "planner": {
+    "labelMap": {
+      "category1": "Risk",
+      "category2": "Compliance",
+      "category3": "Finance",
+      "category4": "Security",
+      "category5": "External-Dependency",
+      "category6": "Blocked"
+    }
+  },
+  "phases": [
+    {"id":"explore","name":"EXPLORE","state":"pending","owners":[{"type":"user","id":"owner-ops","displayName":"Ops Lead"}],"sla":{"targetHours":24,"warningHours":18},"dependencies":[],"evidenceLinks":[],"taskTemplates":[{"title":"Confirm buyer diligence scope","checklist":["Buyer request list collected","Data room index approved"]},{"title":"Identify deal-risk hotspots","labels":["Risk","Finance"],"checklist":["Revenue concentration analyzed","Carrier dependency matrix drafted"]}]},
+    {"id":"plan","name":"PLAN","state":"pending","owners":[{"type":"user","id":"owner-pm","displayName":"Program Manager"}],"sla":{"targetHours":36,"warningHours":24},"dependencies":[{"phaseId":"explore"}],"evidenceLinks":[],"taskTemplates":[{"title":"Publish sale-prep workback plan","checklist":["Owner mapping done","Milestone baseline approved"]},{"title":"Define required evidence artifacts","labels":["Compliance"],"checklist":["SOC controls mapping","Contractual obligations matrix"]}]},
+    {"id":"code","name":"CODE","state":"pending","owners":[{"type":"group","id":"eng-team","displayName":"Engineering"}],"sla":{"targetHours":72,"warningHours":48},"dependencies":[{"phaseId":"plan"}],"evidenceLinks":[],"taskTemplates":[{"title":"Implement extraction automations","labels":["External-Dependency"],"checklist":["Fabric pipeline run complete","Dataverse export generated"]},{"title":"Generate buyer-ready KPI pack","labels":["Finance"],"checklist":["Revenue rollup validated","Variance notes attached"]}]},
+    {"id":"test","name":"TEST","state":"pending","owners":[{"type":"group","id":"qa-team","displayName":"QA"}],"sla":{"targetHours":24},"dependencies":[{"phaseId":"code"}],"evidenceLinks":[],"taskTemplates":[{"title":"Validate artifact completeness","checklist":["Evidence links resolvable","No stale data older than 24h"]}]},
+    {"id":"fix","name":"FIX","state":"pending","owners":[{"type":"group","id":"eng-team","displayName":"Engineering"}],"sla":{"targetHours":24},"dependencies":[{"phaseId":"test"}],"evidenceLinks":[],"taskTemplates":[{"title":"Remediate diligence findings","labels":["Risk"],"checklist":["Action owner assigned","Updated artifact linked"]}]},
+    {"id":"document","name":"DOCUMENT","state":"pending","owners":[{"type":"group","id":"revops","displayName":"Revenue Operations"}],"sla":{"targetHours":16},"dependencies":[{"phaseId":"fix"}],"evidenceLinks":[],"taskTemplates":[{"title":"Publish final closeout pack","checklist":["Executive summary written","Evidence manifest exported","Sign-off captured"]}]}
+  ]
+}


### PR DESCRIPTION
### Motivation
- Convert the original Planner scaffolding into a usable end-to-end orchestration tool modeled on the ergonomics of the Jira orchestrator. 
- Provide runtime primitives (plan/bucket/task lifecycle, blocker handling, SLA/evidence fields) so templates can be applied to real Planner plans. 
- Make operations safe to validate locally by supporting `--dry-run` and using only the standard library for HTTP calls in CI-like environments.

### Description
- Introduce `planner-orchestrator` package with a practical API in `planner_client.py` that implements plans, buckets, tasks, task details, checklist/refs, label/assignment updates, structured error handling, and a `dry_run` mode. 
- Add `state_manager.py` with `WorkflowStateManager` implementing `init_plan`, `sync_workflow`, `advance_phase`, `blocker_report`, and `closeout_pack`, plus dependency validation and phase↔task synchronization logic. 
- Add an executable CLI `scripts/orchestrate_planner.py` that wires the client and state manager into operations (`init-plan`, `sync-workflow`, `advance-phase`, `blocker-report`, `closeout-pack`) with argument validation, `--dry-run`, and output artifact writing. 
- Expand `workflow.schema.json` and four workflow templates under `workflows/templates/planner/` to include planner metadata, `taskTemplates`, checklists, owners, SLAs, dependencies, and evidence link structures. 
- Add `commands/orchestrate-planner.md` documenting usage, examples, and dry-run guidance.

### Testing
- Compiled Python modules with `python -m py_compile` for `planner_client.py`, `state_manager.py`, `__init__.py`, and the CLI, which completed successfully. 
- Parsed JSON schema and all template files using a Python `json.load` script which validated 5 JSON files successfully. 
- Performed an end-to-end dry-run sequence with the new CLI (`init-plan`, `sync-workflow`, `blocker-report`, `closeout-pack`) producing expected output artifacts, all commands succeeded in dry-run mode. 
- Verified the CLI module loader is resilient in this environment and the orchestrator produces the expected JSON outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7d7a82e8832a82d2fff0c3fd7c3c)