### PR TITLE
Add plugin root index.json files, generator, loader support, and CI validation

### DIFF
--- a/.github/workflows/plugin-index-check.yml
+++ b/.github/workflows/plugin-index-check.yml
@@ -1,0 +1,35 @@
+name: plugin-index-check
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/**'
+      - 'scripts/generate-plugin-indexes.mjs'
+      - 'scripts/validate-plugin-indexes.mjs'
+      - '.github/workflows/plugin-index-check.yml'
+      - 'package.json'
+  push:
+    branches:
+      - main
+    paths:
+      - 'plugins/**'
+      - 'scripts/generate-plugin-indexes.mjs'
+      - 'scripts/validate-plugin-indexes.mjs'
+      - '.github/workflows/plugin-index-check.yml'
+      - 'package.json'
+
+jobs:
+  check-plugin-indexes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate plugin indexes are synchronized and complete
+        run: npm run plugin:index:check

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",
     "ha:registry:generate": "node plugins/home-assistant-architect/scripts/generate-registry.ts",
-    "ha:registry:check": "node plugins/home-assistant-architect/scripts/generate-registry.ts --check"
+    "ha:registry:check": "node plugins/home-assistant-architect/scripts/generate-registry.ts --check",
+    "plugin:index:generate": "node scripts/generate-plugin-indexes.mjs",
+    "plugin:index:check": "node scripts/generate-plugin-indexes.mjs --check && node scripts/validate-plugin-indexes.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.0",

--- a/plugins/ahling-command-center/index.json
+++ b/plugins/ahling-command-center/index.json
@@ -1,0 +1,560 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "ahling-command-center",
+    "root": "plugins/ahling-command-center"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "ahling-command-center:command:commands.acc-agent",
+        "name": "/mp:acc-agent",
+        "path": "commands/acc-agent.md",
+        "summary": "Manage Microsoft Agent Framework including AutoGen and Semantic Kernel agents, multi-agent workflows, tool registration,",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-agent",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-compose",
+        "name": "/mp:acc-compose",
+        "path": "commands/acc-compose.md",
+        "summary": "Generate optimized Docker Compose files for ACC services with automatic resource allocation, dependency management, netw",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-compose",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "docker"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-config",
+        "name": "/mp:acc-config",
+        "path": "commands/acc-config.md",
+        "summary": "Generate service configuration files with automatic Vault secret injection, environment variable templating, and validat",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-config",
+            "commands"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-deploy",
+        "name": "/mp:acc-deploy",
+        "path": "commands/acc-deploy.md",
+        "summary": "Deploy Ahling Command Center services by phase or individually with automatic dependency validation, pre-deployment chec",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "acc-deploy",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-ha",
+        "name": "/mp:acc-ha",
+        "path": "commands/acc-ha.md",
+        "summary": "Manage Home Assistant including entities, automations, voice pipeline, scenes, scripts, and integration with Ollama for ",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-ha",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-init",
+        "name": "/mp:acc-init",
+        "path": "commands/acc-init.md",
+        "summary": "Initialize the complete Ahling Command Center project structure with directories, configuration templates, and base file",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-init",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-knowledge",
+        "name": "/mp:acc-knowledge",
+        "path": "commands/acc-knowledge.md",
+        "summary": "Manage ACC knowledge graph using Neo4j for structured data and Qdrant for vector embeddings with semantic search capabil",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-knowledge",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-logs",
+        "name": "/mp:acc-logs",
+        "path": "commands/acc-logs.md",
+        "summary": "View, filter, and analyze ACC service logs with real-time tailing, pattern matching, time-based filtering, and multi-ser",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-logs",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-ollama",
+        "name": "/mp:acc-ollama",
+        "path": "commands/acc-ollama.md",
+        "summary": "Manage Ollama models including pulling, listing, running, GPU optimization for AMD RX 7900 XTX, model creation, and perf",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-ollama",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-orchestrate",
+        "name": "/mp:acc-orchestrate",
+        "path": "commands/acc-orchestrate.md",
+        "summary": "Execute complex multi-agent workflows that orchestrate multiple ACC services including Ollama for reasoning, knowledge g",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-orchestrate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-repo",
+        "name": "/mp:acc-repo",
+        "path": "commands/acc-repo.md",
+        "summary": "Scaffold a complete service repository with Docker configuration, environment templates, health checks, Vault integratio",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-repo",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "docker"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-resource",
+        "name": "/mp:acc-resource",
+        "path": "commands/acc-resource.md",
+        "summary": "Monitor and optimize resource allocation across ACC infrastructure with focus on 24-core CPU, 61GB RAM, and RX 7900 XTX ",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-resource",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-status",
+        "name": "/mp:acc-status",
+        "path": "commands/acc-status.md",
+        "summary": "Comprehensive health check of ACC infrastructure including service availability, resource usage, dependency validation, ",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-status",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-vault",
+        "name": "/mp:acc-vault",
+        "path": "commands/acc-vault.md",
+        "summary": "Manage HashiCorp Vault secrets for ACC services including setting secrets, retrieving values, listing paths, rotating cr",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-vault",
+            "commands"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:command:commands.acc-voice",
+        "name": "/mp:acc-voice",
+        "path": "commands/acc-voice.md",
+        "summary": "Test and configure the ACC voice assistant pipeline including Whisper speech-to-text, Piper text-to-speech, Wyoming prot",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "acc-voice",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "ahling-command-center:agent:agents.agent-architect",
+        "name": "agent-architect",
+        "path": "agents/agent-architect.md",
+        "summary": "Agent Architect Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "agent-architect"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:agent:agents.compose-builder",
+        "name": "compose-builder",
+        "path": "agents/compose-builder.md",
+        "summary": "Docker Compose Builder Agent",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "compose-builder"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "docker"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:agent:agents.config-generator",
+        "name": "config-generator",
+        "path": "agents/config-generator.md",
+        "summary": "Configuration Generator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "config-generator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:agent:agents.ha-coordinator",
+        "name": "ha-coordinator",
+        "path": "agents/ha-coordinator.md",
+        "summary": "Home Assistant Coordinator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-coordinator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:agent:agents.health-monitor",
+        "name": "health-monitor",
+        "path": "agents/health-monitor.md",
+        "summary": "Health Monitor Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "health-monitor"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:agent:agents.infrastructure-architect",
+        "name": "infrastructure-architect",
+        "path": "agents/infrastructure-architect.md",
+        "summary": "Infrastructure Architect Agent",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "infrastructure-architect"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:agent:agents.ollama-orchestrator",
+        "name": "ollama-orchestrator",
+        "path": "agents/ollama-orchestrator.md",
+        "summary": "Ollama Orchestrator Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ollama-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:agent:agents.resource-optimizer",
+        "name": "resource-optimizer",
+        "path": "agents/resource-optimizer.md",
+        "summary": "Resource Optimizer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "resource-optimizer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:agent:agents.troubleshooter",
+        "name": "troubleshooter",
+        "path": "agents/troubleshooter.md",
+        "summary": "Troubleshooter Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "troubleshooter"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:agent:agents.vault-manager",
+        "name": "vault-manager",
+        "path": "agents/vault-manager.md",
+        "summary": "Vault Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "vault-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "ahling-command-center:skill:skills.ai-core.skill",
+        "name": "ai-core",
+        "path": "skills/ai-core/SKILL.md",
+        "summary": "AI Core Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ai core"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:skill:skills.home-assistant-brain.skill",
+        "name": "home-assistant-brain",
+        "path": "skills/home-assistant-brain/SKILL.md",
+        "summary": "Home Assistant Brain Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "home assistant brain"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:skill:skills.home-automation.skill",
+        "name": "home-automation",
+        "path": "skills/home-automation/SKILL.md",
+        "summary": "Home Automation Skill",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "home automation"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:skill:skills.infrastructure-foundation.skill",
+        "name": "infrastructure-foundation",
+        "path": "skills/infrastructure-foundation/SKILL.md",
+        "summary": "Infrastructure Foundation Skill",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "infrastructure foundation"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:skill:skills.intelligence-layer.skill",
+        "name": "intelligence-layer",
+        "path": "skills/intelligence-layer/SKILL.md",
+        "summary": "Intelligence Layer Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "intelligence layer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:skill:skills.microsoft-agents.skill",
+        "name": "microsoft-agents",
+        "path": "skills/microsoft-agents/SKILL.md",
+        "summary": "Microsoft Agents Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "microsoft agents"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:skill:skills.ollama-mastery.skill",
+        "name": "ollama-mastery",
+        "path": "skills/ollama-mastery/SKILL.md",
+        "summary": "Ollama Mastery Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ollama mastery"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "ahling-command-center:skill:skills.perception-pipeline.skill",
+        "name": "perception-pipeline",
+        "path": "skills/perception-pipeline/SKILL.md",
+        "summary": "Perception Pipeline Skill",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "perception pipeline"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": []
+  },
+  "keyDocs": []
+}

--- a/plugins/aws-eks-helm-keycloak/index.json
+++ b/plugins/aws-eks-helm-keycloak/index.json
@@ -1,0 +1,335 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "aws-eks-helm-keycloak",
+    "root": "plugins/aws-eks-helm-keycloak"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "aws-eks-helm-keycloak:command:commands.debug",
+        "name": "/mp:debug",
+        "path": "commands/debug.md",
+        "summary": "Debug",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "debug",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:command:commands.dev-up",
+        "name": "/mp:dev-up",
+        "path": "commands/dev-up.md",
+        "summary": "Dev Up",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "dev-up",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:command:commands.pipeline-scaffold",
+        "name": "/mp:pipeline-scaffold",
+        "path": "commands/pipeline-scaffold.md",
+        "summary": "Pipeline Scaffold",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "pipeline-scaffold",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:command:commands.preview",
+        "name": "/mp:preview",
+        "path": "commands/preview.md",
+        "summary": "Preview",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "preview",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:command:commands.service-onboard",
+        "name": "/mp:service-onboard",
+        "path": "commands/service-onboard.md",
+        "summary": "Service Onboard",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "service-onboard",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:command:commands.setup",
+        "name": "/mp:setup",
+        "path": "commands/setup.md",
+        "summary": "Setup Wizard",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "setup",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:command:commands.ship",
+        "name": "/mp:ship",
+        "path": "commands/ship.md",
+        "summary": "Ship",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ship",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "aws-eks-helm-keycloak:agent:agents.deployment-strategist",
+        "name": "deployment-strategist",
+        "path": "agents/deployment-strategist.md",
+        "summary": "Deployment Strategist Agent",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deployment-strategist"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:agent:agents.dev-assistant",
+        "name": "dev-assistant",
+        "path": "agents/dev-assistant.md",
+        "summary": "Dev Assistant Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "dev-assistant"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:agent:agents.pipeline-architect",
+        "name": "pipeline-architect",
+        "path": "agents/pipeline-architect.md",
+        "summary": "Pipeline Architect Agent",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "pipeline-architect"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:agent:agents.setup-orchestrator",
+        "name": "setup-orchestrator",
+        "path": "agents/setup-orchestrator.md",
+        "summary": "Setup Orchestrator Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "setup-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "aws-eks-helm-keycloak:skill:skills.harness-code-integration.skill",
+        "name": "harness-code-integration",
+        "path": "skills/harness-code-integration/SKILL.md",
+        "summary": "Harness Code Integration Skill",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness code integration"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:skill:skills.harness-eks-deployments.skill",
+        "name": "harness-eks-deployments",
+        "path": "skills/harness-eks-deployments/SKILL.md",
+        "summary": "Harness EKS Deployments Skill",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "harness eks deployments"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "kubernetes"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:skill:skills.harness-keycloak-auth.skill",
+        "name": "harness-keycloak-auth",
+        "path": "skills/harness-keycloak-auth/SKILL.md",
+        "summary": "Harness Keycloak Auth Skill",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness keycloak auth"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:skill:skills.helm-development.skill",
+        "name": "helm-development",
+        "path": "skills/helm-development/SKILL.md",
+        "summary": "Helm Development Skill",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "helm development"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "kubernetes"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:skill:skills.local-eks-development.skill",
+        "name": "local-eks-development",
+        "path": "skills/local-eks-development/SKILL.md",
+        "summary": "Local EKS Development Skill",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "local eks development"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "kubernetes"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:skill:skills.setup-wizard.skill",
+        "name": "setup-wizard",
+        "path": "skills/setup-wizard/SKILL.md",
+        "summary": "Setup Wizard Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "setup wizard"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": [
+      {
+        "id": "aws-eks-helm-keycloak:hook:hooks.scripts.keycloak-sync",
+        "name": "keycloak-sync.sh",
+        "path": "hooks/scripts/keycloak-sync.sh",
+        "summary": "Hook script keycloak-sync.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "keycloak-sync"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "aws-eks-helm-keycloak:hook:hooks.scripts.pre-deploy-validation",
+        "name": "pre-deploy-validation.sh",
+        "path": "hooks/scripts/pre-deploy-validation.sh",
+        "summary": "Hook script pre-deploy-validation.sh",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "pre-deploy-validation"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "aws-eks-helm-keycloak:doc:readme",
+      "path": "README.md",
+      "summary": "AWS EKS Helm Keycloak Plugin (The Conduit-Artisan)"
+    }
+  ]
+}

--- a/plugins/claude-code-templating-plugin/index.json
+++ b/plugins/claude-code-templating-plugin/index.json
@@ -1,0 +1,288 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "claude-code-templating-plugin",
+    "root": "plugins/claude-code-templating-plugin"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "claude-code-templating-plugin:command:commands.archetype",
+        "name": "/mp:archetype",
+        "path": "commands/archetype.md",
+        "summary": "Archetype Command - Complete Lifecycle",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "archetype",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:command:commands.generate",
+        "name": "/mp:generate",
+        "path": "commands/generate.md",
+        "summary": "Code Generation Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "generate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:command:commands.harness",
+        "name": "/mp:harness",
+        "path": "commands/harness.md",
+        "summary": "Harness CI/CD Command",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:command:commands.scaffold",
+        "name": "/mp:scaffold",
+        "path": "commands/scaffold.md",
+        "summary": "Project Scaffolding Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "scaffold",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:command:commands.template",
+        "name": "/mp:template",
+        "path": "commands/template.md",
+        "summary": "Template Management Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "template",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "claude-code-templating-plugin:agent:agents.readme",
+        "name": "README",
+        "path": "agents/README.md",
+        "summary": "Harness Expert Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "readme"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:agent:agents.archetype-creator",
+        "name": "archetype-creator",
+        "path": "agents/archetype-creator.md",
+        "summary": "Archetype Creator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "archetype-creator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:agent:agents.codegen-agent",
+        "name": "codegen-agent",
+        "path": "agents/codegen-agent.md",
+        "summary": "Codegen Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "codegen-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:agent:agents.database-agent",
+        "name": "database-agent",
+        "path": "agents/database-agent.md",
+        "summary": "Database Agent",
+        "tags": {
+          "domain": "data",
+          "triggerTerms": [
+            "database-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "database"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:agent:agents.harness-expert",
+        "name": "harness-expert",
+        "path": "agents/harness-expert.md",
+        "summary": "Harness Expert Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness-expert"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:agent:agents.scaffold-agent",
+        "name": "scaffold-agent",
+        "path": "agents/scaffold-agent.md",
+        "summary": "Scaffold Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "scaffold-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:agent:agents.testing-agent",
+        "name": "testing-agent",
+        "path": "agents/testing-agent.md",
+        "summary": "Testing Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "testing-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "claude-code-templating-plugin:skill:skills.harness-expert.skill",
+        "name": "harness-expert",
+        "path": "skills/harness-expert/SKILL.md",
+        "summary": "Harness Expert Skill",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness expert"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:skill:skills.project-scaffolding.skill",
+        "name": "project-scaffolding",
+        "path": "skills/project-scaffolding/SKILL.md",
+        "summary": "Project Scaffolding Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "project scaffolding"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "claude-code-templating-plugin:skill:skills.universal-templating.skill",
+        "name": "universal-templating",
+        "path": "skills/universal-templating/SKILL.md",
+        "summary": "Universal Templating Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "universal templating"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": []
+  },
+  "keyDocs": [
+    {
+      "id": "claude-code-templating-plugin:doc:readme",
+      "path": "README.md",
+      "summary": "Claude Code Templating Plugin"
+    },
+    {
+      "id": "claude-code-templating-plugin:doc:claude",
+      "path": "CLAUDE.md",
+      "summary": "Claude Code Templating Plugin"
+    },
+    {
+      "id": "claude-code-templating-plugin:doc:docs.changelog",
+      "path": "docs/CHANGELOG.md",
+      "summary": "Changelog"
+    },
+    {
+      "id": "claude-code-templating-plugin:doc:docs.mcp-client-manager",
+      "path": "docs/MCP-CLIENT-MANAGER.md",
+      "summary": "MCP Client Manager - Implementation Summary"
+    },
+    {
+      "id": "claude-code-templating-plugin:doc:docs.upgrade-plan-v2",
+      "path": "docs/UPGRADE-PLAN-v2.md",
+      "summary": "Claude Code Templating Plugin - v2.0.0 Upgrade Plan"
+    }
+  ]
+}

--- a/plugins/deployment-pipeline/index.json
+++ b/plugins/deployment-pipeline/index.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "deployment-pipeline",
+    "root": "plugins/deployment-pipeline"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "deployment-pipeline:command:commands.approve",
+        "name": "/mp:approve",
+        "path": "commands/approve.md",
+        "summary": "Deploy Approve",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "approve",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "deployment-pipeline:command:commands.history",
+        "name": "/mp:history",
+        "path": "commands/history.md",
+        "summary": "Deploy History",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "history",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "deployment-pipeline:command:commands.rollback",
+        "name": "/mp:rollback",
+        "path": "commands/rollback.md",
+        "summary": "Deploy Rollback",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "rollback",
+            "commands"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "deployment-pipeline:command:commands.start",
+        "name": "/mp:start",
+        "path": "commands/start.md",
+        "summary": "Deploy Start",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "start",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "deployment-pipeline:command:commands.status",
+        "name": "/mp:status",
+        "path": "commands/status.md",
+        "summary": "Deploy Status",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "status",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "deployment-pipeline:agent:agents.orchestrator",
+        "name": "orchestrator",
+        "path": "agents/orchestrator.md",
+        "summary": "Deployment Orchestrator Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "orchestrator"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "deployment-pipeline:agent:agents.rollback",
+        "name": "rollback",
+        "path": "agents/rollback.md",
+        "summary": "Rollback Specialist Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "rollback"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "deployment-pipeline:agent:agents.validator",
+        "name": "validator",
+        "path": "agents/validator.md",
+        "summary": "Deployment Validator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "validator"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [],
+    "hooks": []
+  },
+  "keyDocs": [
+    {
+      "id": "deployment-pipeline:doc:readme",
+      "path": "README.md",
+      "summary": "Deployment Pipeline Plugin"
+    }
+  ]
+}

--- a/plugins/exec-automator/index.json
+++ b/plugins/exec-automator/index.json
@@ -1,0 +1,484 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "exec-automator",
+    "root": "plugins/exec-automator"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "exec-automator:command:commands.analyze",
+        "name": "/mp:analyze",
+        "path": "commands/analyze.md",
+        "summary": "Executive Document Analysis - Extract Responsibilities & Automation Opportunities",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "analyze",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.customize",
+        "name": "/mp:customize",
+        "path": "commands/customize.md",
+        "summary": "Executive Automation Customization",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "customize",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.dashboard",
+        "name": "/mp:dashboard",
+        "path": "commands/dashboard.md",
+        "summary": "Executive Automation Dashboard",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "dashboard",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.deploy",
+        "name": "/mp:deploy",
+        "path": "commands/deploy.md",
+        "summary": "Executive Workflow Deployment Command",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.export",
+        "name": "/mp:export",
+        "path": "commands/export.md",
+        "summary": "Executive Automation Export - Configuration & Data Backup",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "export",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.generate",
+        "name": "/mp:generate",
+        "path": "commands/generate.md",
+        "summary": "LangGraph Workflow Code Generator",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "generate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.integrate",
+        "name": "/mp:integrate",
+        "path": "commands/integrate.md",
+        "summary": "Executive Integration Manager",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "integrate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.map",
+        "name": "/mp:map",
+        "path": "commands/map.md",
+        "summary": "LangGraph Workflow Mapping Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "map",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.orchestrate",
+        "name": "/mp:orchestrate",
+        "path": "commands/orchestrate.md",
+        "summary": "Executive Director Automation Orchestrator",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "orchestrate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.report",
+        "name": "/mp:report",
+        "path": "commands/report.md",
+        "summary": "Executive Automation Report Generator",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "report",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.score",
+        "name": "/mp:score",
+        "path": "commands/score.md",
+        "summary": "Automation Potential Scoring Engine",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "score",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.simulate",
+        "name": "/mp:simulate",
+        "path": "commands/simulate.md",
+        "summary": "Workflow Simulation Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "simulate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:command:commands.template",
+        "name": "/mp:template",
+        "path": "commands/template.md",
+        "summary": "Template Manager - Executive Automation Templates",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "template",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "exec-automator:agent:agents.admin-coordinator",
+        "name": "admin-coordinator",
+        "path": "agents/admin-coordinator.md",
+        "summary": "Admin Coordinator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "admin-coordinator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.communications-director",
+        "name": "communications-director",
+        "path": "agents/communications-director.md",
+        "summary": "Communications Director Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "communications-director"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.compliance-monitor",
+        "name": "compliance-monitor",
+        "path": "agents/compliance-monitor.md",
+        "summary": "Compliance Monitor Agent",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "compliance-monitor"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.event-orchestrator",
+        "name": "event-orchestrator",
+        "path": "agents/event-orchestrator.md",
+        "summary": "Event Orchestrator Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "event-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.finance-manager",
+        "name": "finance-manager",
+        "path": "agents/finance-manager.md",
+        "summary": "Finance Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "finance-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.meeting-facilitator",
+        "name": "meeting-facilitator",
+        "path": "agents/meeting-facilitator.md",
+        "summary": "Meeting Facilitator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "meeting-facilitator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.membership-steward",
+        "name": "membership-steward",
+        "path": "agents/membership-steward.md",
+        "summary": "Membership Steward Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "membership-steward"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.org-analyzer",
+        "name": "org-analyzer",
+        "path": "agents/org-analyzer.md",
+        "summary": "Organizational Analyzer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "org-analyzer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.social-media-manager",
+        "name": "social-media-manager",
+        "path": "agents/social-media-manager.md",
+        "summary": "Social Media Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "social-media-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.sponsor-relations",
+        "name": "sponsor-relations",
+        "path": "agents/sponsor-relations.md",
+        "summary": "Sponsor Relations Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "sponsor-relations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:agent:agents.workflow-designer",
+        "name": "workflow-designer",
+        "path": "agents/workflow-designer.md",
+        "summary": "Workflow Designer Agent",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "workflow-designer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [],
+    "hooks": [
+      {
+        "id": "exec-automator:hook:hooks.scripts.document-detect",
+        "name": "document-detect.sh",
+        "path": "hooks/scripts/document-detect.sh",
+        "summary": "Hook script document-detect.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "document-detect"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:hook:hooks.scripts.execution-tracker",
+        "name": "execution-tracker.sh",
+        "path": "hooks/scripts/execution-tracker.sh",
+        "summary": "Hook script execution-tracker.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "execution-tracker"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:hook:hooks.scripts.workflow-cleanup",
+        "name": "workflow-cleanup.sh",
+        "path": "hooks/scripts/workflow-cleanup.sh",
+        "summary": "Hook script workflow-cleanup.sh",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "workflow-cleanup"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "exec-automator:hook:hooks.scripts.workflow-init",
+        "name": "workflow-init.sh",
+        "path": "hooks/scripts/workflow-init.sh",
+        "summary": "Hook script workflow-init.sh",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "workflow-init"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "exec-automator:doc:readme",
+      "path": "README.md",
+      "summary": "exec-automator"
+    }
+  ]
+}

--- a/plugins/fastapi-backend/index.json
+++ b/plugins/fastapi-backend/index.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "fastapi-backend",
+    "root": "plugins/fastapi-backend"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "fastapi-backend:command:commands.deploy",
+        "name": "/mp:deploy",
+        "path": "commands/deploy.md",
+        "summary": "Deploy FastAPI to Kubernetes",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "kubernetes"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:command:commands.dev",
+        "name": "/mp:dev",
+        "path": "commands/dev.md",
+        "summary": "Start FastAPI Development Server",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "dev",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:command:commands.docker",
+        "name": "/mp:docker",
+        "path": "commands/docker.md",
+        "summary": "Docker Operations for FastAPI",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "docker",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "docker"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:command:commands.endpoint",
+        "name": "/mp:endpoint",
+        "path": "commands/endpoint.md",
+        "summary": "Generate FastAPI Endpoint",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "endpoint",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:command:commands.migrate",
+        "name": "/mp:migrate",
+        "path": "commands/migrate.md",
+        "summary": "Beanie/MongoDB Migrations",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "migrate",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:command:commands.model",
+        "name": "/mp:model",
+        "path": "commands/model.md",
+        "summary": "Generate Beanie Document Model",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "model",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:command:commands.scaffold",
+        "name": "/mp:scaffold",
+        "path": "commands/scaffold.md",
+        "summary": "Scaffold FastAPI Project",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "scaffold",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:command:commands.task",
+        "name": "/mp:task",
+        "path": "commands/task.md",
+        "summary": "Generate Background Task",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "task",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:command:commands.test",
+        "name": "/mp:test",
+        "path": "commands/test.md",
+        "summary": "Generate FastAPI Test Suite",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "test",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:command:commands.ws",
+        "name": "/mp:ws",
+        "path": "commands/ws.md",
+        "summary": "Generate WebSocket Endpoint",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ws",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "fastapi-backend:agent:agents.api-architect",
+        "name": "api-architect",
+        "path": "agents/api-architect.md",
+        "summary": "API Architect Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "api-architect"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:agent:agents.performance-optimizer",
+        "name": "performance-optimizer",
+        "path": "agents/performance-optimizer.md",
+        "summary": "Performance Optimizer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "performance-optimizer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:agent:agents.security-reviewer",
+        "name": "security-reviewer",
+        "path": "agents/security-reviewer.md",
+        "summary": "Security Reviewer Agent",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "security-reviewer"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:agent:agents.test-generator",
+        "name": "test-generator",
+        "path": "agents/test-generator.md",
+        "summary": "Test Generator Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "test-generator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "fastapi-backend:skill:skills.beanie-odm.skill",
+        "name": "beanie-odm",
+        "path": "skills/beanie-odm/SKILL.md",
+        "summary": "Beanie ODM for MongoDB",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "beanie odm"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:skill:skills.fastapi-background.skill",
+        "name": "fastapi-background",
+        "path": "skills/fastapi-background/SKILL.md",
+        "summary": "FastAPI Background Task Processing",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "fastapi background"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:skill:skills.fastapi-caching.skill",
+        "name": "fastapi-caching",
+        "path": "skills/fastapi-caching/SKILL.md",
+        "summary": "FastAPI Caching with Redis",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "fastapi caching"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "database"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:skill:skills.fastapi-k8s.skill",
+        "name": "fastapi-k8s",
+        "path": "skills/fastapi-k8s/SKILL.md",
+        "summary": "FastAPI Docker & Kubernetes Deployment",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "fastapi k8s"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "docker",
+            "kubernetes"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:skill:skills.fastapi-observability.skill",
+        "name": "fastapi-observability",
+        "path": "skills/fastapi-observability/SKILL.md",
+        "summary": "FastAPI Observability",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "fastapi observability"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:skill:skills.fastapi-patterns.skill",
+        "name": "fastapi-patterns",
+        "path": "skills/fastapi-patterns/SKILL.md",
+        "summary": "FastAPI Development Patterns",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "fastapi patterns"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:skill:skills.fastapi-realtime.skill",
+        "name": "fastapi-realtime",
+        "path": "skills/fastapi-realtime/SKILL.md",
+        "summary": "FastAPI Real-Time & Integration Features",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "fastapi realtime"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:skill:skills.keycloak-fastapi.skill",
+        "name": "keycloak-fastapi",
+        "path": "skills/keycloak-fastapi/SKILL.md",
+        "summary": "Keycloak Integration for FastAPI",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "keycloak fastapi"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": [
+      {
+        "id": "fastapi-backend:hook:hooks.scripts.post-endpoint",
+        "name": "post-endpoint.sh",
+        "path": "hooks/scripts/post-endpoint.sh",
+        "summary": "Hook script post-endpoint.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "post-endpoint"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:hook:hooks.scripts.pre-commit",
+        "name": "pre-commit.sh",
+        "path": "hooks/scripts/pre-commit.sh",
+        "summary": "Hook script pre-commit.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "pre-commit"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "fastapi-backend:hook:hooks.scripts.pre-deploy",
+        "name": "pre-deploy.sh",
+        "path": "hooks/scripts/pre-deploy.sh",
+        "summary": "Hook script pre-deploy.sh",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "pre-deploy"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "fastapi-backend:doc:readme",
+      "path": "README.md",
+      "summary": "FastAPI Backend Plugin for Claude Code"
+    }
+  ]
+}

--- a/plugins/frontend-design-system/index.json
+++ b/plugins/frontend-design-system/index.json
@@ -1,0 +1,384 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "frontend-design-system",
+    "root": "plugins/frontend-design-system"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "frontend-design-system:command:commands.audit",
+        "name": "/mp:audit",
+        "path": "commands/audit.md",
+        "summary": "Design System Audit Command",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "audit",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:command:commands.component",
+        "name": "/mp:component",
+        "path": "commands/component.md",
+        "summary": "Styled Component Generation Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "component",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:command:commands.convert",
+        "name": "/mp:convert",
+        "path": "commands/convert.md",
+        "summary": "CSS Format Conversion Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "convert",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:command:commands.keycloak",
+        "name": "/mp:keycloak",
+        "path": "commands/keycloak.md",
+        "summary": "Keycloak Theme Generation Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "keycloak",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:command:commands.palette",
+        "name": "/mp:palette",
+        "path": "commands/palette.md",
+        "summary": "Color Palette Generation Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "palette",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:command:commands.style",
+        "name": "/mp:style",
+        "path": "commands/style.md",
+        "summary": "Style Application Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "style",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:command:commands.theme",
+        "name": "/mp:theme",
+        "path": "commands/theme.md",
+        "summary": "Multi-Tenant Theme Management Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "theme",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:command:commands.tokens",
+        "name": "/mp:tokens",
+        "path": "commands/tokens.md",
+        "summary": "Design Tokens Generation Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "tokens",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "frontend-design-system:agent:agents.accessibility-auditor",
+        "name": "accessibility-auditor",
+        "path": "agents/accessibility-auditor.md",
+        "summary": "Accessibility Auditor Agent",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "accessibility-auditor"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:agent:agents.component-designer",
+        "name": "component-designer",
+        "path": "agents/component-designer.md",
+        "summary": "Component Designer Agent",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "component-designer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:agent:agents.design-architect",
+        "name": "design-architect",
+        "path": "agents/design-architect.md",
+        "summary": "Design Architect Agent",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "design-architect"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:agent:agents.responsive-specialist",
+        "name": "responsive-specialist",
+        "path": "agents/responsive-specialist.md",
+        "summary": "Responsive Specialist Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "responsive-specialist"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:agent:agents.style-implementer",
+        "name": "style-implementer",
+        "path": "agents/style-implementer.md",
+        "summary": "Style Implementer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "style-implementer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:agent:agents.theme-engineer",
+        "name": "theme-engineer",
+        "path": "agents/theme-engineer.md",
+        "summary": "Theme Engineer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "theme-engineer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "frontend-design-system:skill:skills.component-patterns.skill",
+        "name": "component-patterns",
+        "path": "skills/component-patterns/SKILL.md",
+        "summary": "Component Patterns Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "component patterns"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:skill:skills.css-generation.skill",
+        "name": "css-generation",
+        "path": "skills/css-generation/SKILL.md",
+        "summary": "CSS Generation Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "css generation"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:skill:skills.design-styles.skill",
+        "name": "design-styles",
+        "path": "skills/design-styles/SKILL.md",
+        "summary": "Design Styles Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "design styles"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:skill:skills.keycloak-theming.skill",
+        "name": "keycloak-theming",
+        "path": "skills/keycloak-theming/SKILL.md",
+        "summary": "Keycloak Theming Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "keycloak theming"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": [
+      {
+        "id": "frontend-design-system:hook:hooks.scripts.check-style-consistency",
+        "name": "check-style-consistency.sh",
+        "path": "hooks/scripts/check-style-consistency.sh",
+        "summary": "Hook script check-style-consistency.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "check-style-consistency"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:hook:hooks.scripts.sync-themes",
+        "name": "sync-themes.sh",
+        "path": "hooks/scripts/sync-themes.sh",
+        "summary": "Hook script sync-themes.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "sync-themes"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:hook:hooks.scripts.update-tokens",
+        "name": "update-tokens.sh",
+        "path": "hooks/scripts/update-tokens.sh",
+        "summary": "Hook script update-tokens.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "update-tokens"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "frontend-design-system:hook:hooks.scripts.validate-accessibility",
+        "name": "validate-accessibility.sh",
+        "path": "hooks/scripts/validate-accessibility.sh",
+        "summary": "Hook script validate-accessibility.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "validate-accessibility"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "frontend-design-system:doc:readme",
+      "path": "README.md",
+      "summary": "Frontend Design System Plugin"
+    }
+  ]
+}

--- a/plugins/fullstack-iac/index.json
+++ b/plugins/fullstack-iac/index.json
@@ -1,0 +1,223 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "fullstack-iac",
+    "root": "plugins/fullstack-iac"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "fullstack-iac:command:commands.ansible",
+        "name": "/mp:ansible",
+        "path": "commands/ansible.md",
+        "summary": "Zenith Ansible",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ansible",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fullstack-iac:command:commands.api",
+        "name": "/mp:api",
+        "path": "commands/api.md",
+        "summary": "Zenith API Scaffold",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "api",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fullstack-iac:command:commands.docker",
+        "name": "/mp:docker",
+        "path": "commands/docker.md",
+        "summary": "Zenith Docker",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "docker",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "docker"
+          ]
+        }
+      },
+      {
+        "id": "fullstack-iac:command:commands.frontend",
+        "name": "/mp:frontend",
+        "path": "commands/frontend.md",
+        "summary": "Zenith Frontend Scaffold",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "frontend",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fullstack-iac:command:commands.infra",
+        "name": "/mp:infra",
+        "path": "commands/infra.md",
+        "summary": "Zenith Infrastructure",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "infra",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fullstack-iac:command:commands.k8s",
+        "name": "/mp:k8s",
+        "path": "commands/k8s.md",
+        "summary": "Zenith Kubernetes",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "k8s",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "kubernetes"
+          ]
+        }
+      },
+      {
+        "id": "fullstack-iac:command:commands.monorepo",
+        "name": "/mp:monorepo",
+        "path": "commands/monorepo.md",
+        "summary": "Zenith Monorepo",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "monorepo",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fullstack-iac:command:commands.new",
+        "name": "/mp:new",
+        "path": "commands/new.md",
+        "summary": "Zenith New Project",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "new",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "fullstack-iac:agent:agents.api-architect",
+        "name": "api-architect",
+        "path": "agents/api-architect.md",
+        "summary": "FastAPI Architect",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "api-architect"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fullstack-iac:agent:agents.frontend-builder",
+        "name": "frontend-builder",
+        "path": "agents/frontend-builder.md",
+        "summary": "Frontend Builder (React Specialist)",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "frontend-builder"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "fullstack-iac:skill:skills.fastapi-patterns.skill",
+        "name": "fastapi-patterns",
+        "path": "skills/fastapi-patterns/SKILL.md",
+        "summary": "FastAPI Patterns Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "fastapi patterns"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "fullstack-iac:skill:skills.react-vite.skill",
+        "name": "react-vite",
+        "path": "skills/react-vite/SKILL.md",
+        "summary": "React Vite Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "react vite"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": []
+  },
+  "keyDocs": [
+    {
+      "id": "fullstack-iac:doc:readme",
+      "path": "README.md",
+      "summary": "Zenith - Full-Stack Development & Infrastructure Automation"
+    }
+  ]
+}

--- a/plugins/home-assistant-architect/index.json
+++ b/plugins/home-assistant-architect/index.json
@@ -1,0 +1,609 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "home-assistant-architect",
+    "root": "plugins/home-assistant-architect"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "home-assistant-architect:command:commands.ha-automation",
+        "name": "/mp:ha-automation",
+        "path": "commands/ha-automation.md",
+        "summary": "Home Assistant Automation Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ha-automation",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:command:commands.ha-camera",
+        "name": "/mp:ha-camera",
+        "path": "commands/ha-camera.md",
+        "summary": "/ha-camera Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ha-camera",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:command:commands.ha-control",
+        "name": "/mp:ha-control",
+        "path": "commands/ha-control.md",
+        "summary": "Home Assistant Control Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ha-control",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:command:commands.ha-dashboard",
+        "name": "/mp:ha-dashboard",
+        "path": "commands/ha-dashboard.md",
+        "summary": "/ha-dashboard Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ha-dashboard",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:command:commands.ha-deploy",
+        "name": "/mp:ha-deploy",
+        "path": "commands/ha-deploy.md",
+        "summary": "Home Assistant Deploy Command",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "ha-deploy",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:command:commands.ha-energy",
+        "name": "/mp:ha-energy",
+        "path": "commands/ha-energy.md",
+        "summary": "/ha-energy Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ha-energy",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:command:commands.ha-mcp",
+        "name": "/mp:ha-mcp",
+        "path": "commands/ha-mcp.md",
+        "summary": "Home Assistant MCP Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ha-mcp",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:command:commands.ha-sensor",
+        "name": "/mp:ha-sensor",
+        "path": "commands/ha-sensor.md",
+        "summary": "/ha-sensor Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ha-sensor",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:command:commands.ollama-setup",
+        "name": "/mp:ollama-setup",
+        "path": "commands/ollama-setup.md",
+        "summary": "Ollama Setup Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ollama-setup",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "home-assistant-architect:agent:agents.ha-automation-architect",
+        "name": "ha-automation-architect",
+        "path": "agents/ha-automation-architect.md",
+        "summary": "Home Assistant Automation Architect Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ha-automation-architect"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-camera-nvr",
+        "name": "ha-camera-nvr",
+        "path": "agents/ha-camera-nvr.md",
+        "summary": "Home Assistant Camera and NVR Integration Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-camera-nvr"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-customization-expert",
+        "name": "ha-customization-expert",
+        "path": "agents/ha-customization-expert.md",
+        "summary": "Home Assistant Customization Expert Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-customization-expert"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-dashboard-designer",
+        "name": "ha-dashboard-designer",
+        "path": "agents/ha-dashboard-designer.md",
+        "summary": "Home Assistant Advanced Dashboard Designer Agent",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "ha-dashboard-designer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-data-writer",
+        "name": "ha-data-writer",
+        "path": "agents/ha-data-writer.md",
+        "summary": "Home Assistant Data Writer Agent",
+        "tags": {
+          "domain": "data",
+          "triggerTerms": [
+            "ha-data-writer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-device-controller",
+        "name": "ha-device-controller",
+        "path": "agents/ha-device-controller.md",
+        "summary": "Home Assistant Device Controller Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-device-controller"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-diagnostics",
+        "name": "ha-diagnostics",
+        "path": "agents/ha-diagnostics.md",
+        "summary": "Home Assistant Diagnostics Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-diagnostics"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-energy-management",
+        "name": "ha-energy-management",
+        "path": "agents/ha-energy-management.md",
+        "summary": "Home Assistant Energy Management System Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-energy-management"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-energy-optimizer",
+        "name": "ha-energy-optimizer",
+        "path": "agents/ha-energy-optimizer.md",
+        "summary": "Home Assistant Energy Optimizer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-energy-optimizer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-frontend-builder",
+        "name": "ha-frontend-builder",
+        "path": "agents/ha-frontend-builder.md",
+        "summary": "Home Assistant Frontend Builder Agent",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "ha-frontend-builder"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-security-auditor",
+        "name": "ha-security-auditor",
+        "path": "agents/ha-security-auditor.md",
+        "summary": "Home Assistant Security Auditor Agent",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "ha-security-auditor"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-sensor-manager",
+        "name": "ha-sensor-manager",
+        "path": "agents/ha-sensor-manager.md",
+        "summary": "Home Assistant Sensor Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-sensor-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ha-voice-assistant",
+        "name": "ha-voice-assistant",
+        "path": "agents/ha-voice-assistant.md",
+        "summary": "Home Assistant Voice Assistant Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-voice-assistant"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.local-llm-manager",
+        "name": "local-llm-manager",
+        "path": "agents/local-llm-manager.md",
+        "summary": "Local LLM Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "local-llm-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:agent:agents.ubuntu-ha-deployer",
+        "name": "ubuntu-ha-deployer",
+        "path": "agents/ubuntu-ha-deployer.md",
+        "summary": "Ubuntu Home Assistant Deployer Agent",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "ubuntu-ha-deployer"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "home-assistant-architect:skill:skills.camera-nvr.skill",
+        "name": "camera-nvr",
+        "path": "skills/camera-nvr/SKILL.md",
+        "summary": "Camera and NVR Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "camera nvr"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:skill:skills.energy-management.skill",
+        "name": "energy-management",
+        "path": "skills/energy-management/SKILL.md",
+        "summary": "Energy Management Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "energy management"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:skill:skills.ha-automation.skill",
+        "name": "ha-automation",
+        "path": "skills/ha-automation/SKILL.md",
+        "summary": "Home Assistant Automation Skill",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ha automation"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:skill:skills.ha-core.skill",
+        "name": "ha-core",
+        "path": "skills/ha-core/SKILL.md",
+        "summary": "Home Assistant Core Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha core"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:skill:skills.local-llm.skill",
+        "name": "local-llm",
+        "path": "skills/local-llm/SKILL.md",
+        "summary": "Local LLM Integration Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "local llm"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:skill:skills.lovelace-design.skill",
+        "name": "lovelace-design",
+        "path": "skills/lovelace-design/SKILL.md",
+        "summary": "Lovelace Dashboard Design Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "lovelace design"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:skill:skills.sensor-management.skill",
+        "name": "sensor-management",
+        "path": "skills/sensor-management/SKILL.md",
+        "summary": "Sensor Management Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "sensor management"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:skill:skills.ubuntu-deployment.skill",
+        "name": "ubuntu-deployment",
+        "path": "skills/ubuntu-deployment/SKILL.md",
+        "summary": "Ubuntu Deployment Skill",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "ubuntu deployment"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": [
+      {
+        "id": "home-assistant-architect:hook:hooks.scripts.ha-health-check",
+        "name": "ha-health-check.sh",
+        "path": "hooks/scripts/ha-health-check.sh",
+        "summary": "Hook script ha-health-check.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ha-health-check"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:hook:hooks.scripts.ollama-status",
+        "name": "ollama-status.sh",
+        "path": "hooks/scripts/ollama-status.sh",
+        "summary": "Hook script ollama-status.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ollama-status"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:hook:hooks.scripts.security-scan",
+        "name": "security-scan.sh",
+        "path": "hooks/scripts/security-scan.sh",
+        "summary": "Hook script security-scan.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "security-scan"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "home-assistant-architect:hook:hooks.scripts.validate-yaml",
+        "name": "validate-yaml.sh",
+        "path": "hooks/scripts/validate-yaml.sh",
+        "summary": "Hook script validate-yaml.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "validate-yaml"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "home-assistant-architect:doc:readme",
+      "path": "README.md",
+      "summary": "Home Assistant Architect Plugin"
+    }
+  ]
+}

--- a/plugins/jira-orchestrator/index.json
+++ b/plugins/jira-orchestrator/index.json
@@ -1,0 +1,2488 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "jira-orchestrator",
+    "root": "plugins/jira-orchestrator"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "jira-orchestrator:command:commands.approve",
+        "name": "/mp:approve",
+        "path": "commands/approve.md",
+        "summary": "Jira Approval Workflows",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "approve",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.batch",
+        "name": "/mp:batch",
+        "path": "commands/batch.md",
+        "summary": "Jira Batch Operations",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "batch",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.branch",
+        "name": "/mp:branch",
+        "path": "commands/branch.md",
+        "summary": "Jira Branch Creation",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "branch",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.bulk-commit",
+        "name": "/mp:bulk-commit",
+        "path": "commands/bulk-commit.md",
+        "summary": "Bulk Commit Processing",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "bulk-commit",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.cancel",
+        "name": "/mp:cancel",
+        "path": "commands/cancel.md",
+        "summary": "Cancel active orchestration, stop sub-agents, save checkpoint, update Jira, and enable resume.",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "cancel",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.commit-template",
+        "name": "/mp:commit-template",
+        "path": "commands/commit-template.md",
+        "summary": "Commit Template Generator",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "commit-template",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.commit",
+        "name": "/mp:commit",
+        "path": "commands/commit.md",
+        "summary": "Jira Smart Commit Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "commit",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.compliance",
+        "name": "/mp:compliance",
+        "path": "commands/compliance.md",
+        "summary": "Compliance Management Command",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "compliance",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.confluence",
+        "name": "/mp:confluence",
+        "path": "commands/confluence.md",
+        "summary": "Jira-Confluence Integration",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "confluence",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.council",
+        "name": "/mp:council",
+        "path": "commands/council.md",
+        "summary": "Council Review - Blackboard Pattern",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "council",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.create-repo",
+        "name": "/mp:create-repo",
+        "path": "commands/create-repo.md",
+        "summary": "/jira:create-repo",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "create-repo",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.deploy",
+        "name": "/mp:deploy",
+        "path": "commands/deploy.md",
+        "summary": "Deployment Tracking",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.docs-external",
+        "name": "/mp:docs-external",
+        "path": "commands/docs-external.md",
+        "summary": "/jira:docs-external",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "docs-external",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.docs",
+        "name": "/mp:docs",
+        "path": "commands/docs.md",
+        "summary": "Jira Documentation Generator",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "docs",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.enterprise",
+        "name": "/mp:enterprise",
+        "path": "commands/enterprise.md",
+        "summary": "/jira:enterprise",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "enterprise",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.events",
+        "name": "/mp:events",
+        "path": "commands/events.md",
+        "summary": "Event Sourcing Operations",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "events",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.export",
+        "name": "/mp:export",
+        "path": "commands/export.md",
+        "summary": "Jira Export & Reporting",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "export",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.harness-review",
+        "name": "/mp:harness-review",
+        "path": "commands/harness-review.md",
+        "summary": "Harness PR Review Command",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness-review",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.infra",
+        "name": "/mp:infra",
+        "path": "commands/infra.md",
+        "summary": "/jira:infra",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "infra",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.install-hooks",
+        "name": "/mp:install-hooks",
+        "path": "commands/install-hooks.md",
+        "summary": "/jira:install-hooks",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "install-hooks",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.intelligence",
+        "name": "/mp:intelligence",
+        "path": "commands/intelligence.md",
+        "summary": "Intelligence Analytics",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "intelligence",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.iterate",
+        "name": "/mp:iterate",
+        "path": "commands/iterate.md",
+        "summary": "DEPRECATED: Use `/jira:pr --iterate`",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "iterate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.metrics",
+        "name": "/mp:metrics",
+        "path": "commands/metrics.md",
+        "summary": "Jira Orchestrator Metrics Dashboard",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "metrics",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.notify",
+        "name": "/mp:notify",
+        "path": "commands/notify.md",
+        "summary": "/jira:notify",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "notify",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.orchestrate-advanced",
+        "name": "/mp:orchestrate-advanced",
+        "path": "commands/orchestrate-advanced.md",
+        "summary": "Advanced Orchestration Patterns",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "orchestrate-advanced",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.plan-prs",
+        "name": "/mp:plan-prs",
+        "path": "commands/plan-prs.md",
+        "summary": "Plan PRs Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "plan-prs",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.portfolio",
+        "name": "/mp:portfolio",
+        "path": "commands/portfolio.md",
+        "summary": "Portfolio Management",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "portfolio",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.pr-fix",
+        "name": "/mp:pr-fix",
+        "path": "commands/pr-fix.md",
+        "summary": "DEPRECATED: Use `/jira:pr --fix`",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "pr-fix",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.pr",
+        "name": "/mp:pr",
+        "path": "commands/pr.md",
+        "summary": "> ⚠️ **Migration Notice:** This command now consolidates `/pr-fix` and `/jira:iterate`.",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "pr",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.prepare",
+        "name": "/mp:prepare",
+        "path": "commands/prepare.md",
+        "summary": "Prepare Task for Work",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "prepare",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.process-worklogs",
+        "name": "/mp:process-worklogs",
+        "path": "commands/process-worklogs.md",
+        "summary": "Process Pending Worklogs",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "process-worklogs",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.qa-review",
+        "name": "/mp:qa-review",
+        "path": "commands/qa-review.md",
+        "summary": "QA Review Workflow",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "qa-review",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.quality",
+        "name": "/mp:quality",
+        "path": "commands/quality.md",
+        "summary": "Quality Intelligence Report",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "quality",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.reason",
+        "name": "/mp:reason",
+        "path": "commands/reason.md",
+        "summary": "Reasoning Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "reason",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.release",
+        "name": "/mp:release",
+        "path": "commands/release.md",
+        "summary": "Release Management Command",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "release",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.review",
+        "name": "/mp:review",
+        "path": "commands/review.md",
+        "summary": "Code Review Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "review",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.setup",
+        "name": "/mp:setup",
+        "path": "commands/setup.md",
+        "summary": "Jira Orchestrator v7.5.0 - Interactive Setup Wizard",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "setup",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.ship",
+        "name": "/mp:ship",
+        "path": "commands/ship.md",
+        "summary": "Ship Command v2.0 - Intelligent Orchestration",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "ship",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.sla",
+        "name": "/mp:sla",
+        "path": "commands/sla.md",
+        "summary": "Jira SLA Management Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "sla",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.sprint-plan",
+        "name": "/mp:sprint-plan",
+        "path": "commands/sprint-plan.md",
+        "summary": "Sprint Planning Automation",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "sprint-plan",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.sprint",
+        "name": "/mp:sprint",
+        "path": "commands/sprint.md",
+        "summary": "/jira:sprint",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "sprint",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.status",
+        "name": "/mp:status",
+        "path": "commands/status.md",
+        "summary": "/jira:status",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "status",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.sync",
+        "name": "/mp:sync",
+        "path": "commands/sync.md",
+        "summary": "Jira Sync Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "sync",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.team",
+        "name": "/mp:team",
+        "path": "commands/team.md",
+        "summary": "Team & Resource Management",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "team",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.triage",
+        "name": "/mp:triage",
+        "path": "commands/triage.md",
+        "summary": "Jira Issue Triage",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "triage",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:command:commands.work",
+        "name": "/mp:work",
+        "path": "commands/work.md",
+        "summary": "Jira Issue Orchestration",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "work",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "jira-orchestrator:agent:agents.advanced-orchestration-patterns",
+        "name": "advanced-orchestration-patterns",
+        "path": "agents/advanced-orchestration-patterns.md",
+        "summary": "Advanced Orchestration Patterns Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "advanced-orchestration-patterns"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.agent-router",
+        "name": "agent-router",
+        "path": "agents/agent-router.md",
+        "summary": "Agent Router",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "agent-router"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.approval-orchestrator",
+        "name": "approval-orchestrator",
+        "path": "agents/approval-orchestrator.md",
+        "summary": "Approval Orchestrator Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "approval-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.batch-commit-processor",
+        "name": "batch-commit-processor",
+        "path": "agents/batch-commit-processor.md",
+        "summary": "Batch Commit Processor Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "batch-commit-processor"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.batch-processor",
+        "name": "batch-processor",
+        "path": "agents/batch-processor.md",
+        "summary": "Batch Processor Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "batch-processor"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.bulk-importer",
+        "name": "bulk-importer",
+        "path": "agents/bulk-importer.md",
+        "summary": "Bulk Importer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "bulk-importer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.chain-of-thought-reasoner",
+        "name": "chain-of-thought-reasoner",
+        "path": "agents/chain-of-thought-reasoner.md",
+        "summary": "Chain-of-Thought Reasoner Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "chain-of-thought-reasoner"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.checkpoint-pr-manager",
+        "name": "checkpoint-pr-manager",
+        "path": "agents/checkpoint-pr-manager.md",
+        "summary": "Checkpoint PR Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "checkpoint-pr-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.code-quality-enforcer",
+        "name": "code-quality-enforcer",
+        "path": "agents/code-quality-enforcer.md",
+        "summary": "Code Quality Enforcer Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "code-quality-enforcer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.code-reviewer",
+        "name": "code-reviewer",
+        "path": "agents/code-reviewer.md",
+        "summary": "Code Reviewer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "code-reviewer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.commit-message-generator",
+        "name": "commit-message-generator",
+        "path": "agents/commit-message-generator.md",
+        "summary": "Commit Message Generator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "commit-message-generator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.commit-orchestrator",
+        "name": "commit-orchestrator",
+        "path": "agents/commit-orchestrator.md",
+        "summary": "Commit Orchestrator Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "commit-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.commit-tracker",
+        "name": "commit-tracker",
+        "path": "agents/commit-tracker.md",
+        "summary": "Commit Tracker Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "commit-tracker"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.completion-flow-orchestrator",
+        "name": "completion-flow-orchestrator",
+        "path": "agents/completion-flow-orchestrator.md",
+        "summary": "Completion Flow Orchestrator",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "completion-flow-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.completion-orchestrator",
+        "name": "completion-orchestrator",
+        "path": "agents/completion-orchestrator.md",
+        "summary": "Completion Orchestrator Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "completion-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.compliance-reporter",
+        "name": "compliance-reporter",
+        "path": "agents/compliance-reporter.md",
+        "summary": "Compliance Reporter Agent",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "compliance-reporter"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.confluence-documentation-creator",
+        "name": "confluence-documentation-creator",
+        "path": "agents/confluence-documentation-creator.md",
+        "summary": "Confluence Documentation Creator",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "confluence-documentation-creator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.confluence-manager",
+        "name": "confluence-manager",
+        "path": "agents/confluence-manager.md",
+        "summary": "Confluence Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "confluence-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.council-coordinator",
+        "name": "council-coordinator",
+        "path": "agents/council-coordinator.md",
+        "summary": "Council Coordinator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "council-coordinator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.dependency-mapper",
+        "name": "dependency-mapper",
+        "path": "agents/dependency-mapper.md",
+        "summary": "Dependency Mapper Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "dependency-mapper"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.discord-notifier",
+        "name": "discord-notifier",
+        "path": "agents/discord-notifier.md",
+        "summary": "Discord Notifier Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "discord-notifier"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.documentation-hub",
+        "name": "documentation-hub",
+        "path": "agents/documentation-hub.md",
+        "summary": "Documentation Hub Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "documentation-hub"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.documentation-sync-agent",
+        "name": "documentation-sync-agent",
+        "path": "agents/documentation-sync-agent.md",
+        "summary": "Documentation Sync Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "documentation-sync-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.documentation-writer",
+        "name": "documentation-writer",
+        "path": "agents/documentation-writer.md",
+        "summary": "Documentation Writer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "documentation-writer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.draft-pr-manager",
+        "name": "draft-pr-manager",
+        "path": "agents/draft-pr-manager.md",
+        "summary": "Draft PR Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "draft-pr-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.epic-decomposer",
+        "name": "epic-decomposer",
+        "path": "agents/epic-decomposer.md",
+        "summary": "Epic Decomposer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "epic-decomposer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.escalation-manager",
+        "name": "escalation-manager",
+        "path": "agents/escalation-manager.md",
+        "summary": "Escalation Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "escalation-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.event-sourcing-orchestrator",
+        "name": "event-sourcing-orchestrator",
+        "path": "agents/event-sourcing-orchestrator.md",
+        "summary": "Event Sourcing Orchestrator",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "event-sourcing-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.expert-agent-matcher",
+        "name": "expert-agent-matcher",
+        "path": "agents/expert-agent-matcher.md",
+        "summary": "Expert Agent Matcher",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "expert-agent-matcher"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.export-generator",
+        "name": "export-generator",
+        "path": "agents/export-generator.md",
+        "summary": "Export Generator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "export-generator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.external-documentation-publisher",
+        "name": "external-documentation-publisher",
+        "path": "agents/external-documentation-publisher.md",
+        "summary": "External Documentation Publisher Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "external-documentation-publisher"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.governance-auditor",
+        "name": "governance-auditor",
+        "path": "agents/governance-auditor.md",
+        "summary": "Governance Auditor Agent",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "governance-auditor"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.harness-api-expert",
+        "name": "harness-api-expert",
+        "path": "agents/harness-api-expert.md",
+        "summary": "Harness API Expert Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness-api-expert"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.harness-jira-sync",
+        "name": "harness-jira-sync",
+        "path": "agents/harness-jira-sync.md",
+        "summary": "Harness-Jira Synchronization Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness-jira-sync"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.hypothesis-debugger",
+        "name": "hypothesis-debugger",
+        "path": "agents/hypothesis-debugger.md",
+        "summary": "Hypothesis-Driven Debugger Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "hypothesis-debugger"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.infrastructure-orchestrator",
+        "name": "infrastructure-orchestrator",
+        "path": "agents/infrastructure-orchestrator.md",
+        "summary": "Infrastructure Orchestrator Agent",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "infrastructure-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.intelligence-analyzer",
+        "name": "intelligence-analyzer",
+        "path": "agents/intelligence-analyzer.md",
+        "summary": "Intelligence Analyzer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "intelligence-analyzer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.issue-validator",
+        "name": "issue-validator",
+        "path": "agents/issue-validator.md",
+        "summary": "Issue Validator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "issue-validator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.learning-coordinator",
+        "name": "learning-coordinator",
+        "path": "agents/learning-coordinator.md",
+        "summary": "Learning Coordinator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "learning-coordinator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.metrics-dashboard",
+        "name": "metrics-dashboard",
+        "path": "agents/metrics-dashboard.md",
+        "summary": "Metrics Dashboard Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "metrics-dashboard"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.notification-analytics",
+        "name": "notification-analytics",
+        "path": "agents/notification-analytics.md",
+        "summary": "Notification Analytics Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "notification-analytics"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.notification-router",
+        "name": "notification-router",
+        "path": "agents/notification-router.md",
+        "summary": "Notification Router",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "notification-router"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.pagerduty-notifier",
+        "name": "pagerduty-notifier",
+        "path": "agents/pagerduty-notifier.md",
+        "summary": "PagerDuty Notifier Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "pagerduty-notifier"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.parallel-sub-issue-worker",
+        "name": "parallel-sub-issue-worker",
+        "path": "agents/parallel-sub-issue-worker.md",
+        "summary": "Parallel Sub-Issue Worker Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "parallel-sub-issue-worker"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.pattern-analyzer",
+        "name": "pattern-analyzer",
+        "path": "agents/pattern-analyzer.md",
+        "summary": "Pattern Analyzer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "pattern-analyzer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.performance-tracker",
+        "name": "performance-tracker",
+        "path": "agents/performance-tracker.md",
+        "summary": "Performance Tracker Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "performance-tracker"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.policy-enforcer",
+        "name": "policy-enforcer",
+        "path": "agents/policy-enforcer.md",
+        "summary": "Policy Enforcer Agent",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "policy-enforcer"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.portfolio-manager",
+        "name": "portfolio-manager",
+        "path": "agents/portfolio-manager.md",
+        "summary": "Portfolio Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "portfolio-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.pr-creator",
+        "name": "pr-creator",
+        "path": "agents/pr-creator.md",
+        "summary": "PR Creator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "pr-creator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.pr-documentation-logger",
+        "name": "pr-documentation-logger",
+        "path": "agents/pr-documentation-logger.md",
+        "summary": "PR Documentation Logger Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "pr-documentation-logger"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.pr-size-estimator",
+        "name": "pr-size-estimator",
+        "path": "agents/pr-size-estimator.md",
+        "summary": "PR Size Estimator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "pr-size-estimator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.qa-comment-responder",
+        "name": "qa-comment-responder",
+        "path": "agents/qa-comment-responder.md",
+        "summary": "QA Comment Responder Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "qa-comment-responder"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.qa-confluence-documenter",
+        "name": "qa-confluence-documenter",
+        "path": "agents/qa-confluence-documenter.md",
+        "summary": "QA Confluence Documenter Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "qa-confluence-documenter"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.qa-ticket-reviewer",
+        "name": "qa-ticket-reviewer",
+        "path": "agents/qa-ticket-reviewer.md",
+        "summary": "QA Ticket Reviewer Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "qa-ticket-reviewer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.qa-transition",
+        "name": "qa-transition",
+        "path": "agents/qa-transition.md",
+        "summary": "QA Transition Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "qa-transition"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.quality-enhancer",
+        "name": "quality-enhancer",
+        "path": "agents/quality-enhancer.md",
+        "summary": "Quality Enhancer Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "quality-enhancer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.quality-intelligence",
+        "name": "quality-intelligence",
+        "path": "agents/quality-intelligence.md",
+        "summary": "Quality Intelligence Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "quality-intelligence"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.release-coordinator",
+        "name": "release-coordinator",
+        "path": "agents/release-coordinator.md",
+        "summary": "Release Coordinator Agent",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "release-coordinator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.requirements-analyzer",
+        "name": "requirements-analyzer",
+        "path": "agents/requirements-analyzer.md",
+        "summary": "Requirements Analyzer Agent",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "requirements-analyzer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.review-facilitator",
+        "name": "review-facilitator",
+        "path": "agents/review-facilitator.md",
+        "summary": "Review Facilitator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "review-facilitator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.review-orchestrator",
+        "name": "review-orchestrator",
+        "path": "agents/review-orchestrator.md",
+        "summary": "Review Orchestrator Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "review-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.review-progress-tracker",
+        "name": "review-progress-tracker",
+        "path": "agents/review-progress-tracker.md",
+        "summary": "Review Progress Tracker Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "review-progress-tracker"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.roadmap-planner",
+        "name": "roadmap-planner",
+        "path": "agents/roadmap-planner.md",
+        "summary": "Roadmap Planner Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "roadmap-planner"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.root-cause-analyzer",
+        "name": "root-cause-analyzer",
+        "path": "agents/root-cause-analyzer.md",
+        "summary": "Root Cause Analyzer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "root-cause-analyzer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.skill-mapper",
+        "name": "skill-mapper",
+        "path": "agents/skill-mapper.md",
+        "summary": "Skill Mapper Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "skill-mapper"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.sla-monitor",
+        "name": "sla-monitor",
+        "path": "agents/sla-monitor.md",
+        "summary": "SLA Monitor Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "sla-monitor"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.slack-notifier",
+        "name": "slack-notifier",
+        "path": "agents/slack-notifier.md",
+        "summary": "Slack Notifier",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "slack-notifier"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.smart-commit-validator",
+        "name": "smart-commit-validator",
+        "path": "agents/smart-commit-validator.md",
+        "summary": "Smart Commit Validator Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "smart-commit-validator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.sprint-planner",
+        "name": "sprint-planner",
+        "path": "agents/sprint-planner.md",
+        "summary": "Sprint Planner Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "sprint-planner"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.sub-item-documenter",
+        "name": "sub-item-documenter",
+        "path": "agents/sub-item-documenter.md",
+        "summary": "Sub-Item Documenter Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "sub-item-documenter"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.tag-manager",
+        "name": "tag-manager",
+        "path": "agents/tag-manager.md",
+        "summary": "Tag Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "tag-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.task-enricher",
+        "name": "task-enricher",
+        "path": "agents/task-enricher.md",
+        "summary": "Task Enricher Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "task-enricher"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.team-capacity-planner",
+        "name": "team-capacity-planner",
+        "path": "agents/team-capacity-planner.md",
+        "summary": "Team Capacity Planner Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "team-capacity-planner"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.test-strategist",
+        "name": "test-strategist",
+        "path": "agents/test-strategist.md",
+        "summary": "Test Strategist",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "test-strategist"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.transition-manager",
+        "name": "transition-manager",
+        "path": "agents/transition-manager.md",
+        "summary": "Transition Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "transition-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.tree-of-thought-reasoner",
+        "name": "tree-of-thought-reasoner",
+        "path": "agents/tree-of-thought-reasoner.md",
+        "summary": "Tree-of-Thought Reasoner Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "tree-of-thought-reasoner"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.triage-agent",
+        "name": "triage-agent",
+        "path": "agents/triage-agent.md",
+        "summary": "Jira Issue Triage Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "triage-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.webhook-publisher",
+        "name": "webhook-publisher",
+        "path": "agents/webhook-publisher.md",
+        "summary": "Webhook Publisher",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "webhook-publisher"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.workload-balancer",
+        "name": "workload-balancer",
+        "path": "agents/workload-balancer.md",
+        "summary": "Workload Balancer Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "workload-balancer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.worklog-manager",
+        "name": "worklog-manager",
+        "path": "agents/worklog-manager.md",
+        "summary": "Worklog Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "worklog-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:agent:agents.worktree-orchestrator",
+        "name": "worktree-orchestrator",
+        "path": "agents/worktree-orchestrator.md",
+        "summary": "Worktree Orchestrator Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "worktree-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "jira-orchestrator:skill:skills.clean-architecture.skill",
+        "name": "clean-architecture",
+        "path": "skills/clean-architecture/SKILL.md",
+        "summary": "Clean Architecture Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "clean architecture"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.code-review.skill",
+        "name": "code-review",
+        "path": "skills/code-review/SKILL.md",
+        "summary": "Code Review Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "code review"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.confluence.skill",
+        "name": "confluence",
+        "path": "skills/confluence/SKILL.md",
+        "summary": "Confluence Documentation Patterns",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "confluence"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.harness-cd.skill",
+        "name": "harness-cd",
+        "path": "skills/harness-cd/SKILL.md",
+        "summary": "Harness CD Skill",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness cd"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.harness-ci.skill",
+        "name": "harness-ci",
+        "path": "skills/harness-ci/SKILL.md",
+        "summary": "Harness CI Skill",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness ci"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.harness-mcp.skill",
+        "name": "harness-mcp",
+        "path": "skills/harness-mcp/SKILL.md",
+        "summary": "Harness MCP Skill",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness mcp"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.harness-platform.skill",
+        "name": "harness-platform",
+        "path": "skills/harness-platform/SKILL.md",
+        "summary": "Harness Platform Administration Skill",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "harness platform"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.jira-orchestration.skill",
+        "name": "jira-orchestration",
+        "path": "skills/jira-orchestration/SKILL.md",
+        "summary": "Jira Orchestration Workflow",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "jira orchestration"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.pr-workflow.skill",
+        "name": "pr-workflow",
+        "path": "skills/pr-workflow/SKILL.md",
+        "summary": "PR Workflow Skill",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "pr workflow"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.task-details.skill",
+        "name": "task-details",
+        "path": "skills/task-details/SKILL.md",
+        "summary": "Task Details Enrichment Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "task details"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:skill:skills.triage.skill",
+        "name": "triage",
+        "path": "skills/triage/SKILL.md",
+        "summary": "Jira Issue Triage and Routing Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "triage"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": [
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.detect-jira-key",
+        "name": "detect-jira-key.sh",
+        "path": "hooks/scripts/detect-jira-key.sh",
+        "summary": "Hook script detect-jira-key.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "detect-jira-key"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.docs-reminder",
+        "name": "docs-reminder.sh",
+        "path": "hooks/scripts/docs-reminder.sh",
+        "summary": "Hook script docs-reminder.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "docs-reminder"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.lib.platform-utils",
+        "name": "platform-utils.sh",
+        "path": "hooks/scripts/lib/platform-utils.sh",
+        "summary": "Hook script platform-utils.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "platform-utils"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.post-task-learning",
+        "name": "post-task-learning.sh",
+        "path": "hooks/scripts/post-task-learning.sh",
+        "summary": "Hook script post-task-learning.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "post-task-learning"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.pr-size-guard",
+        "name": "pr-size-guard.sh",
+        "path": "hooks/scripts/pr-size-guard.sh",
+        "summary": "Hook script pr-size-guard.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "pr-size-guard"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.process-pending-worklogs",
+        "name": "process-pending-worklogs.sh",
+        "path": "hooks/scripts/process-pending-worklogs.sh",
+        "summary": "Hook script process-pending-worklogs.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "process-pending-worklogs"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.review-gate",
+        "name": "review-gate.sh",
+        "path": "hooks/scripts/review-gate.sh",
+        "summary": "Hook script review-gate.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "review-gate"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.session-resume",
+        "name": "session-resume.sh",
+        "path": "hooks/scripts/session-resume.sh",
+        "summary": "Hook script session-resume.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "session-resume"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.test-hook",
+        "name": "test-hook.sh",
+        "path": "hooks/scripts/test-hook.sh",
+        "summary": "Hook script test-hook.sh",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "test-hook"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "jira-orchestrator:hook:hooks.scripts.triage-check",
+        "name": "triage-check.sh",
+        "path": "hooks/scripts/triage-check.sh",
+        "summary": "Hook script triage-check.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "triage-check"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "jira-orchestrator:doc:readme",
+      "path": "README.md",
+      "summary": "Golden Armada - Lobbi Autonomous DevOps Orchestration"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.architecture-summary",
+      "path": "docs/ARCHITECTURE-SUMMARY.md",
+      "summary": "Plugin Ecosystem Architecture - Executive Summary"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.budget-prediction-usage",
+      "path": "docs/BUDGET-PREDICTION-USAGE.md",
+      "summary": "Predictive Token Budget Management - Usage Guide"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.compaction-report",
+      "path": "docs/COMPACTION-REPORT.md",
+      "summary": "Agent Files Compaction Report"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.confluence-documentation",
+      "path": "docs/CONFLUENCE-DOCUMENTATION.md",
+      "summary": "Jira Orchestrator - Complete Documentation"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.database-integration-analysis",
+      "path": "docs/DATABASE-INTEGRATION-ANALYSIS.md",
+      "summary": "Database & Workflow Orchestration Integration Analysis for Jira Orchestrator"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.database-setup",
+      "path": "docs/DATABASE-SETUP.md",
+      "summary": "Database Setup Guide - Jira Orchestrator"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.development-standards",
+      "path": "docs/DEVELOPMENT-STANDARDS.md",
+      "summary": "Development Standards & Best Practices"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.flags",
+      "path": "docs/FLAGS.md",
+      "summary": "Jira Orchestrator Flag System"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.github-jira-integration-guide",
+      "path": "docs/GITHUB-JIRA-INTEGRATION-GUIDE.md",
+      "summary": "GitHub-Jira Integration Guide v1.4.0"
+    },
+    {
+      "id": "jira-orchestrator:doc:docs.harness-jira-connector-setup",
+      "path": "docs/HARNESS-JIRA-CONNECTOR-SETUP.md",
+      "summary": "Harness Jira Connector Setup Guide"
+    }
+  ]
+}

--- a/plugins/lobbi-platform-manager/index.json
+++ b/plugins/lobbi-platform-manager/index.json
@@ -1,0 +1,320 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "lobbi-platform-manager",
+    "root": "plugins/lobbi-platform-manager"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "lobbi-platform-manager:command:commands.env-generate",
+        "name": "/mp:env-generate",
+        "path": "commands/env-generate.md",
+        "summary": "Generate complete .env configuration files for different environments (development, staging, production) with sensible d",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "env-generate",
+            "commands"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:command:commands.env-validate",
+        "name": "/mp:env-validate",
+        "path": "commands/env-validate.md",
+        "summary": "Validate the .env file configuration for the keycloak-alpha platform, checking for required variables, format validation",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "env-validate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:command:commands.health",
+        "name": "/mp:health",
+        "path": "commands/health.md",
+        "summary": "Check the health status of all services in the keycloak-alpha platform including service availability, response times, p",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "health",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:command:commands.keycloak-setup",
+        "name": "/mp:keycloak-setup",
+        "path": "commands/keycloak-setup.md",
+        "summary": "Initialize Keycloak realm and client configuration for the-lobbi/keycloak-alpha platform with proper OAuth settings, mul",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "keycloak-setup",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:command:commands.keycloak-theme",
+        "name": "/mp:keycloak-theme",
+        "path": "commands/keycloak-theme.md",
+        "summary": "Generate and deploy tenant-specific Keycloak themes with custom branding (colors, logos, CSS) for multi-tenant organizat",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "keycloak-theme",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:command:commands.keycloak-user",
+        "name": "/mp:keycloak-user",
+        "path": "commands/keycloak-user.md",
+        "summary": "Create Keycloak users for testing and development, supporting both single user creation with specific credentials and bu",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "keycloak-user",
+            "commands"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:command:commands.service",
+        "name": "/mp:service",
+        "path": "commands/service.md",
+        "summary": "Manage individual services in the keycloak-alpha platform using docker-compose, including start, stop, restart operation",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "service",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "docker"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:command:commands.test-gen",
+        "name": "/mp:test-gen",
+        "path": "commands/test-gen.md",
+        "summary": "Generate comprehensive Jest test files from Express.js API routes, including unit tests, integration tests, and end-to-e",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "test-gen",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "lobbi-platform-manager:agent:agents.env-manager",
+        "name": "env-manager",
+        "path": "agents/env-manager.md",
+        "summary": "Environment Manager Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "env-manager"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:agent:agents.keycloak-admin",
+        "name": "keycloak-admin",
+        "path": "agents/keycloak-admin.md",
+        "summary": "Keycloak Administration Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "keycloak-admin"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:agent:agents.service-orchestrator",
+        "name": "service-orchestrator",
+        "path": "agents/service-orchestrator.md",
+        "summary": "Service Orchestration Agent",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "service-orchestrator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:agent:agents.test-generator",
+        "name": "test-generator",
+        "path": "agents/test-generator.md",
+        "summary": "Test Generator Agent",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "test-generator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "lobbi-platform-manager:skill:skills.keycloak-admin.skill",
+        "name": "keycloak-admin",
+        "path": "skills/keycloak-admin/SKILL.md",
+        "summary": "Keycloak Admin Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "keycloak admin"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:skill:skills.mern-patterns.skill",
+        "name": "mern-patterns",
+        "path": "skills/mern-patterns/SKILL.md",
+        "summary": "MERN Stack Patterns Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "mern patterns"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:skill:skills.multi-tenant.skill",
+        "name": "multi-tenant",
+        "path": "skills/multi-tenant/SKILL.md",
+        "summary": "Multi-Tenant Architecture Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "multi tenant"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": [
+      {
+        "id": "lobbi-platform-manager:hook:hooks.scripts.check-health",
+        "name": "check-health.sh",
+        "path": "hooks/scripts/check-health.sh",
+        "summary": "Hook script check-health.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "check-health"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:hook:hooks.scripts.check-keycloak",
+        "name": "check-keycloak.sh",
+        "path": "hooks/scripts/check-keycloak.sh",
+        "summary": "Hook script check-keycloak.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "check-keycloak"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "lobbi-platform-manager:hook:hooks.scripts.check-security",
+        "name": "check-security.sh",
+        "path": "hooks/scripts/check-security.sh",
+        "summary": "Hook script check-security.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "check-security"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "lobbi-platform-manager:doc:readme",
+      "path": "README.md",
+      "summary": "Lobbi Platform Manager"
+    }
+  ]
+}

--- a/plugins/marketplace-pro/index.json
+++ b/plugins/marketplace-pro/index.json
@@ -1,0 +1,323 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "marketplace-pro",
+    "root": "plugins/marketplace-pro"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "marketplace-pro:command:commands.compose",
+        "name": "/mp:compose",
+        "path": "commands/compose.md",
+        "summary": "Plugin Composition Engine",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "compose",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.dev",
+        "name": "/mp:dev",
+        "path": "commands/dev.md",
+        "summary": "Plugin Dev Studio",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "dev",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.help",
+        "name": "/mp:help",
+        "path": "commands/help.md",
+        "summary": "Marketplace Pro Help",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "help",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.lock",
+        "name": "/mp:lock",
+        "path": "commands/lock.md",
+        "summary": "/mp:lock — Plugin Lockfile Management",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "lock",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.policy",
+        "name": "/mp:policy",
+        "path": "commands/policy.md",
+        "summary": "/mp:policy — Plugin Policy Enforcement",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "policy",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.quick",
+        "name": "/mp:quick",
+        "path": "commands/quick.md",
+        "summary": "Marketplace Pro Quick Commands",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "quick",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.recommend",
+        "name": "/mp:recommend",
+        "path": "commands/recommend.md",
+        "summary": "Plugin Recommendation Engine",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "recommend",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.registry",
+        "name": "/mp:registry",
+        "path": "commands/registry.md",
+        "summary": "/mp:registry — Federated Registry Management",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "registry",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.setup",
+        "name": "/mp:setup",
+        "path": "commands/setup.md",
+        "summary": "Marketplace Pro Setup Wizard",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "setup",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.status",
+        "name": "/mp:status",
+        "path": "commands/status.md",
+        "summary": "Marketplace Pro Status Dashboard",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "status",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.trust",
+        "name": "/mp:trust",
+        "path": "commands/trust.md",
+        "summary": "Plugin Trust Score & Security Audit",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "trust",
+            "commands"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:command:commands.verify",
+        "name": "/mp:verify",
+        "path": "commands/verify.md",
+        "summary": "Verify Plugin Bundle Signature",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "verify",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "marketplace-pro:agent:agents.marketplace-advisor",
+        "name": "marketplace-advisor",
+        "path": "agents/marketplace-advisor.md",
+        "summary": "Marketplace Advisor",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "marketplace-advisor"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "marketplace-pro:skill:skills.composition.skill",
+        "name": "composition",
+        "path": "skills/composition/SKILL.md",
+        "summary": "Intent-Based Composition Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "composition"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:skill:skills.devstudio.skill",
+        "name": "devstudio",
+        "path": "skills/devstudio/SKILL.md",
+        "summary": "Plugin Dev Studio Workflow",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "devstudio"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:skill:skills.federation.skill",
+        "name": "federation",
+        "path": "skills/federation/SKILL.md",
+        "summary": "Federated Registry Protocol",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "federation"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:skill:skills.intelligence.skill",
+        "name": "intelligence",
+        "path": "skills/intelligence/SKILL.md",
+        "summary": "Contextual Plugin Intelligence",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "intelligence"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "marketplace-pro:skill:skills.security.skill",
+        "name": "security",
+        "path": "skills/security/SKILL.md",
+        "summary": "Supply Chain Security & Trust Scoring",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "security"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": []
+  },
+  "keyDocs": [
+    {
+      "id": "marketplace-pro:doc:readme",
+      "path": "README.md",
+      "summary": "Marketplace Pro"
+    }
+  ]
+}

--- a/plugins/react-animation-studio/index.json
+++ b/plugins/react-animation-studio/index.json
@@ -1,0 +1,532 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "react-animation-studio",
+    "root": "plugins/react-animation-studio"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "react-animation-studio:command:commands.animate-3d",
+        "name": "/mp:animate-3d",
+        "path": "commands/animate-3d.md",
+        "summary": "/animate-3d Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-3d",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-audit",
+        "name": "/mp:animate-audit",
+        "path": "commands/animate-audit.md",
+        "summary": "/animate-audit",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "animate-audit",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-background",
+        "name": "/mp:animate-background",
+        "path": "commands/animate-background.md",
+        "summary": "/animate-background Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-background",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-component",
+        "name": "/mp:animate-component",
+        "path": "commands/animate-component.md",
+        "summary": "/animate-component",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-component",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-effects",
+        "name": "/mp:animate-effects",
+        "path": "commands/animate-effects.md",
+        "summary": "/animate-effects Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-effects",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-export",
+        "name": "/mp:animate-export",
+        "path": "commands/animate-export.md",
+        "summary": "/animate-export",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-export",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-preset",
+        "name": "/mp:animate-preset",
+        "path": "commands/animate-preset.md",
+        "summary": "/animate-preset",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-preset",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-scroll",
+        "name": "/mp:animate-scroll",
+        "path": "commands/animate-scroll.md",
+        "summary": "/animate-scroll",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-scroll",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-sequence",
+        "name": "/mp:animate-sequence",
+        "path": "commands/animate-sequence.md",
+        "summary": "/animate-sequence",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-sequence",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-text",
+        "name": "/mp:animate-text",
+        "path": "commands/animate-text.md",
+        "summary": "/animate-text Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-text",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate-transition",
+        "name": "/mp:animate-transition",
+        "path": "commands/animate-transition.md",
+        "summary": "/animate-transition",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate-transition",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:command:commands.animate",
+        "name": "/mp:animate",
+        "path": "commands/animate.md",
+        "summary": "/animate",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "animate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "react-animation-studio:agent:agents.animation-architect",
+        "name": "animation-architect",
+        "path": "agents/animation-architect.md",
+        "summary": "Animation Architect",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "animation-architect"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:agent:agents.creative-effects-artist",
+        "name": "creative-effects-artist",
+        "path": "agents/creative-effects-artist.md",
+        "summary": "Creative Effects Artist Agent",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "creative-effects-artist"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:agent:agents.interaction-specialist",
+        "name": "interaction-specialist",
+        "path": "agents/interaction-specialist.md",
+        "summary": "Interaction Specialist",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "interaction-specialist"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:agent:agents.motion-designer",
+        "name": "motion-designer",
+        "path": "agents/motion-designer.md",
+        "summary": "Motion Designer",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "motion-designer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:agent:agents.performance-optimizer",
+        "name": "performance-optimizer",
+        "path": "agents/performance-optimizer.md",
+        "summary": "Performance Optimizer",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "performance-optimizer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:agent:agents.transition-engineer",
+        "name": "transition-engineer",
+        "path": "agents/transition-engineer.md",
+        "summary": "Transition Engineer",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "transition-engineer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "react-animation-studio:skill:skills.3d-animations.skill",
+        "name": "3d-animations",
+        "path": "skills/3d-animations/SKILL.md",
+        "summary": "3D Animations Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "3d animations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.accent-animations.skill",
+        "name": "accent-animations",
+        "path": "skills/accent-animations/SKILL.md",
+        "summary": "Accent Animations Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "accent animations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.background-animations.skill",
+        "name": "background-animations",
+        "path": "skills/background-animations/SKILL.md",
+        "summary": "Background Animations Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "background animations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.creative-effects.skill",
+        "name": "creative-effects",
+        "path": "skills/creative-effects/SKILL.md",
+        "summary": "Creative Effects Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "creative effects"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.css-animations.skill",
+        "name": "css-animations",
+        "path": "skills/css-animations/SKILL.md",
+        "summary": "CSS Animations Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "css animations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.framer-motion.skill",
+        "name": "framer-motion",
+        "path": "skills/framer-motion/SKILL.md",
+        "summary": "Framer Motion Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "framer motion"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.gsap.skill",
+        "name": "gsap",
+        "path": "skills/gsap/SKILL.md",
+        "summary": "GSAP Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "gsap"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.scroll-animations.skill",
+        "name": "scroll-animations",
+        "path": "skills/scroll-animations/SKILL.md",
+        "summary": "Scroll Animations Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "scroll animations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.spring-physics.skill",
+        "name": "spring-physics",
+        "path": "skills/spring-physics/SKILL.md",
+        "summary": "Spring Physics Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "spring physics"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.svg-animations.skill",
+        "name": "svg-animations",
+        "path": "skills/svg-animations/SKILL.md",
+        "summary": "SVG Animations Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "svg animations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:skill:skills.text-animations.skill",
+        "name": "text-animations",
+        "path": "skills/text-animations/SKILL.md",
+        "summary": "Text Animations Skill",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "text animations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": [
+      {
+        "id": "react-animation-studio:hook:hooks.scripts.animation-lint",
+        "name": "animation-lint.sh",
+        "path": "hooks/scripts/animation-lint.sh",
+        "summary": "Hook script animation-lint.sh",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "animation-lint"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "react-animation-studio:hook:hooks.scripts.performance-check",
+        "name": "performance-check.sh",
+        "path": "hooks/scripts/performance-check.sh",
+        "summary": "Hook script performance-check.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "performance-check"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "react-animation-studio:doc:readme",
+      "path": "README.md",
+      "summary": "React Animation Studio"
+    }
+  ]
+}

--- a/plugins/team-accelerator/index.json
+++ b/plugins/team-accelerator/index.json
@@ -1,0 +1,384 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "team-accelerator",
+    "root": "plugins/team-accelerator"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "team-accelerator:command:commands.deploy",
+        "name": "/mp:deploy",
+        "path": "commands/deploy.md",
+        "summary": "Deploy Command",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:command:commands.docs",
+        "name": "/mp:docs",
+        "path": "commands/docs.md",
+        "summary": "Docs Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "docs",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:command:commands.integrate",
+        "name": "/mp:integrate",
+        "path": "commands/integrate.md",
+        "summary": "Integrate Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "integrate",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:command:commands.perf",
+        "name": "/mp:perf",
+        "path": "commands/perf.md",
+        "summary": "Perf Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "perf",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:command:commands.quality",
+        "name": "/mp:quality",
+        "path": "commands/quality.md",
+        "summary": "Quality Command",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "quality",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:command:commands.status",
+        "name": "/mp:status",
+        "path": "commands/status.md",
+        "summary": "Status Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "status",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:command:commands.test",
+        "name": "/mp:test",
+        "path": "commands/test.md",
+        "summary": "Test Command",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "test",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:command:commands.workflow",
+        "name": "/mp:workflow",
+        "path": "commands/workflow.md",
+        "summary": "Workflow Command",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "workflow",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "team-accelerator:agent:agents.code-reviewer",
+        "name": "code-reviewer",
+        "path": "agents/code-reviewer.md",
+        "summary": "Code Reviewer",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "code-reviewer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:agent:agents.devops-engineer",
+        "name": "devops-engineer",
+        "path": "agents/devops-engineer.md",
+        "summary": "DevOps Engineer",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "devops-engineer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:agent:agents.documentation-writer",
+        "name": "documentation-writer",
+        "path": "agents/documentation-writer.md",
+        "summary": "Documentation Writer",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "documentation-writer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:agent:agents.integration-specialist",
+        "name": "integration-specialist",
+        "path": "agents/integration-specialist.md",
+        "summary": "Integration Specialist",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "integration-specialist"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:agent:agents.performance-engineer",
+        "name": "performance-engineer",
+        "path": "agents/performance-engineer.md",
+        "summary": "Performance Engineer",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "performance-engineer"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:agent:agents.workflow-automator",
+        "name": "workflow-automator",
+        "path": "agents/workflow-automator.md",
+        "summary": "Workflow Automator",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "workflow-automator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "team-accelerator:skill:skills.code-quality.skill",
+        "name": "code-quality",
+        "path": "skills/code-quality/SKILL.md",
+        "summary": "Code Quality Skill",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "code quality"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:skill:skills.devops-practices.skill",
+        "name": "devops-practices",
+        "path": "skills/devops-practices/SKILL.md",
+        "summary": "DevOps Practices Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "devops practices"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:skill:skills.integration-patterns.skill",
+        "name": "integration-patterns",
+        "path": "skills/integration-patterns/SKILL.md",
+        "summary": "Integration Patterns Skill",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "integration patterns"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:skill:skills.workflow-automation.skill",
+        "name": "workflow-automation",
+        "path": "skills/workflow-automation/SKILL.md",
+        "summary": "Workflow Automation Skill",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "workflow automation"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "hooks": [
+      {
+        "id": "team-accelerator:hook:hooks.scripts.analyze-tests",
+        "name": "analyze-tests.sh",
+        "path": "hooks/scripts/analyze-tests.sh",
+        "summary": "Hook script analyze-tests.sh",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "analyze-tests"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:hook:hooks.scripts.docs-sync",
+        "name": "docs-sync.sh",
+        "path": "hooks/scripts/docs-sync.sh",
+        "summary": "Hook script docs-sync.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "docs-sync"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:hook:hooks.scripts.notify-deploy",
+        "name": "notify-deploy.sh",
+        "path": "hooks/scripts/notify-deploy.sh",
+        "summary": "Hook script notify-deploy.sh",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "notify-deploy"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "team-accelerator:hook:hooks.scripts.validate-code",
+        "name": "validate-code.sh",
+        "path": "hooks/scripts/validate-code.sh",
+        "summary": "Hook script validate-code.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "validate-code"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "team-accelerator:doc:readme",
+      "path": "README.md",
+      "summary": "Team Accelerator"
+    }
+  ]
+}

--- a/plugins/tvs-microsoft-deploy/index.json
+++ b/plugins/tvs-microsoft-deploy/index.json
@@ -1,0 +1,914 @@
+{
+  "schemaVersion": 1,
+  "plugin": {
+    "id": "tvs-microsoft-deploy",
+    "root": "plugins/tvs-microsoft-deploy"
+  },
+  "capabilities": {
+    "commands": [
+      {
+        "id": "tvs-microsoft-deploy:command:commands.browser-fallback",
+        "name": "/mp:browser-fallback",
+        "path": "commands/browser-fallback.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "browser-fallback",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.cost-report",
+        "name": "/mp:cost-report",
+        "path": "commands/cost-report.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "cost-report",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.deploy-all",
+        "name": "/mp:deploy-all",
+        "path": "commands/deploy-all.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy-all",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.deploy-azure",
+        "name": "/mp:deploy-azure",
+        "path": "commands/deploy-azure.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy-azure",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.deploy-dataverse",
+        "name": "/mp:deploy-dataverse",
+        "path": "commands/deploy-dataverse.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy-dataverse",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.deploy-fabric",
+        "name": "/mp:deploy-fabric",
+        "path": "commands/deploy-fabric.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy-fabric",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.deploy-identity",
+        "name": "/mp:deploy-identity",
+        "path": "commands/deploy-identity.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy-identity",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.deploy-portal",
+        "name": "/mp:deploy-portal",
+        "path": "commands/deploy-portal.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy-portal",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.deploy-teams",
+        "name": "/mp:deploy-teams",
+        "path": "commands/deploy-teams.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "deploy-teams",
+            "commands"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.extract-a3",
+        "name": "/mp:extract-a3",
+        "path": "commands/extract-a3.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "extract-a3",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.health",
+        "name": "/mp:health",
+        "path": "commands/health.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "health",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.identity-attestation",
+        "name": "/mp:identity-attestation",
+        "path": "commands/identity-attestation.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "testing",
+          "triggerTerms": [
+            "identity-attestation",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.identity-drift",
+        "name": "/mp:identity-drift",
+        "path": "commands/identity-drift.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "identity-drift",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.normalize-carriers",
+        "name": "/mp:normalize-carriers",
+        "path": "commands/normalize-carriers.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "normalize-carriers",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.orchestrate-planner",
+        "name": "/mp:orchestrate-planner",
+        "path": "commands/orchestrate-planner.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "orchestrate-planner",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.quick-start",
+        "name": "/mp:quick-start",
+        "path": "commands/quick-start.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "frontend",
+          "triggerTerms": [
+            "quick-start",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.status-check",
+        "name": "/mp:status-check",
+        "path": "commands/status-check.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "status-check",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:command:commands.taia-readiness",
+        "name": "/mp:taia-readiness",
+        "path": "commands/taia-readiness.md",
+        "summary": "> Docs Hub: [CLI Hub](../docs/cli/README.md#command-index)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "taia-readiness",
+            "commands"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "agents": [
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.analytics-agent",
+        "name": "analytics-agent",
+        "path": "agents/analytics-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "analytics-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.azure-agent",
+        "name": "azure-agent",
+        "path": "agents/azure-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "azure-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.browser-fallback-agent",
+        "name": "browser-fallback-agent",
+        "path": "agents/browser-fallback-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "browser-fallback-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.carrier-normalization-agent",
+        "name": "carrier-normalization-agent",
+        "path": "agents/carrier-normalization-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "carrier-normalization-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.client-solution-architect-agent",
+        "name": "client-solution-architect-agent",
+        "path": "agents/client-solution-architect-agent.md",
+        "summary": "Client Solution Architect Agent (NORTHSTAR)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "client-solution-architect-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.comms-agent",
+        "name": "comms-agent",
+        "path": "agents/comms-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "comms-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.consulting-crm-agent",
+        "name": "consulting-crm-agent",
+        "path": "agents/consulting-crm-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "consulting-crm-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.data-agent",
+        "name": "data-agent",
+        "path": "agents/data-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "data",
+          "triggerTerms": [
+            "data-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.embedded-analytics-agent",
+        "name": "embedded-analytics-agent",
+        "path": "agents/embedded-analytics-agent.md",
+        "summary": "Embedded Analytics Agent (BEACON)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "embedded-analytics-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.excel-automation-agent",
+        "name": "excel-automation-agent",
+        "path": "agents/excel-automation-agent.md",
+        "summary": "Excel Automation Agent (GRIDLINE)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "excel-automation-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.fabric-pipeline-agent",
+        "name": "fabric-pipeline-agent",
+        "path": "agents/fabric-pipeline-agent.md",
+        "summary": "Fabric Pipeline Agent (FLOWGRID)",
+        "tags": {
+          "domain": "deployment",
+          "triggerTerms": [
+            "fabric-pipeline-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.github-agent",
+        "name": "github-agent",
+        "path": "agents/github-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "github-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.identity-agent",
+        "name": "identity-agent",
+        "path": "agents/identity-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "identity-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.ingest-agent",
+        "name": "ingest-agent",
+        "path": "agents/ingest-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "ingest-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.m365-governance-agent",
+        "name": "m365-governance-agent",
+        "path": "agents/m365-governance-agent.md",
+        "summary": "M365 Governance Agent (SENTINEL)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "m365-governance-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.michelle-scripts-agent",
+        "name": "michelle-scripts-agent",
+        "path": "agents/michelle-scripts-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "michelle-scripts-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.planner-orchestrator-agent",
+        "name": "planner-orchestrator-agent",
+        "path": "agents/planner-orchestrator-agent.md",
+        "summary": "Planner Orchestrator Agent (CONDUCTOR)",
+        "tags": {
+          "domain": "automation",
+          "triggerTerms": [
+            "planner-orchestrator-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.platform-agent",
+        "name": "platform-agent",
+        "path": "agents/platform-agent.md",
+        "summary": "> Docs Hub: [Architecture Hub](../docs/architecture/README.md#agent-topology)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "platform-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:agent:agents.power-pages-agent",
+        "name": "power-pages-agent",
+        "path": "agents/power-pages-agent.md",
+        "summary": "Power Pages Agent (PORTALSMITH)",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "power-pages-agent"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "markdown"
+          ]
+        }
+      }
+    ],
+    "skills": [],
+    "hooks": [
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.audit-azure-provisioning",
+        "name": "audit-azure-provisioning.sh",
+        "path": "hooks/audit-azure-provisioning.sh",
+        "summary": "Hook script audit-azure-provisioning.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "audit-azure-provisioning"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.audit-dataverse-changes",
+        "name": "audit-dataverse-changes.sh",
+        "path": "hooks/audit-dataverse-changes.sh",
+        "summary": "Hook script audit-dataverse-changes.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "audit-dataverse-changes"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.audit-fabric-operations",
+        "name": "audit-fabric-operations.sh",
+        "path": "hooks/audit-fabric-operations.sh",
+        "summary": "Hook script audit-fabric-operations.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "audit-fabric-operations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.audit-graph-api-calls",
+        "name": "audit-graph-api-calls.sh",
+        "path": "hooks/audit-graph-api-calls.sh",
+        "summary": "Hook script audit-graph-api-calls.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "audit-graph-api-calls"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.audit-metadata-check",
+        "name": "audit-metadata-check.sh",
+        "path": "hooks/audit-metadata-check.sh",
+        "summary": "Hook script audit-metadata-check.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "audit-metadata-check"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.audit-pac-operations",
+        "name": "audit-pac-operations.sh",
+        "path": "hooks/audit-pac-operations.sh",
+        "summary": "Hook script audit-pac-operations.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "audit-pac-operations"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.hipaa-config-guard",
+        "name": "hipaa-config-guard.sh",
+        "path": "hooks/hipaa-config-guard.sh",
+        "summary": "Hook script hipaa-config-guard.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "hipaa-config-guard"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.identity-policy-engine",
+        "name": "identity-policy-engine.sh",
+        "path": "hooks/identity-policy-engine.sh",
+        "summary": "Hook script identity-policy-engine.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "identity-policy-engine"
+          ],
+          "riskLevel": "medium",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.keyvault-secrets-enforcer",
+        "name": "keyvault-secrets-enforcer.sh",
+        "path": "hooks/keyvault-secrets-enforcer.sh",
+        "summary": "Hook script keyvault-secrets-enforcer.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "keyvault-secrets-enforcer"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.pac-auth-check",
+        "name": "pac-auth-check.sh",
+        "path": "hooks/pac-auth-check.sh",
+        "summary": "Hook script pac-auth-check.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "pac-auth-check"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.scope-permission-misuse-check",
+        "name": "scope-permission-misuse-check.sh",
+        "path": "hooks/scope-permission-misuse-check.sh",
+        "summary": "Hook script scope-permission-misuse-check.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "scope-permission-misuse-check"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.stripe-webhook-security",
+        "name": "stripe-webhook-security.sh",
+        "path": "hooks/stripe-webhook-security.sh",
+        "summary": "Hook script stripe-webhook-security.sh",
+        "tags": {
+          "domain": "security",
+          "triggerTerms": [
+            "stripe-webhook-security"
+          ],
+          "riskLevel": "high",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.taia-winddown-guard",
+        "name": "taia-winddown-guard.sh",
+        "path": "hooks/taia-winddown-guard.sh",
+        "summary": "Hook script taia-winddown-guard.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "taia-winddown-guard"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.tenant-drift-check",
+        "name": "tenant-drift-check.sh",
+        "path": "hooks/tenant-drift-check.sh",
+        "summary": "Hook script tenant-drift-check.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "tenant-drift-check"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.tenant-isolation-validator",
+        "name": "tenant-isolation-validator.sh",
+        "path": "hooks/tenant-isolation-validator.sh",
+        "summary": "Hook script tenant-isolation-validator.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "tenant-isolation-validator"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      },
+      {
+        "id": "tvs-microsoft-deploy:hook:hooks.unsafe-destructive-call-check",
+        "name": "unsafe-destructive-call-check.sh",
+        "path": "hooks/unsafe-destructive-call-check.sh",
+        "summary": "Hook script unsafe-destructive-call-check.sh",
+        "tags": {
+          "domain": "general",
+          "triggerTerms": [
+            "unsafe-destructive-call-check"
+          ],
+          "riskLevel": "low",
+          "expectedTools": [
+            "bash"
+          ]
+        }
+      }
+    ]
+  },
+  "keyDocs": [
+    {
+      "id": "tvs-microsoft-deploy:doc:docs.readme",
+      "path": "docs/README.md",
+      "summary": "TVS Microsoft Deploy Documentation Hub"
+    },
+    {
+      "id": "tvs-microsoft-deploy:doc:docs.apis.readme",
+      "path": "docs/apis/README.md",
+      "summary": "API Guides"
+    },
+    {
+      "id": "tvs-microsoft-deploy:doc:docs.architecture.readme",
+      "path": "docs/architecture/README.md",
+      "summary": "Architecture Hub"
+    },
+    {
+      "id": "tvs-microsoft-deploy:doc:docs.cli.readme",
+      "path": "docs/cli/README.md",
+      "summary": "CLI Hub"
+    },
+    {
+      "id": "tvs-microsoft-deploy:doc:docs.sales.embedded-analytics-playbook",
+      "path": "docs/sales/embedded-analytics-playbook.md",
+      "summary": "Embedded Analytics Playbook"
+    },
+    {
+      "id": "tvs-microsoft-deploy:doc:docs.skills.readme",
+      "path": "docs/skills/README.md",
+      "summary": "Skills Hub"
+    }
+  ]
+}

--- a/scripts/generate-plugin-indexes.mjs
+++ b/scripts/generate-plugin-indexes.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+
+const repoRoot = process.cwd();
+const pluginsRoot = path.join(repoRoot, 'plugins');
+const checkMode = process.argv.includes('--check');
+
+function walk(dir, predicate = () => true) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full, predicate));
+    else if (entry.isFile() && predicate(full)) out.push(full);
+  }
+  return out;
+}
+
+function readSummary(filePath) {
+  const text = fs.readFileSync(filePath, 'utf-8');
+  const lines = text.split(/\r?\n/);
+  let i = 0;
+  if (lines[0]?.trim() === '---') {
+    i = 1;
+    while (i < lines.length && lines[i].trim() !== '---') i++;
+    i++;
+  }
+  for (; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    if (line.startsWith('#')) return line.replace(/^#+\s*/, '').slice(0, 120);
+    return line.replace(/^[-*]\s*/, '').slice(0, 120);
+  }
+  return 'No summary available';
+}
+
+function inferDomain(name, relPath) {
+  const s = `${name} ${relPath}`.toLowerCase();
+  if (/(security|trust|policy|verify|compliance|audit)/.test(s)) return 'security';
+  if (/(deploy|release|pipeline|helm|eks|iac|infra)/.test(s)) return 'deployment';
+  if (/(test|harness|qa|quality)/.test(s)) return 'testing';
+  if (/(data|database|sql|db)/.test(s)) return 'data';
+  if (/(ui|frontend|design|react|animation)/.test(s)) return 'frontend';
+  if (/(automation|workflow|orchestrator|command)/.test(s)) return 'automation';
+  return 'general';
+}
+
+function inferRisk(name, summary) {
+  const s = `${name} ${summary}`.toLowerCase();
+  if (/(delete|destroy|production|security|credential|secret|rollback)/.test(s)) return 'high';
+  if (/(deploy|migrate|configure|policy|registry)/.test(s)) return 'medium';
+  return 'low';
+}
+
+function inferTools(text) {
+  const s = text.toLowerCase();
+  const tools = [];
+  const patterns = [
+    ['bash', /(bash|shell|sh\b|terminal)/],
+    ['git', /\bgit\b/],
+    ['node', /(node|npm|pnpm|yarn)/],
+    ['docker', /docker/],
+    ['kubernetes', /(kubernetes|kubectl|helm|eks)/],
+    ['terraform', /terraform/],
+    ['python', /python/],
+    ['database', /(sql|postgres|database|redis)/],
+  ];
+  for (const [name, re] of patterns) if (re.test(s)) tools.push(name);
+  return tools.length ? tools : ['markdown'];
+}
+
+function mkId(plugin, type, relPath) {
+  const stem = relPath.replace(/\\/g, '/').replace(/\.[^.]+$/, '').replace(/\//g, '.').toLowerCase();
+  return `${plugin}:${type}:${stem}`;
+}
+
+function buildEntries(pluginName, pluginRoot, type) {
+  const rel = (p) => path.relative(pluginRoot, p).replace(/\\/g, '/');
+  if (type === 'commands') {
+    return walk(path.join(pluginRoot, 'commands'), (p) => p.endsWith('.md')).map((p) => {
+      const rp = rel(p);
+      const name = `/mp:${path.basename(p, '.md')}`;
+      const summary = readSummary(p);
+      return {
+        id: mkId(pluginName, 'command', rp),
+        name,
+        path: rp,
+        summary,
+        tags: {
+          domain: inferDomain(name, rp),
+          triggerTerms: [path.basename(p, '.md').toLowerCase(), path.basename(path.dirname(p)).toLowerCase()].filter(Boolean),
+          riskLevel: inferRisk(name, summary),
+          expectedTools: inferTools(`${name} ${summary} ${rp}`),
+        },
+      };
+    });
+  }
+  if (type === 'agents') {
+    return walk(path.join(pluginRoot, 'agents'), (p) => p.endsWith('.md')).map((p) => {
+      const rp = rel(p);
+      const name = path.basename(p, '.md');
+      const summary = readSummary(p);
+      return {
+        id: mkId(pluginName, 'agent', rp), name, path: rp, summary,
+        tags: {
+          domain: inferDomain(name, rp),
+          triggerTerms: [name.toLowerCase()],
+          riskLevel: inferRisk(name, summary),
+          expectedTools: inferTools(`${summary} ${rp}`),
+        },
+      };
+    });
+  }
+  if (type === 'skills') {
+    const skillsRoot = path.join(pluginRoot, 'skills');
+    if (!fs.existsSync(skillsRoot)) return [];
+    return fs.readdirSync(skillsRoot, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => path.join(skillsRoot, d.name, 'SKILL.md'))
+      .filter((p) => fs.existsSync(p))
+      .map((p) => {
+        const rp = rel(p);
+        const name = path.basename(path.dirname(p));
+        const summary = readSummary(p);
+        return {
+          id: mkId(pluginName, 'skill', rp), name, path: rp, summary,
+          tags: {
+            domain: inferDomain(name, rp),
+            triggerTerms: [name.toLowerCase().replace(/-/g, ' ')],
+            riskLevel: inferRisk(name, summary),
+            expectedTools: inferTools(`${summary} ${rp}`),
+          },
+        };
+      });
+  }
+  if (type === 'hooks') {
+    return walk(path.join(pluginRoot, 'hooks'), (p) => /\.(sh|bash|ps1|js|ts)$/.test(p)).map((p) => {
+      const rp = rel(p);
+      const name = path.basename(p);
+      return {
+        id: mkId(pluginName, 'hook', rp),
+        name,
+        path: rp,
+        summary: `Hook script ${name}`,
+        tags: {
+          domain: inferDomain(name, rp),
+          triggerTerms: [name.replace(/\.[^.]+$/, '').toLowerCase()],
+          riskLevel: inferRisk(name, rp),
+          expectedTools: inferTools(rp),
+        },
+      };
+    });
+  }
+  return [];
+}
+
+function buildKeyDocs(pluginName, pluginRoot) {
+  const rel = (p) => path.relative(pluginRoot, p).replace(/\\/g, '/');
+  const docs = [];
+  for (const name of ['README.md', 'CLAUDE.md']) {
+    const p = path.join(pluginRoot, name);
+    if (fs.existsSync(p)) {
+      docs.push({ id: mkId(pluginName, 'doc', rel(p)), path: rel(p), summary: readSummary(p) });
+    }
+  }
+  for (const p of walk(path.join(pluginRoot, 'docs'), (f) => f.endsWith('.md')).slice(0, 10)) {
+    docs.push({ id: mkId(pluginName, 'doc', rel(p)), path: rel(p), summary: readSummary(p) });
+  }
+  return docs;
+}
+
+function buildIndex(pluginDirName) {
+  const pluginRoot = path.join(pluginsRoot, pluginDirName);
+  const index = {
+    schemaVersion: 1,
+    plugin: {
+      id: pluginDirName,
+      root: `plugins/${pluginDirName}`,
+    },
+    capabilities: {
+      commands: buildEntries(pluginDirName, pluginRoot, 'commands'),
+      agents: buildEntries(pluginDirName, pluginRoot, 'agents'),
+      skills: buildEntries(pluginDirName, pluginRoot, 'skills'),
+      hooks: buildEntries(pluginDirName, pluginRoot, 'hooks'),
+    },
+    keyDocs: buildKeyDocs(pluginDirName, pluginRoot),
+  };
+  return index;
+}
+
+function stableJson(value) {
+  return JSON.stringify(value, null, 2) + '\n';
+}
+
+let changed = 0;
+for (const entry of fs.readdirSync(pluginsRoot, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const pluginName = entry.name;
+  const pluginRoot = path.join(pluginsRoot, pluginName);
+  const outPath = path.join(pluginRoot, 'index.json');
+  const generated = stableJson(buildIndex(pluginName));
+  const existing = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf-8') : null;
+
+  if (existing !== generated) {
+    changed++;
+    if (!checkMode) fs.writeFileSync(outPath, generated, 'utf-8');
+    console.log(`${checkMode ? 'OUTDATED' : 'UPDATED'} ${path.relative(repoRoot, outPath)}`);
+  }
+}
+
+if (checkMode && changed > 0) {
+  console.error(`\n${changed} plugin index file(s) are out of date. Run: node scripts/generate-plugin-indexes.mjs`);
+  process.exit(1);
+}
+
+console.log(`Done. ${changed === 0 ? 'All plugin index files are current.' : `Changed: ${changed}`}`);

--- a/scripts/validate-plugin-indexes.mjs
+++ b/scripts/validate-plugin-indexes.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+
+const root = process.cwd();
+const pluginsRoot = path.join(root, 'plugins');
+
+function walk(dir, pred) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(p, pred));
+    else if (e.isFile() && pred(p)) out.push(p);
+  }
+  return out;
+}
+
+function rel(base, p) {
+  return path.relative(base, p).replace(/\\/g, '/');
+}
+
+let errors = 0;
+for (const entry of fs.readdirSync(pluginsRoot, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const pluginRoot = path.join(pluginsRoot, entry.name);
+  const indexPath = path.join(pluginRoot, 'index.json');
+
+  if (!fs.existsSync(indexPath)) {
+    console.error(`ERROR [${entry.name}] Missing index.json`);
+    errors++;
+    continue;
+  }
+
+  let idx;
+  try {
+    idx = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+  } catch (e) {
+    console.error(`ERROR [${entry.name}] Invalid index.json: ${e.message}`);
+    errors++;
+    continue;
+  }
+
+  const checks = [
+    ['commands', walk(path.join(pluginRoot, 'commands'), (p) => p.endsWith('.md'))],
+    ['agents', walk(path.join(pluginRoot, 'agents'), (p) => p.endsWith('.md'))],
+    ['skills', fs.existsSync(path.join(pluginRoot, 'skills'))
+      ? fs.readdirSync(path.join(pluginRoot, 'skills'), { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => path.join(pluginRoot, 'skills', d.name, 'SKILL.md'))
+        .filter((p) => fs.existsSync(p))
+      : []],
+  ];
+
+  for (const [kind, files] of checks) {
+    const expected = new Set(files.map((p) => rel(pluginRoot, p)));
+    const listed = new Set(((idx.capabilities?.[kind]) || []).map((x) => x.path));
+
+    for (const p of expected) {
+      if (!listed.has(p)) {
+        console.error(`ERROR [${entry.name}] Missing ${kind} entry for ${p}`);
+        errors++;
+      }
+    }
+    for (const p of listed) {
+      if (!expected.has(p)) {
+        console.error(`ERROR [${entry.name}] Stale ${kind} entry for ${p}`);
+        errors++;
+      }
+      if (!fs.existsSync(path.join(pluginRoot, p))) {
+        console.error(`ERROR [${entry.name}] Path does not exist: ${p}`);
+        errors++;
+      }
+    }
+  }
+}
+
+if (errors > 0) {
+  console.error(`\nValidation failed with ${errors} error(s).`);
+  process.exit(1);
+}
+
+console.log('All plugin indexes are complete and valid.');


### PR DESCRIPTION
### Motivation
- Replace expensive ad-hoc markdown tree scans with a small machine-readable plugin index per plugin that lists commands, agents, skills, hooks and key docs. 
- Provide stable identifiers and simple tags (domain, trigger terms, risk level, expected tools) so capabilities can be discovered and routed deterministically. 
- Prevent drift by providing a generator to produce/upkeep indexes and a CI gate to enforce completeness and path integrity. 

### Description
- Add per-plugin `index.json` files under `plugins/*/index.json` containing `schemaVersion`, `plugin`, `capabilities` (commands/agents/skills/hooks) and `keyDocs` with stable `id`, `path`, `summary`, and `tags` fields. 
- Add generator `scripts/generate-plugin-indexes.mjs` which builds deterministic indexes (supports `--check` mode) and a validator `scripts/validate-plugin-indexes.mjs` that verifies index completeness and that indexed paths exist. 
- Update the marketplace devstudio loader to consult `plugins/*/index.json` first via `readResourcesFromIndex()` in `plugins/marketplace-pro/src/devstudio/server.ts`, with a fallback to legacy markdown scanning for backward compatibility. 
- Add npm scripts (`plugin:index:generate`, `plugin:index:check`) and a GitHub Actions workflow `.github/workflows/plugin-index-check.yml` to run index generation/validation on plugin-related changes. 

### Testing
- Ran the generator: `node scripts/generate-plugin-indexes.mjs` which updated/created `plugins/*/index.json` files (reported as `UPDATED`). — success. 
- Ran the CI check: `npm run plugin:index:check` (which runs generator in `--check` and validator) and it completed with "All plugin index files are current." and "All plugin indexes are complete and valid." — success. 
- Ran type-check: `npm run type-check` which failed due to existing TypeScript syntax errors in `src/hooks/useNodeTypes.test.ts` that are unrelated to this change. — failure (pre-existing, not caused by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ddca6aaa8832a9c759e67c9b33610)