### PR TITLE
Add Fabric ad-hoc pipeline specs, templates, and tooling

### DIFF
--- a/plugins/tvs-microsoft-deploy/fabric/pipelines/adhoc_pipeline.schema.json
+++ b/plugins/tvs-microsoft-deploy/fabric/pipelines/adhoc_pipeline.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Fabric Ad Hoc Pipeline",
+  "type": "object",
+  "required": [
+    "pipeline_id",
+    "display_name",
+    "workspace_id",
+    "sources",
+    "transforms",
+    "sinks",
+    "schedule",
+    "quality_rules",
+    "lineage"
+  ],
+  "properties": {
+    "pipeline_id": {"type": "string", "pattern": "^pl_[a-z0-9_]+$"},
+    "display_name": {"type": "string", "minLength": 3},
+    "workspace_id": {"type": "string", "minLength": 5},
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "object", "connection_ref"],
+        "properties": {
+          "id": {"type": "string"},
+          "type": {"type": "string"},
+          "object": {"type": "string"},
+          "connection_ref": {"type": "string"},
+          "watermark_column": {"type": "string"}
+        }
+      }
+    },
+    "transforms": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "type"],
+        "properties": {
+          "id": {"type": "string"},
+          "type": {"type": "string", "enum": ["notebook", "sql", "spark_job"]},
+          "notebook_path": {"type": "string"},
+          "timeout_minutes": {"type": "integer", "minimum": 1}
+        }
+      }
+    },
+    "sinks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "target", "mode"],
+        "properties": {
+          "id": {"type": "string"},
+          "type": {"type": "string"},
+          "lakehouse_id": {"type": "string"},
+          "target": {"type": "string"},
+          "mode": {"type": "string", "enum": ["append", "overwrite", "merge"]}
+        }
+      }
+    },
+    "schedule": {
+      "type": "object",
+      "required": ["frequency", "timezone", "retry"],
+      "properties": {
+        "frequency": {"type": "string", "enum": ["adhoc", "hourly", "daily", "weekly", "monthly"]},
+        "cron_utc": {"type": ["string", "null"]},
+        "timezone": {"type": "string"},
+        "retry": {
+          "type": "object",
+          "required": ["max_attempts", "initial_backoff_seconds", "max_backoff_seconds"],
+          "properties": {
+            "max_attempts": {"type": "integer", "minimum": 1, "maximum": 10},
+            "initial_backoff_seconds": {"type": "integer", "minimum": 1},
+            "max_backoff_seconds": {"type": "integer", "minimum": 1}
+          }
+        }
+      }
+    },
+    "quality_rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "operator", "threshold", "severity"],
+        "properties": {
+          "id": {"type": "string"},
+          "type": {"type": "string"},
+          "operator": {"type": "string"},
+          "threshold": {"type": ["number", "integer"]},
+          "severity": {"type": "string", "enum": ["warning", "error"]}
+        }
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "required": ["owner", "domain", "upstream", "downstream", "tags"],
+      "properties": {
+        "owner": {"type": "string"},
+        "domain": {"type": "string"},
+        "upstream": {"type": "array", "items": {"type": "string"}},
+        "downstream": {"type": "array", "items": {"type": "string"}},
+        "tags": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }
+}

