### PR TITLE
Add generated registries and drift checks for home-assistant-architect plugin

### DIFF
--- a/.github/workflows/home-assistant-architect-registry-check.yml
+++ b/.github/workflows/home-assistant-architect-registry-check.yml
@@ -1,0 +1,29 @@
+name: home-assistant-architect-registry-check
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/home-assistant-architect/**'
+      - '.github/workflows/home-assistant-architect-registry-check.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'plugins/home-assistant-architect/**'
+      - '.github/workflows/home-assistant-architect-registry-check.yml'
+
+jobs:
+  registry-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Verify generated registries and README totals
+        run: node plugins/home-assistant-architect/scripts/generate-registry.ts --check

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "ha:registry:generate": "node plugins/home-assistant-architect/scripts/generate-registry.ts",
+    "ha:registry:check": "node plugins/home-assistant-architect/scripts/generate-registry.ts --check"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.0",

--- a/plugins/home-assistant-architect/.claude-plugin/plugin.json
+++ b/plugins/home-assistant-architect/.claude-plugin/plugin.json
@@ -17,5 +17,19 @@
     "mcp-server",
     "ubuntu",
     "iot"
-  ]
+  ],
+  "registries": {
+    "commands": ".claude-plugin/registry/commands.json",
+    "agents": ".claude-plugin/registry/agents.json",
+    "skills": ".claude-plugin/registry/skills.json",
+    "hooks": ".claude-plugin/registry/hooks.json",
+    "mcpEntrypoints": ".claude-plugin/registry/mcp-entrypoints.json"
+  },
+  "registryCounts": {
+    "commands": 9,
+    "agents": 15,
+    "skills": 8,
+    "hooks": 10,
+    "mcpEntrypoints": 2
+  }
 }

--- a/plugins/home-assistant-architect/.claude-plugin/registry/agents.json
+++ b/plugins/home-assistant-architect/.claude-plugin/registry/agents.json
@@ -1,0 +1,66 @@
+{
+  "kind": "agents",
+  "entries": [
+    {
+      "id": "ha-automation-architect",
+      "path": "agents/ha-automation-architect.md"
+    },
+    {
+      "id": "ha-camera-nvr",
+      "path": "agents/ha-camera-nvr.md"
+    },
+    {
+      "id": "ha-customization-expert",
+      "path": "agents/ha-customization-expert.md"
+    },
+    {
+      "id": "ha-dashboard-designer",
+      "path": "agents/ha-dashboard-designer.md"
+    },
+    {
+      "id": "ha-data-writer",
+      "path": "agents/ha-data-writer.md"
+    },
+    {
+      "id": "ha-device-controller",
+      "path": "agents/ha-device-controller.md"
+    },
+    {
+      "id": "ha-diagnostics",
+      "path": "agents/ha-diagnostics.md"
+    },
+    {
+      "id": "ha-energy-management",
+      "path": "agents/ha-energy-management.md"
+    },
+    {
+      "id": "ha-energy-optimizer",
+      "path": "agents/ha-energy-optimizer.md"
+    },
+    {
+      "id": "ha-frontend-builder",
+      "path": "agents/ha-frontend-builder.md"
+    },
+    {
+      "id": "ha-security-auditor",
+      "path": "agents/ha-security-auditor.md"
+    },
+    {
+      "id": "ha-sensor-manager",
+      "path": "agents/ha-sensor-manager.md"
+    },
+    {
+      "id": "ha-voice-assistant",
+      "path": "agents/ha-voice-assistant.md"
+    },
+    {
+      "id": "local-llm-manager",
+      "path": "agents/local-llm-manager.md"
+    },
+    {
+      "id": "ubuntu-ha-deployer",
+      "path": "agents/ubuntu-ha-deployer.md"
+    }
+  ],
+  "count": 15
+}

--- a/plugins/home-assistant-architect/.claude-plugin/registry/commands.json
+++ b/plugins/home-assistant-architect/.claude-plugin/registry/commands.json
@@ -1,0 +1,42 @@
+{
+  "kind": "commands",
+  "entries": [
+    {
+      "id": "ha-automation",
+      "path": "commands/ha-automation.md"
+    },
+    {
+      "id": "ha-camera",
+      "path": "commands/ha-camera.md"
+    },
+    {
+      "id": "ha-control",
+      "path": "commands/ha-control.md"
+    },
+    {
+      "id": "ha-dashboard",
+      "path": "commands/ha-dashboard.md"
+    },
+    {
+      "id": "ha-deploy",
+      "path": "commands/ha-deploy.md"
+    },
+    {
+      "id": "ha-energy",
+      "path": "commands/ha-energy.md"
+    },
+    {
+      "id": "ha-mcp",
+      "path": "commands/ha-mcp.md"
+    },
+    {
+      "id": "ha-sensor",
+      "path": "commands/ha-sensor.md"
+    },
+    {
+      "id": "ollama-setup",
+      "path": "commands/ollama-setup.md"
+    }
+  ],
+  "count": 9
+}

--- a/plugins/home-assistant-architect/.claude-plugin/registry/hooks.json
+++ b/plugins/home-assistant-architect/.claude-plugin/registry/hooks.json
@@ -1,0 +1,46 @@
+{
+  "kind": "hooks",
+  "entries": [
+    {
+      "id": "hooks",
+      "path": "hooks/hooks.json"
+    },
+    {
+      "id": "ha-health-check",
+      "path": "hooks/scripts/ha-health-check.sh"
+    },
+    {
+      "id": "ollama-status",
+      "path": "hooks/scripts/ollama-status.sh"
+    },
+    {
+      "id": "security-scan",
+      "path": "hooks/scripts/security-scan.sh"
+    },
+    {
+      "id": "validate-yaml",
+      "path": "hooks/scripts/validate-yaml.sh"
+    },
+    {
+      "id": "event:PostToolUse",
+      "path": "hooks/hooks.json"
+    },
+    {
+      "id": "event:PreToolUse",
+      "path": "hooks/hooks.json"
+    },
+    {
+      "id": "event:SessionEnd",
+      "path": "hooks/hooks.json"
+    },
+    {
+      "id": "event:TaskCompleted",
+      "path": "hooks/hooks.json"
+    },
+    {
+      "id": "event:UserPromptSubmit",
+      "path": "hooks/hooks.json"
+    }
+  ],
+  "count": 10
+}

--- a/plugins/home-assistant-architect/.claude-plugin/registry/mcp-entrypoints.json
+++ b/plugins/home-assistant-architect/.claude-plugin/registry/mcp-entrypoints.json
@@ -1,0 +1,14 @@
+{
+  "kind": "mcpEntrypoints",
+  "entries": [
+    {
+      "id": "index",
+      "path": "mcp-server/src/index.ts"
+    },
+    {
+      "id": "index",
+      "path": "mcp-server/dist/index.js"
+    }
+  ],
+  "count": 2
+}

--- a/plugins/home-assistant-architect/.claude-plugin/registry/skills.json
+++ b/plugins/home-assistant-architect/.claude-plugin/registry/skills.json
@@ -1,0 +1,38 @@
+{
+  "kind": "skills",
+  "entries": [
+    {
+      "id": "camera-nvr",
+      "path": "skills/camera-nvr/SKILL.md"
+    },
+    {
+      "id": "energy-management",
+      "path": "skills/energy-management/SKILL.md"
+    },
+    {
+      "id": "ha-automation",
+      "path": "skills/ha-automation/SKILL.md"
+    },
+    {
+      "id": "ha-core",
+      "path": "skills/ha-core/SKILL.md"
+    },
+    {
+      "id": "local-llm",
+      "path": "skills/local-llm/SKILL.md"
+    },
+    {
+      "id": "lovelace-design",
+      "path": "skills/lovelace-design/SKILL.md"
+    },
+    {
+      "id": "sensor-management",
+      "path": "skills/sensor-management/SKILL.md"
+    },
+    {
+      "id": "ubuntu-deployment",
+      "path": "skills/ubuntu-deployment/SKILL.md"
+    }
+  ],
+  "count": 8
+}

--- a/plugins/home-assistant-architect/README.md
+++ b/plugins/home-assistant-architect/README.md
@@ -4,7 +4,17 @@ Comprehensive Claude Code plugin for Home Assistant automation, local LLM integr
 
 ## Features
 
-### Sub-Agents (8 Specialized)
+## Registry Snapshot
+
+<!-- registry-summary:start -->
+- Sub-agents: **15**
+- Commands: **9**
+- Skills: **8**
+- Hook entries (config, scripts, and hook events): **10**
+- MCP entrypoints: **2**
+<!-- registry-summary:end -->
+
+### Sub-Agents
 
 | Agent | Purpose | Model |
 |-------|---------|-------|
@@ -141,7 +151,7 @@ HA_VOICE_MODEL=llama3.2:3b
 │                                                                      │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐               │
 │  │   Agents     │  │   Commands   │  │    Skills    │               │
-│  │  (8 types)   │  │  (8 types)   │  │  (4 types)   │               │
+│  │  (dynamic)   │  │  (dynamic)   │  │  (dynamic)   │               │
 │  └──────────────┘  └──────────────┘  └──────────────┘               │
 │          │                │                 │                        │
 │          └────────────────┼─────────────────┘                        │

--- a/plugins/home-assistant-architect/scripts/generate-registry.ts
+++ b/plugins/home-assistant-architect/scripts/generate-registry.ts
@@ -1,0 +1,191 @@
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..', '..');
+const pluginRoot = path.join(repoRoot, 'plugins', 'home-assistant-architect');
+const manifestPath = path.join(pluginRoot, '.claude-plugin', 'plugin.json');
+const registryDir = path.join(pluginRoot, '.claude-plugin', 'registry');
+const readmePath = path.join(pluginRoot, 'README.md');
+const hooksPath = path.join(pluginRoot, 'hooks', 'hooks.json');
+const mcpPackagePath = path.join(pluginRoot, 'mcp-server', 'package.json');
+
+const checkMode = process.argv.includes('--check');
+
+type RegistryEntry = {
+  id: string;
+  path: string;
+};
+
+type RegistryFile = {
+  kind: string;
+  count: number;
+  entries: RegistryEntry[];
+};
+
+const rel = (...parts: string[]) => path.join(...parts).replaceAll(path.sep, '/');
+
+const listFiles = (dir: string, filter: (fileName: string, fullPath: string) => boolean): string[] => {
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((fileName) => filter(fileName, path.join(dir, fileName)))
+    .sort((a, b) => a.localeCompare(b));
+};
+
+const listSkillEntries = (): RegistryEntry[] => {
+  const skillsRoot = path.join(pluginRoot, 'skills');
+
+  if (!existsSync(skillsRoot)) {
+    return [];
+  }
+
+  return readdirSync(skillsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((dirName) => existsSync(path.join(skillsRoot, dirName, 'SKILL.md')))
+    .sort((a, b) => a.localeCompare(b))
+    .map((dirName) => ({
+      id: dirName,
+      path: rel('skills', dirName, 'SKILL.md')
+    }));
+};
+
+const registryData: Record<string, RegistryFile> = {
+  commands: {
+    kind: 'commands',
+    entries: listFiles(path.join(pluginRoot, 'commands'), (fileName) => fileName.endsWith('.md')).map((fileName) => ({
+      id: fileName.replace(/\.md$/, ''),
+      path: rel('commands', fileName)
+    })),
+    count: 0
+  },
+  agents: {
+    kind: 'agents',
+    entries: listFiles(path.join(pluginRoot, 'agents'), (fileName) => fileName.endsWith('.md')).map((fileName) => ({
+      id: fileName.replace(/\.md$/, ''),
+      path: rel('agents', fileName)
+    })),
+    count: 0
+  },
+  skills: {
+    kind: 'skills',
+    entries: listSkillEntries(),
+    count: 0
+  },
+  hooks: {
+    kind: 'hooks',
+    entries: [
+      { id: 'hooks', path: rel('hooks', 'hooks.json') },
+      ...listFiles(path.join(pluginRoot, 'hooks', 'scripts'), (fileName) => fileName.endsWith('.sh')).map((fileName) => ({
+        id: fileName.replace(/\.sh$/, ''),
+        path: rel('hooks', 'scripts', fileName)
+      }))
+    ],
+    count: 0
+  },
+  mcpEntrypoints: {
+    kind: 'mcpEntrypoints',
+    entries: [],
+    count: 0
+  }
+};
+
+const hooksConfig = JSON.parse(readFileSync(hooksPath, 'utf-8')) as { hooks?: Record<string, unknown[]> };
+const hookEvents = Object.keys(hooksConfig.hooks ?? {}).sort();
+const hookEventEntries = hookEvents.map((eventName) => ({
+  id: `event:${eventName}`,
+  path: rel('hooks', 'hooks.json')
+}));
+registryData.hooks.entries = [...registryData.hooks.entries, ...hookEventEntries];
+
+const mcpPackage = JSON.parse(readFileSync(mcpPackagePath, 'utf-8')) as { main?: string };
+const mcpCandidates = [
+  rel('mcp-server', 'src', 'index.ts'),
+  mcpPackage.main ? rel('mcp-server', mcpPackage.main) : null
+].filter((entry): entry is string => Boolean(entry));
+
+registryData.mcpEntrypoints.entries = Array.from(new Set(mcpCandidates)).map((entryPath) => ({
+  id: path.basename(entryPath).replace(/\.(c|m)?(j|t)s$/, ''),
+  path: entryPath
+}));
+
+for (const registry of Object.values(registryData)) {
+  registry.count = registry.entries.length;
+}
+
+const registryFiles: Record<string, string> = {
+  commands: rel('.claude-plugin', 'registry', 'commands.json'),
+  agents: rel('.claude-plugin', 'registry', 'agents.json'),
+  skills: rel('.claude-plugin', 'registry', 'skills.json'),
+  hooks: rel('.claude-plugin', 'registry', 'hooks.json'),
+  mcpEntrypoints: rel('.claude-plugin', 'registry', 'mcp-entrypoints.json')
+};
+
+const writeJson = (filePath: string, data: unknown): string => `${JSON.stringify(data, null, 2)}\n`;
+
+const pendingWrites: Array<{ filePath: string; content: string }> = [];
+for (const [kind, relativePath] of Object.entries(registryFiles)) {
+  const absolutePath = path.join(pluginRoot, relativePath);
+  const content = writeJson(absolutePath, registryData[kind]);
+  pendingWrites.push({ filePath: absolutePath, content });
+}
+
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Record<string, unknown>;
+manifest.registries = {
+  commands: registryFiles.commands,
+  agents: registryFiles.agents,
+  skills: registryFiles.skills,
+  hooks: registryFiles.hooks,
+  mcpEntrypoints: registryFiles.mcpEntrypoints
+};
+manifest.registryCounts = Object.fromEntries(
+  Object.entries(registryData).map(([kind, data]) => [kind, data.count])
+);
+const manifestContent = writeJson(manifestPath, manifest);
+pendingWrites.push({ filePath: manifestPath, content: manifestContent });
+
+const readme = readFileSync(readmePath, 'utf-8');
+const summaryLines = [
+  '<!-- registry-summary:start -->',
+  `- Sub-agents: **${registryData.agents.count}**`,
+  `- Commands: **${registryData.commands.count}**`,
+  `- Skills: **${registryData.skills.count}**`,
+  `- Hook entries (config, scripts, and hook events): **${registryData.hooks.count}**`,
+  `- MCP entrypoints: **${registryData.mcpEntrypoints.count}**`,
+  '<!-- registry-summary:end -->'
+].join('\n');
+
+const summaryPattern = /<!-- registry-summary:start -->[\s\S]*?<!-- registry-summary:end -->/;
+if (!summaryPattern.test(readme)) {
+  throw new Error('README is missing registry summary markers.');
+}
+
+const readmeContent = readme.replace(summaryPattern, summaryLines);
+pendingWrites.push({ filePath: readmePath, content: readmeContent });
+
+let driftDetected = false;
+for (const pending of pendingWrites) {
+  const current = existsSync(pending.filePath) ? readFileSync(pending.filePath, 'utf-8') : '';
+  if (current !== pending.content) {
+    driftDetected = true;
+    if (!checkMode) {
+      writeFileSync(pending.filePath, pending.content, 'utf-8');
+      console.log(`updated ${path.relative(repoRoot, pending.filePath)}`);
+    } else {
+      console.error(`drift detected: ${path.relative(repoRoot, pending.filePath)}`);
+    }
+  }
+}
+
+if (checkMode && driftDetected) {
+  process.exit(1);
+}
+
+if (!driftDetected) {
+  console.log('registry and documentation are up to date');
+}


### PR DESCRIPTION
### Motivation

- Keep plugin manifest, documentation, and CI in sync with actual filesystem contents for commands, agents, skills, hooks, and MCP entrypoints.
- Prevent README and manifest drift by automatically generating authoritative indexes and failing CI when counts diverge.

### Description

- Add `plugins/home-assistant-architect/scripts/generate-registry.ts` which scans plugin directories and regenerates per-kind registry files, updates `.claude-plugin/plugin.json` with `registries` paths and `registryCounts`, and syncs a README snapshot block. 
- Commit generated registry index files to `.claude-plugin/registry/` for `commands.json`, `agents.json`, `skills.json`, `hooks.json`, and `mcp-entrypoints.json`. 
- Update `plugins/home-assistant-architect/.claude-plugin/plugin.json` to include explicit `registries` and `registryCounts` metadata. 
- Update `plugins/home-assistant-architect/README.md` to include a `<!-- registry-summary:start -->/<!-- registry-summary:end -->` snapshot block consumed by the generator and make the architecture counts dynamic. 
- Add CI workflow `.github/workflows/home-assistant-architect-registry-check.yml` that runs the generator in `--check` mode and fails on drift, and add root npm scripts `ha:registry:generate` and `ha:registry:check` that invoke the generator.

### Testing

- Ran `node plugins/home-assistant-architect/scripts/generate-registry.ts` which generated registry files, updated the manifest and README, and reported updates; the command completed successfully. 
- Ran `npm run ha:registry:check` (which runs the script with `--check`) and validated the check-mode passes after README markers were added; the check succeeded. 
- The CI workflow is added to run the same `--check` command on PRs and pushes to `main` to ensure future drift fails the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ddb29e8f4832abecd0563132302bf)