### PR TITLE
Improve context-manager cache keying and invalidation

### DIFF
--- a/plugins/claude-code-templating-plugin/test/unit/core/context-manager.test.ts
+++ b/plugins/claude-code-templating-plugin/test/unit/core/context-manager.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, utimes, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createContextManager } from '../../../src/core/context-manager.js';
+
+describe('ContextManager cache invalidation', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'context-manager-'));
+    await mkdir(join(workspace, 'src'), { recursive: true });
+    await writeFile(join(workspace, 'src', 'index.ts'), 'export const value = 1;\n', 'utf-8');
+    await writeFile(join(workspace, 'package.json'), '{"name":"cache-test"}\n', 'utf-8');
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('returns cached context when options and files are unchanged', async () => {
+    const manager = createContextManager();
+
+    const first = await manager.loadContext(workspace, { project: 'demo' });
+    const second = await manager.loadContext(workspace, { project: 'demo' });
+
+    expect(second).toBe(first);
+  });
+
+  it('invalidates cache when effective load options change', async () => {
+    const manager = createContextManager();
+
+    const first = await manager.loadContext(workspace, { project: 'demo' });
+    const second = await manager.loadContext(
+      workspace,
+      { project: 'demo' },
+      { maxFileSize: 10 }
+    );
+
+    expect(second).not.toBe(first);
+    expect(second.files.some((file) => file.truncated)).toBe(true);
+  });
+
+  it('invalidates cache when scanned files change', async () => {
+    const manager = createContextManager();
+
+    const first = await manager.loadContext(workspace, { project: 'demo' });
+
+    const targetFile = join(workspace, 'src', 'index.ts');
+    await writeFile(targetFile, 'export const value = 2;\n', 'utf-8');
+
+    const now = new Date();
+    await utimes(targetFile, now, now);
+
+    const second = await manager.loadContext(workspace, { project: 'demo' });
+
+    expect(second).not.toBe(first);
+    expect(second.files.find((file) => file.path === 'src/index.ts')?.content).toContain('value = 2');
+  });
+});


### PR DESCRIPTION
### Motivation
- Make context caching robust to changes in effective load options (depth, include/exclude, file/token limits) so cached contexts are only reused when truly equivalent.
- Add file-change awareness so cached entries are invalidated when scanned files change (mtime/size) to prevent serving stale file contents.
- Persist minimal cache metadata alongside `LoadedContext` to support validation logic and TTL-based guard.

### Description
- Introduced `ContextCacheMetadata` and `ContextCacheEntry` and changed the in-memory cache to store metadata alongside `LoadedContext`.
- Updated `getCacheKey()` to incorporate an `optionsHash` computed by `hashLoadOptions()` so the effective load options are part of the cache key.
- Added file-change detection via `createFileFingerprint()` / `createFingerprintFromFileStats()` which snapshots file `mtimeMs` and `size` and produces a hash; added a short TTL guard (`CACHE_TTL_MS`) and file-fingerprint comparison before returning cached entries.
- Refactored file discovery into `findFiles()` and updated caching logic to store `fileFingerprint` and `createdAt`; added `hashString()` helper and switched to `statSync` for fingerprint sampling.
- Added unit tests `test/unit/core/context-manager.test.ts` exercising cache hit for unchanged state, invalidation when options change, and invalidation when a scanned file is modified.

### Testing
- Ran `npm test -- context-manager` in the plugin package; the test file executed and all tests passed (1 test file, 3 tests passing).
- The new unit tests verify: cache reuse when nothing changes, invalidation on effective option change, and invalidation on file content/mtime change (all passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ddb176170832abcedf0a27ff02b23)