### PR TITLE
Tighten Home Assistant hook targeting and add debounce/severity docs

### DIFF
--- a/plugins/home-assistant-architect/hooks/hooks.json
+++ b/plugins/home-assistant-architect/hooks/hooks.json
@@ -1,26 +1,73 @@
 {
   "$schema": "../../../.claude/schemas/hooks.schema.json",
   "name": "home-assistant-hooks",
-  "version": "1.0.0",
-  "description": "Event-driven hooks for Home Assistant automation and monitoring",
+  "version": "1.1.0",
+  "description": "Scoped event-driven hooks for Home Assistant and Ollama workflows",
   "hooks": {
     "UserPromptSubmit": [
       {
+        "matcher": "(^|\\s)/(ha-control|ha-automation|ha-deploy|ha-diagnose|ha-voice|ha-backup|ha-mcp|ollama-setup)\\b|\\b(home assistant|hass|homeassistant|configuration\\.ya?ml|automations?\\.ya?ml|secrets\\.ya?ml|scenes\\.ya?ml|scripts\\.ya?ml|assist_pipeline)\\b|\\bmcp__home_assistant__",
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Monitor for Home Assistant-related state change requests. If the user message contains keywords like 'turn on', 'turn off', 'set', 'adjust', 'home assistant', 'light', 'switch', or 'thermostat', detect and handle the HA state change request."
+            "severity": "info",
+            "debounce_key": "ha-userprompt-context",
+            "debounce_scope": "session",
+            "debounce_window_seconds": 900,
+            "prompt": "Handle Home Assistant intent only when the user references HA-specific commands, HA config files, HA domains/entities, or Home Assistant MCP tools. Do not trigger on generic verbs (for example: set, adjust, turn on) without HA context."
           }
         ]
       }
     ],
     "PreToolUse": [
       {
-        "matcher": "Write",
+        "matcher": "Write|Edit|MultiEdit",
+        "conditions": {
+          "path_any": [
+            "**/configuration.yaml",
+            "**/secrets.yaml",
+            "**/automations.yaml",
+            "**/scripts.yaml",
+            "**/scenes.yaml",
+            "**/blueprints/**/*.yaml",
+            "**/packages/**/*.yaml",
+            "**/homeassistant/**/*.yaml"
+          ]
+        },
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Validate YAML syntax before writing automation files matching *.yaml or automations/*.yaml patterns."
+            "severity": "high",
+            "debounce_key": "ha-yaml-prewrite",
+            "debounce_scope": "session",
+            "debounce_window_seconds": 300,
+            "prompt": "Before editing Home Assistant YAML, validate syntax and key HA structures (trigger/condition/action, service calls, entity_id, secrets references). Skip this reminder for non-HA files."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "conditions": {
+          "command_any": [
+            "*ha core*",
+            "*ha addons*",
+            "*ha supervisor*",
+            "*hass*",
+            "*homeassistant*",
+            "*docker*homeassistant*",
+            "*ollama*",
+            "*curl*api/states*",
+            "*curl*api/services*"
+          ]
+        },
+        "hooks": [
+          {
+            "type": "prompt",
+            "severity": "medium",
+            "debounce_key": "ha-bash-domain-safety",
+            "debounce_scope": "session",
+            "debounce_window_seconds": 300,
+            "prompt": "For HA/Ollama shell commands only: verify target host, auth token usage, and service impact before execution. Do not emit for unrelated Bash commands."
           }
         ]
       }
@@ -28,29 +75,62 @@
     "PostToolUse": [
       {
         "matcher": "Bash",
+        "conditions": {
+          "command_any": [
+            "*ollama*",
+            "*ha core*",
+            "*ha supervisor*",
+            "*homeassistant*"
+          ]
+        },
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "If the Bash command involved Ollama (contained 'ollama'), verify Ollama model availability and status."
+            "severity": "medium",
+            "debounce_key": "ha-post-bash-health",
+            "debounce_scope": "session",
+            "debounce_window_seconds": 600,
+            "prompt": "After HA/Ollama commands, check service health/state once per debounce window (HA core status, API responsiveness, and Ollama model/service availability)."
           }
         ]
       },
       {
-        "matcher": "Write",
+        "matcher": "Write|Edit|MultiEdit",
+        "conditions": {
+          "path_any": [
+            "**/configuration.yaml",
+            "**/secrets.yaml",
+            "**/automations.yaml",
+            "**/scripts.yaml",
+            "**/scenes.yaml",
+            "**/blueprints/**/*.yaml",
+            "**/packages/**/*.yaml",
+            "**/homeassistant/**/*.yaml"
+          ]
+        },
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Scan for security issues in Home Assistant configuration changes, especially for configuration.yaml, secrets.yaml, and other *.yaml files."
+            "severity": "high",
+            "debounce_key": "ha-postwrite-security",
+            "debounce_scope": "session",
+            "debounce_window_seconds": 600,
+            "prompt": "Review Home Assistant config edits for security and reliability (secret leakage, unsafe external URLs/commands, privileged add-ons, and invalid entity/service references)."
           }
         ]
       }
     ],
     "TaskCompleted": [
       {
+        "matcher": "ha-deploy|ha-automation|ha-config|ollama-setup",
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Run health check after HA-related tasks of type ha-deploy, ha-automation, or ha-config."
+            "severity": "info",
+            "debounce_key": "ha-task-healthcheck",
+            "debounce_scope": "session",
+            "debounce_window_seconds": 900,
+            "prompt": "Run focused health checks only after HA/Ollama task types (ha-deploy, ha-automation, ha-config, ollama-setup)."
           }
         ]
       }
@@ -60,7 +140,11 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Remind to backup after significant Home Assistant changes, especially changes to homeassistant or configuration.yaml."
+            "severity": "info",
+            "debounce_key": "ha-session-backup-reminder",
+            "debounce_scope": "session",
+            "debounce_window_seconds": 3600,
+            "prompt": "If significant HA configuration changed this session, remind once to backup configuration.yaml, automations, and secrets securely."
           }
         ]
       }


### PR DESCRIPTION
### Motivation

- Reduce noisy, generic hook triggers by scoping hooks to Home Assistant (HA) and Ollama-specific contexts only. 
- Prevent accidental, global reminders on generic verbs or unrelated files/commands by attaching path and command constraints. 
- Avoid repeated reminders during a session by adding debounce/ severity metadata so prompts are meaningful and non-redundant.

### Description

- Reworked `plugins/home-assistant-architect/hooks/hooks.json` (bumped to `1.1.0`) to replace broad keyword-only logic with an explicit `UserPromptSubmit` `matcher` that matches HA/OLLAMA commands, HA config filenames, and MCP namespaces. 
- Added `conditions` for `PreToolUse` and `PostToolUse` entries that restrict triggers to HA config paths via `path_any` and to HA/Ollama command domains via `command_any` rather than matching generic tools/verbs. 
- Introduced hook metadata fields `severity`, `debounce_key`, `debounce_scope`, and `debounce_window_seconds` on prompts to implement session-level debounce and severity classification. 
- Updated `plugins/home-assistant-architect/README.md` with a new Hooks section describing triggering rules, the severity + debounce model, and concrete trigger / non-trigger examples.

### Testing

- Ran `jq . plugins/home-assistant-architect/hooks/hooks.json` to validate the modified JSON and it returned successfully. 
- Reviewed diffs via `git diff -- plugins/home-assistant-architect/hooks/hooks.json plugins/home-assistant-architect/README.md` to verify intended changes were applied and readable; review succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ddb289480832ab72a4f206c8de25d)