--- a/plugins/tvs-microsoft-deploy/fabric/pipelines/spec-format.md
+++ b/plugins/tvs-microsoft-deploy/fabric/pipelines/spec-format.md
@@ -1,0 +1,137 @@
+# Fabric Ad Hoc Pipeline Specification Format
+
+This document defines the JSON/YAML structure consumed by `scripts/fabric/create_adhoc_pipeline.py` and `scripts/fabric/run_adhoc_pipeline.py`.
+
+## Required root fields
+
+- `pipeline_id`: globally unique id (e.g. `pl_dataverse_daily_sync`)
+- `display_name`: human-readable name
+- `workspace_id`: Fabric workspace id
+- `sources`: list of source objects
+- `transforms`: ordered list of transform steps
+- `sinks`: list of write destinations
+- `schedule`: cadence and runtime constraints
+- `quality_rules`: gates that can fail the run
+- `lineage`: ownership and upstream/downstream declarations
+
+## YAML example
+
+```yaml
+pipeline_id: pl_dataverse_daily_sync
+display_name: Dataverse to Lakehouse Daily Sync
+workspace_id: ws-tvs-prod-00000001
+sources:
+  - id: src_account
+    type: dataverse
+    object: account
+    connection_ref: dataverse-prod
+    watermark_column: modifiedon
+transforms:
+  - id: tr_normalize
+    type: notebook
+    notebook_path: fabric/notebooks/tvs_curated_transform.ipynb
+    timeout_minutes: 60
+sinks:
+  - id: sink_account_delta
+    type: lakehouse_table
+    lakehouse_id: lh-tvs-raw
+    target: Tables/dv_account
+    mode: merge
+schedule:
+  frequency: daily
+  cron_utc: "0 3 * * *"
+  timezone: UTC
+  retry:
+    max_attempts: 4
+    initial_backoff_seconds: 30
+    max_backoff_seconds: 600
+quality_rules:
+  - id: qr_non_empty
+    type: row_count
+    operator: ">="
+    threshold: 1
+    severity: error
+  - id: qr_freshness
+    type: freshness_minutes
+    operator: "<="
+    threshold: 180
+    severity: warning
+lineage:
+  owner: dataops@tvs.example
+  domain: fabric-platform
+  upstream:
+    - dataverse/account
+  downstream:
+    - semantic-model/client360
+  tags:
+    - ad-hoc
+    - dataverse
+```
+
+## JSON example
+
+```json
+{
+  "pipeline_id": "pl_taia_archive_import",
+  "display_name": "TAIA Archive Import",
+  "workspace_id": "ws-a3archive-prod-00000005",
+  "sources": [
+    {
+      "id": "src_archive",
+      "type": "adls_gen2",
+      "object": "/a3-archive/exports/",
+      "connection_ref": "adls-archive"
+    }
+  ],
+  "transforms": [
+    {
+      "id": "tr_validate",
+      "type": "notebook",
+      "notebook_path": "fabric/notebooks/a3_archive_validate.ipynb",
+      "timeout_minutes": 90
+    }
+  ],
+  "sinks": [
+    {
+      "id": "sink_archive_raw",
+      "type": "lakehouse_table",
+      "lakehouse_id": "lh-a3-archive",
+      "target": "Tables/archive_commission_raw",
+      "mode": "append"
+    }
+  ],
+  "schedule": {
+    "frequency": "adhoc",
+    "cron_utc": null,
+    "timezone": "UTC",
+    "retry": {
+      "max_attempts": 3,
+      "initial_backoff_seconds": 60,
+      "max_backoff_seconds": 900
+    }
+  },
+  "quality_rules": [
+    {
+      "id": "qr_archive_schema",
+      "type": "schema_match",
+      "operator": "=",
+      "threshold": 1,
+      "severity": "error"
+    }
+  ],
+  "lineage": {
+    "owner": "taia-ops@tvs.example",
+    "domain": "taia-archive",
+    "upstream": [
+      "firebase/export"
+    ],
+    "downstream": [
+      "lakehouse/archive_commission_raw"
+    ],
+    "tags": [
+      "ad-hoc",
+      "archive"
+    ]
+  }
+}
+```

--- a/plugins/tvs-microsoft-deploy/fabric/pipelines/templates/client-kpi-mart-generation.pipeline.yaml
+++ b/plugins/tvs-microsoft-deploy/fabric/pipelines/templates/client-kpi-mart-generation.pipeline.yaml
@@ -1,0 +1,57 @@
+pipeline_id: pl_client_kpi_mart_generation
+display_name: Client-specific KPI Mart Generation
+workspace_id: ws-consolidated-prod-00000006
+sources:
+  - id: src_sales_fact
+    type: onelake_shortcut
+    object: Tables/sv_sales_fact_conformed
+    connection_ref: consolidated-onelake
+    watermark_column: event_ts
+  - id: src_commission_fact
+    type: onelake_shortcut
+    object: Tables/sv_commission_fact_normalized
+    connection_ref: consolidated-onelake
+    watermark_column: batch_ts
+transforms:
+  - id: tr_consolidated_rollup
+    type: notebook
+    notebook_path: fabric/notebooks/consolidated_rollup.ipynb
+    timeout_minutes: 45
+sinks:
+  - id: sink_client_kpi_mart
+    type: lakehouse_table
+    lakehouse_id: lh-consolidated-gold
+    target: Tables/gd_client_kpi_mart
+    mode: overwrite
+schedule:
+  frequency: daily
+  cron_utc: "0 4 * * *"
+  timezone: UTC
+  retry:
+    max_attempts: 3
+    initial_backoff_seconds: 120
+    max_backoff_seconds: 1200
+quality_rules:
+  - id: qr_kpi_metric_coverage
+    type: metric_coverage
+    operator: ">="
+    threshold: 0.98
+    severity: error
+  - id: qr_kpi_null_rate
+    type: null_rate
+    operator: "<="
+    threshold: 0.02
+    severity: warning
+lineage:
+  owner: analytics@tvs.example
+  domain: embedded-analytics
+  upstream:
+    - lakehouse/sv_sales_fact_conformed
+    - lakehouse/sv_commission_fact_normalized
+  downstream:
+    - lakehouse/gd_client_kpi_mart
+    - report/buyer_due_diligence
+  tags:
+    - recurring
+    - kpi-mart
+    - client-facing

