### PR TITLE
Add TVS quick-start command for fresh/existing repo bootstrap

### DIFF
--- a/docs/cli/COMMANDS.md
+++ b/docs/cli/COMMANDS.md
@@ -28,6 +28,7 @@ Generated from `commands/*.md`.
 | `tvs:identity-attestation` | Generate periodic access attestation packets for TAIA transition governance and due diligence | `/tvs:identity-attestation --input exports/role-assignments.json --period 2026-Q1` |
 | `tvs:identity-drift` | Detect Entra identity drift and produce remediation recommendations | `/tvs:identity-drift --inventory identity-inventory.json --output reports/identity-drift.json` |
 | `tvs:normalize-carriers` | Carrier normalization sprint for TAIA FMO sale preparation | `/tvs:normalize-carriers [--dry-run] [--collection=carriers|commissions|all]` |
+| `tvs:quick-start` | End-to-end bootstrap for TVS Microsoft Deploy that can initialize a fresh repo or configure an existing repo to the required baseline | `/tvs:quick-start [--repo <path>] [--create-repo <path>] [--env dev|test|prod] [--tenant <tenant-id>] [--entity tvs|consulting|taia|all] [--dry-run]` |
 | `tvs:status-check` | Health check using control-plane dry-run outputs as the verification source of truth | `/tvs:status-check [--env dev|test|prod] [--taia-wind-down]` |
 | `tvs:taia-readiness` | TAIA transition readiness check driven by control-plane wind-down overlay | `/tvs:taia-readiness [--env dev|test|prod]` |
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -91,6 +91,13 @@
     "path": "plugins/tvs-microsoft-deploy/commands/normalize-carriers.md"
   },
   {
+    "file": "quick-start.md",
+    "name": "tvs:quick-start",
+    "description": "End-to-end bootstrap for TVS Microsoft Deploy that can initialize a fresh repo or configure an existing repo to the required baseline",
+    "usage": "/tvs:quick-start [--repo <path>] [--create-repo <path>] [--env dev|test|prod] [--tenant <tenant-id>] [--entity tvs|consulting|taia|all] [--dry-run]",
+    "path": "plugins/tvs-microsoft-deploy/commands/quick-start.md"
+  },
+  {
     "file": "status-check.md",
     "name": "tvs:status-check",
     "description": "Health check using control-plane dry-run outputs as the verification source of truth",

--- a/plugins/tvs-microsoft-deploy/.claude-plugin/README.md
+++ b/plugins/tvs-microsoft-deploy/.claude-plugin/README.md
@@ -45,7 +45,7 @@ az login --tenant $TVS_TENANT_ID
 /tvs:status-check
 ```
 
-## Commands (13)
+## Commands (14)
 
 | Command | Description |
 |---------|-------------|
@@ -59,6 +59,7 @@ az login --tenant $TVS_TENANT_ID
 | `/tvs:normalize-carriers` | Carrier normalization sprint for TAIA sale |
 | `/tvs:deploy-teams` | Teams VA workspace with HIPAA config |
 | `/tvs:cost-report` | Cost analysis across all TVS entities |
+| `/tvs:quick-start` | End-to-end bootstrap for fresh or existing repositories |
 | `/tvs:status-check` | Health check across all resources |
 | `/tvs:taia-readiness` | TAIA wind-down readiness from control-plane overlays |
 | `/tvs:browser-fallback` | Playwright fallback for portal operations |

--- a/plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json
+++ b/plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tvs-microsoft-deploy",
   "version": "1.0.0",
-  "description": "Consul (Forerunner) - Enterprise Microsoft ecosystem orchestrator for TVS (Trusted Virtual Solutions) multi-entity multi-tenant deployment. 12 agents, 13 commands, 7 skills, 9 hooks, 5 workflows.",
+  "description": "Consul (Forerunner) - Enterprise Microsoft ecosystem orchestrator for TVS (Trusted Virtual Solutions) multi-entity multi-tenant deployment. 12 agents, 14 commands, 7 skills, 9 hooks, 5 workflows.",
   "author": {
     "name": "Markus Ahling",
     "email": "markus@lobbi.io"
@@ -64,6 +64,7 @@
     "commands/normalize-carriers.md",
     "commands/deploy-teams.md",
     "commands/cost-report.md",
+    "commands/quick-start.md",
     "commands/status-check.md",
     "commands/taia-readiness.md",
     "commands/browser-fallback.md"

--- a/plugins/tvs-microsoft-deploy/commands/quick-start.md
+++ b/plugins/tvs-microsoft-deploy/commands/quick-start.md
@@ -1,0 +1,103 @@
+---
+name: tvs:quick-start
+description: End-to-end bootstrap for TVS Microsoft Deploy that can initialize a fresh repo or configure an existing repo to the required baseline
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+---
+
+> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)
+
+# Quick Start Bootstrap
+
+Run a single command to prepare a repository for TVS Microsoft Deploy, wire required folder structure/configuration, and validate readiness with dry-run checks.
+
+## Usage
+
+```bash
+/tvs:quick-start [--repo <path>] [--create-repo <path>] [--env dev|test|prod] [--tenant <tenant-id>] [--entity tvs|consulting|taia|all] [--dry-run]
+```
+
+## Modes
+
+- `--repo <path>`: Use an existing repository and configure it.
+- `--create-repo <path>`: Create a brand-new repository at the given path, then configure it.
+
+Exactly one of `--repo` or `--create-repo` must be provided.
+
+## Bootstrap flow
+
+1. Validate tooling (`git`, `node`, `python3`, `pac`, `az`, `gh`).
+2. Create or select target repository.
+3. Ensure required baseline paths exist:
+   - `plugins/tvs-microsoft-deploy/`
+   - `plugins/tvs-microsoft-deploy/control-plane/manifests/`
+   - `plugins/tvs-microsoft-deploy/control-plane/out/`
+   - `docs/cli/`
+4. Copy TVS plugin assets and command contracts into the target repo.
+5. Initialize environment configuration from profile templates (`power-platform/profiles/{env}.json`).
+6. Validate identity policy preconditions:
+
+```bash
+python3 plugins/tvs-microsoft-deploy/scripts/identity_policy_checks.py --json
+```
+
+7. Generate deployment and status plans:
+
+```bash
+node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
+  --manifest plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml \
+  --overlay plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/${ENV:-dev}.yaml \
+  --mode dry-run \
+  --out plugins/tvs-microsoft-deploy/control-plane/out/deploy.dry-run.json
+
+node plugins/tvs-microsoft-deploy/control-plane/planner.mjs \
+  --manifest plugins/tvs-microsoft-deploy/control-plane/manifests/base.yaml \
+  --overlay plugins/tvs-microsoft-deploy/control-plane/manifests/overlays/${ENV:-dev}.yaml \
+  --mode dry-run \
+  --out plugins/tvs-microsoft-deploy/control-plane/out/status.dry-run.json
+```
+
+8. Run readiness validation:
+
+```bash
+/tvs:status-check --env ${ENV:-dev} --entity ${ENTITY:-tvs} --tenant ${TENANT}
+```
+
+## Required outputs
+
+- `plugins/tvs-microsoft-deploy/control-plane/out/deploy.dry-run.json`
+- `plugins/tvs-microsoft-deploy/control-plane/out/status.dry-run.json`
+- `docs/cli/COMMANDS.md`
+
+## Unified Command Contract
+
+### Contract
+- **Schema:** `../cli/command.schema.json`
+- **Required shared arguments:** `--entity`, `--tenant`
+- **Optional shared safety arguments:** `--strict`, `--dry-run`, `--export-json`, `--plan-id`
+- **Error catalog:** `../cli/error-codes.json`
+- **Operator remediation format:** `../cli/operator-remediation.md`
+
+### Shared argument patterns
+```text
+--entity <tvs|consulting|taia|all>
+--tenant <tenant-id>
+--strict
+--dry-run
+--export-json <path>
+--plan-id <plan-id>
+```
+
+### Unified examples
+```bash
+# Configure an existing repo
+/tvs:quick-start --repo . --env dev --entity tvs --tenant tvs-dev --plan-id PLAN-BOOTSTRAP-TVS-001
+
+# Create and configure a fresh repo
+/tvs:quick-start --create-repo ../tvs-greenfield --env test --entity consulting --tenant consulting-test --strict --dry-run --plan-id PLAN-BOOTSTRAP-CONSULTING-001
+```


### PR DESCRIPTION
## Summary
- added new `tvs:quick-start` command contract at `plugins/tvs-microsoft-deploy/commands/quick-start.md`
- documented a single end-to-end bootstrap flow that supports both existing repos (`--repo`) and brand-new repos (`--create-repo`)
- defined required bootstrap outputs and command contract compatibility details
- registered the new command in plugin metadata and plugin command docs
- updated global CLI command index artifacts (`docs/cli/COMMANDS.md` and `docs/cli/commands.json`)

## Why
This provides the requested one-command quick start path for TVS plugin setup, including greenfield repo creation and baseline configuration for an existing repo.

## Validation
- static documentation/contract update only (no runtime tests executed)
- verified command references and counts across:
  - `plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json`
  - `plugins/tvs-microsoft-deploy/.claude-plugin/README.md`
  - `docs/cli/COMMANDS.md`
  - `docs/cli/commands.json`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d84b16490832aa4a26c090518c48a)