--- a/plugins/tvs-microsoft-deploy/fabric/pipelines/templates/dataverse-to-lakehouse-sync.pipeline.yaml
+++ b/plugins/tvs-microsoft-deploy/fabric/pipelines/templates/dataverse-to-lakehouse-sync.pipeline.yaml
@@ -1,0 +1,63 @@
+pipeline_id: pl_dataverse_to_lakehouse_sync
+display_name: Dataverse to Lakehouse Sync
+workspace_id: ws-tvs-prod-00000001
+sources:
+  - id: src_dataverse_account
+    type: dataverse
+    object: account
+    connection_ref: dataverse-tvs-prod
+    watermark_column: modifiedon
+  - id: src_dataverse_opportunity
+    type: dataverse
+    object: opportunity
+    connection_ref: dataverse-tvs-prod
+    watermark_column: modifiedon
+transforms:
+  - id: tr_tvs_curated_transform
+    type: notebook
+    notebook_path: fabric/notebooks/tvs_curated_transform.ipynb
+    timeout_minutes: 60
+sinks:
+  - id: sink_account
+    type: lakehouse_table
+    lakehouse_id: lh-tvs-curated
+    target: Tables/dv_account
+    mode: merge
+  - id: sink_opportunity
+    type: lakehouse_table
+    lakehouse_id: lh-tvs-curated
+    target: Tables/dv_opportunity
+    mode: merge
+schedule:
+  frequency: hourly
+  cron_utc: "15 * * * *"
+  timezone: UTC
+  retry:
+    max_attempts: 4
+    initial_backoff_seconds: 30
+    max_backoff_seconds: 600
+quality_rules:
+  - id: qr_account_primary_key
+    type: duplicate_rate
+    operator: "<="
+    threshold: 0
+    severity: error
+  - id: qr_sync_freshness
+    type: freshness_minutes
+    operator: "<="
+    threshold: 90
+    severity: error
+lineage:
+  owner: dataops@tvs.example
+  domain: crm-analytics
+  upstream:
+    - dataverse/account
+    - dataverse/opportunity
+  downstream:
+    - lakehouse/dv_account
+    - lakehouse/dv_opportunity
+    - semantic-model/client360
+  tags:
+    - recurring
+    - dataverse
+    - lakehouse-sync

--- a/plugins/tvs-microsoft-deploy/fabric/pipelines/templates/taia-archive-import.pipeline.yaml
+++ b/plugins/tvs-microsoft-deploy/fabric/pipelines/templates/taia-archive-import.pipeline.yaml
@@ -1,0 +1,52 @@
+pipeline_id: pl_taia_archive_import
+display_name: TAIA Archive Import
+workspace_id: ws-a3archive-prod-00000005
+sources:
+  - id: src_taia_archive_drop
+    type: adls_gen2
+    object: /a3-archive/exports/
+    connection_ref: adls-taia-archive
+    watermark_column: export_ts
+transforms:
+  - id: tr_a3_archive_validate
+    type: notebook
+    notebook_path: fabric/notebooks/a3_archive_validate.ipynb
+    timeout_minutes: 90
+sinks:
+  - id: sink_archive_raw
+    type: lakehouse_table
+    lakehouse_id: lh-a3-archive-prod
+    target: Tables/archive_commission_raw
+    mode: append
+schedule:
+  frequency: adhoc
+  cron_utc: null
+  timezone: UTC
+  retry:
+    max_attempts: 3
+    initial_backoff_seconds: 60
+    max_backoff_seconds: 900
+quality_rules:
+  - id: qr_archive_required_columns
+    type: schema_match
+    operator: "="
+    threshold: 1
+    severity: error
+  - id: qr_archive_min_rows
+    type: row_count
+    operator: ">="
+    threshold: 100
+    severity: warning
+lineage:
+  owner: taia-ops@tvs.example
+  domain: taia-archive
+  upstream:
+    - firebase/export
+    - adls/a3-archive
+  downstream:
+    - lakehouse/archive_commission_raw
+    - semantic-model/taia_due_diligence
+  tags:
+    - ad-hoc
+    - taia
+    - archive

--- a/plugins/tvs-microsoft-deploy/scripts/fabric/create_adhoc_pipeline.py
+++ b/plugins/tvs-microsoft-deploy/scripts/fabric/create_adhoc_pipeline.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Generate ad hoc Fabric pipeline specs from curated templates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover
+    yaml = None
+
+ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_DIR = ROOT / "fabric" / "pipelines" / "templates"
+
+
+def _load_template(path: Path) -> dict:
+    if yaml is None:
+        raise SystemExit("PyYAML is required. Install with: pip install pyyaml")
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise SystemExit(f"Invalid template payload in {path}")
+    return data
+
+
+def _apply_vars(payload: dict, pairs: list[str]) -> dict:
+    for pair in pairs:
+        if "=" not in pair:
+            raise SystemExit(f"Invalid --set value '{pair}'. Expected key=value")
+        key, raw = pair.split("=", 1)
+        cursor = payload
+        parts = key.split(".")
+        for part in parts[:-1]:
+            if part not in cursor or not isinstance(cursor[part], dict):
+                cursor[part] = {}
+            cursor = cursor[part]
+        cursor[parts[-1]] = raw
+    return payload
+
+
+def _emit(payload: dict, fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(payload, indent=2) + "\n"
+    if yaml is None:
+        raise SystemExit("PyYAML is required for yaml output. Install with: pip install pyyaml")
+    return yaml.safe_dump(payload, sort_keys=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", required=True, help="Template name without extension")
+    parser.add_argument("--output", required=True, help="Output path for the generated spec")
+    parser.add_argument("--format", choices=["yaml", "json"], default="yaml")
+    parser.add_argument("--set", action="append", default=[], metavar="KEY=VALUE", help="Override a value, supports dotted keys")
+    args = parser.parse_args()
+
+    template_path = TEMPLATE_DIR / f"{args.template}.pipeline.yaml"
+    if not template_path.exists():
+        available = sorted(p.stem.replace(".pipeline", "") for p in TEMPLATE_DIR.glob("*.pipeline.yaml"))
+        raise SystemExit(f"Template not found: {args.template}. Available: {', '.join(available)}")
+
+    payload = _apply_vars(_load_template(template_path), args.set)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(_emit(payload, args.format), encoding="utf-8")
+    print(f"Generated {out} from template {template_path.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tvs-microsoft-deploy/scripts/fabric/run_adhoc_pipeline.py
+++ b/plugins/tvs-microsoft-deploy/scripts/fabric/run_adhoc_pipeline.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Validate and execute an ad hoc Fabric pipeline spec with retries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover
+    yaml = None
+
+REQUIRED_TOP_LEVEL = [
+    "pipeline_id",
+    "display_name",
+    "workspace_id",
+    "sources",
+    "transforms",
+    "sinks",
+    "schedule",
+    "quality_rules",
+    "lineage",
+]
+
+
+def _load_spec(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        payload = json.loads(text)
+    else:
+        if yaml is None:
+            raise SystemExit("PyYAML is required for YAML specs. Install with: pip install pyyaml")
+        payload = yaml.safe_load(text)
+
+    if not isinstance(payload, dict):
+        raise SystemExit("Spec must deserialize to an object")
+    return payload
+
+
+def _validate(spec: dict) -> None:
+    missing = [k for k in REQUIRED_TOP_LEVEL if k not in spec]
+    if missing:
+        raise SystemExit(f"Spec missing required top-level keys: {', '.join(missing)}")
+    if not spec["sources"] or not spec["transforms"] or not spec["sinks"]:
+        raise SystemExit("Spec must contain at least one source, transform, and sink")
+
+    retry = spec.get("schedule", {}).get("retry", {})
+    for key in ("max_attempts", "initial_backoff_seconds", "max_backoff_seconds"):
+        if key not in retry:
+            raise SystemExit(f"schedule.retry missing {key}")
+
+    lineage = spec.get("lineage", {})
+    for key in ("owner", "upstream", "downstream", "tags"):
+        if key not in lineage:
+            raise SystemExit(f"lineage missing {key}")
+
+
+def _run_notebook(client, workspace_id: str, transform: dict, run_parameters: dict) -> str:
+    notebook_id = transform.get("notebook_id")
+    if not notebook_id:
+        raise SystemExit(f"Transform {transform.get('id')} is missing notebook_id; required for execution")
+
+    response = client.request(
+        "POST",
+        f"/workspaces/{workspace_id}/items/{notebook_id}/jobs/instances",
+        params={"jobType": "RunNotebook"},
+        json_body={"executionData": {"parameters": run_parameters}},
+    )
+    if response.status_code >= 300:
+        raise SystemExit(f"Notebook start failed ({response.status_code}): {response.text}")
+    payload = response.json()
+    run_id = payload.get("id") or payload.get("runId")
+    if not run_id:
+        raise SystemExit(f"Notebook start response missing run id: {payload}")
+    return run_id
+
+
+def execute(spec: dict, dry_run: bool) -> None:
+    retry = spec["schedule"]["retry"]
+    if dry_run:
+        print(json.dumps({"mode": "dry-run", "pipeline": spec["pipeline_id"], "transforms": spec["transforms"]}, indent=2))
+        return
+
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parents[1] / "api"))
+    from _core import ApiClient  # noqa: WPS433
+
+    client = ApiClient("https://api.fabric.microsoft.com/v1", token_env="FABRIC_TOKEN")
+    workspace_id = spec["workspace_id"]
+
+    for transform in spec["transforms"]:
+        if transform.get("type") != "notebook":
+            print(f"Skipping unsupported transform type: {transform.get('type')}")
+            continue
+
+        attempt = 1
+        delay = int(retry["initial_backoff_seconds"])
+        max_delay = int(retry["max_backoff_seconds"])
+        max_attempts = int(retry["max_attempts"])
+
+        while True:
+            try:
+                run_id = _run_notebook(client, workspace_id, transform, {"pipeline_id": spec["pipeline_id"]})
+                print(f"Submitted {transform['id']} run: {run_id}")
+                break
+            except SystemExit as err:
+                if attempt >= max_attempts:
+                    raise
+                print(f"Attempt {attempt}/{max_attempts} failed for {transform['id']}: {err}. Retrying in {delay}s")
+                time.sleep(delay)
+                delay = min(delay * 2, max_delay)
+                attempt += 1
+
+    print("Execution submitted. Enforce quality_rules and lineage registration in downstream monitoring jobs.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", required=True, help="Path to JSON or YAML pipeline spec")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and print actions without API execution")
+    args = parser.parse_args()
+
+    spec = _load_spec(Path(args.spec))
+    _validate(spec)
+    execute(spec, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tvs-microsoft-deploy/skills/fabric-pipeline-authoring.md
+++ b/plugins/tvs-microsoft-deploy/skills/fabric-pipeline-authoring.md
@@ -1,0 +1,71 @@
+---
+name: Fabric Pipeline Authoring
+description: Use this skill when designing or executing ad hoc Fabric data pipelines under fabric/pipelines/** or scripts/fabric/**, including template generation, retry strategy, quality rules, and lineage requirements.
+version: 1.0.0
+---
+
+> Docs Hub: [Skills Hub](../docs/skills/README.md#skill-index)
+
+# Fabric Pipeline Authoring
+
+## Scope
+
+Use this skill for:
+
+- Building ad hoc pipeline specs in JSON/YAML.
+- Generating pipeline specs from curated templates.
+- Running ad hoc notebook-based transforms with guarded retries.
+- Applying lineage and quality requirements before deployment.
+
+## Authoring Workflow
+
+1. Pick a baseline template from `fabric/pipelines/templates/`.
+2. Generate a pipeline file with `scripts/fabric/create_adhoc_pipeline.py`.
+3. Verify required sections: `sources`, `transforms`, `sinks`, `schedule`, `quality_rules`, `lineage`.
+4. Include notebook `notebook_id` values for executable transforms.
+5. Dry-run with `scripts/fabric/run_adhoc_pipeline.py --dry-run`.
+6. Execute with `FABRIC_TOKEN` set, then monitor run IDs via Fabric jobs APIs.
+
+## Design Patterns
+
+### 1) TAIA archive import
+
+- Source: ADLS/Firebase export landing path.
+- Transform: schema validation notebook first.
+- Sink: append-only raw table for replay safety.
+- Quality: schema_match + minimum row count.
+
+### 2) Dataverse to lakehouse sync
+
+- Source: Dataverse entities with watermark (`modifiedon`).
+- Transform: normalization notebook.
+- Sink: merge mode tables keyed on Dataverse IDs.
+- Quality: duplicate-rate + freshness SLA.
+
+### 3) Client KPI mart generation
+
+- Source: conformed sales/commission OneLake tables.
+- Transform: consolidated rollup notebook.
+- Sink: curated gold mart table (overwrite by partition/date).
+- Quality: metric coverage + null-rate thresholds.
+
+## Retry Strategy
+
+- Retry on `429` and transient `5xx` only.
+- Start at `30-60s` backoff, doubling per attempt.
+- Cap backoff at `10-20m`.
+- Typical limits:
+  - recurring hourly: `max_attempts=4`
+  - daily/adhoc heavy jobs: `max_attempts=3`
+
+## Lineage Requirements
+
+Each spec must declare:
+
+- `lineage.owner`: team mailbox or on-call alias.
+- `lineage.domain`: business or platform area.
+- `lineage.upstream`: all external input systems/tables.
+- `lineage.downstream`: marts, semantic models, reports.
+- `lineage.tags`: searchable labels (`ad-hoc`, `recurring`, domain tags).
+
+If lineage is incomplete, do not promote the pipeline to recurring schedule.


### PR DESCRIPTION
### Motivation

- Provide a standard JSON/YAML specification and validation schema to author ad hoc Microsoft Fabric pipelines with clear sources/transforms/sinks, schedule, quality rules, and lineage metadata.
- Supply reusable templates and small CLI utilities to generate and execute pipeline specs so data engineers can consistently author, review, and run notebook-based transforms.

### Description

- Add pipeline spec documentation and format at `fabric/pipelines/spec-format.md` and a JSON Schema validator at `fabric/pipelines/adhoc_pipeline.schema.json` to enforce required fields and retry/lineage constraints.
- Add three recurring-use templates in `fabric/pipelines/templates/`: `taia-archive-import.pipeline.yaml`, `dataverse-to-lakehouse-sync.pipeline.yaml`, and `client-kpi-mart-generation.pipeline.yaml` for common patterns (archive import, Dataverse sync, KPI mart generation).
- Add a generator `scripts/fabric/create_adhoc_pipeline.py` that loads a template, supports dotted-key overrides (`--set`) and emits JSON or YAML specs.
- Add an executor `scripts/fabric/run_adhoc_pipeline.py` that validates specs, enforces `schedule.retry` and `lineage` requirements, supports `--dry-run`, and submits notebook transforms to Fabric with exponential-backoff retries; it uses the existing `scripts/api/_core.py` `ApiClient` helper for auth/retries and expects `notebook_id` in transform entries for runtime execution.
- Update `skills/fabric-rest.md` with ad hoc pipeline patterns, retry defaults, and lineage requirements and add a new skill doc `skills/fabric-pipeline-authoring.md` describing authoring workflow, design patterns, retry strategy, and lineage rules.

### Testing

- Compiled both scripts with `python3 -m py_compile plugins/tvs-microsoft-deploy/scripts/fabric/create_adhoc_pipeline.py plugins/tvs-microsoft-deploy/scripts/fabric/run_adhoc_pipeline.py` and the compile step succeeded.
- Ran a dry-run validation with `python3 plugins/tvs-microsoft-deploy/scripts/fabric/run_adhoc_pipeline.py --spec /tmp/adhoc-test.json --dry-run` which printed the expected dry-run plan and passed spec validation.
- Attempted to generate YAML output with `scripts/fabric/create_adhoc_pipeline.py` but that invocation failed in this environment because `PyYAML` is not available and package installation is blocked; this is an environment limitation rather than a script defect.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7d836dc8832a855ce0b2f39a9685)