### PR TITLE
Enforce dependency hygiene and deterministic plugin installs

### DIFF
--- a/.github/workflows/no-tracked-node-modules.yml
+++ b/.github/workflows/no-tracked-node-modules.yml
@@ -1,4 +1,4 @@
-name: Prevent tracked node_modules
+name: Prevent tracked dependencies and build artifacts
 
 on:
   pull_request:
@@ -8,18 +8,11 @@ on:
       - master
 
 jobs:
-  check-node-modules:
+  dependency-hygiene:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Fail if node_modules is tracked
-        run: |
-          set -euo pipefail
-          tracked=$(git ls-files 'plugins/claude-code-templating-plugin/node_modules/**')
-          if [ -n "$tracked" ]; then
-            echo "Tracked node_modules files detected:"
-            echo "$tracked"
-            exit 1
-          fi
+      - name: Fail if dependency folders or build artifacts are tracked
+        run: scripts/check-no-tracked-deps.sh

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,13 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-lock.yaml
 
+# Nested dependencies and generated artifacts (plugin-safe)
+**/node_modules/
+**/.pnpm/
+**/.yarn/
+**/dist/
+**/build/
+
 # IDE
 .vscode/
 .idea/

--- a/plugins/claude-code-templating-plugin/README.md
+++ b/plugins/claude-code-templating-plugin/README.md
@@ -38,6 +38,12 @@ npm install
 git add package-lock.json
 ```
 
+### Dependency + lockfile policy
+
+- `npm ci` is required for CI and recommended for all fresh local installs.
+- Treat `package-lock.json` as mandatory and commit lockfile changes with dependency updates.
+- Do not commit `node_modules/`, `dist/`, or `build/`; if a packaged bundle is required, attach it as a release artifact.
+
 ## Configuration
 
 ### Environment Variables

--- a/plugins/jira-orchestrator/README.md
+++ b/plugins/jira-orchestrator/README.md
@@ -19,12 +19,23 @@
 ## Quick Start
 
 ```bash
-# Install (sets up hooks automatically)
+cd plugins/jira-orchestrator
+
+# Deterministic install from package-lock.json
+npm ci
+
+# Install plugin wiring (sets up hooks automatically)
 bash scripts/install.sh
 
 # Verify
 claude /jira:setup
 ```
+
+### Dependency + lockfile policy
+
+- Commit `package-lock.json` and use `npm ci` for local development and CI.
+- Use `npm install` only when intentionally changing dependencies, then commit the updated lockfile in the same PR.
+- Never commit `node_modules/`, `dist/`, or `build/` directories; publish generated bundles as release artifacts instead.
 
 ---
 

--- a/scripts/check-no-tracked-deps.sh
+++ b/scripts/check-no-tracked-deps.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+patterns=(
+  '**/node_modules/**'
+  '**/.pnpm/**'
+  '**/.yarn/**'
+)
+
+artifact_patterns=(
+  '**/dist/**'
+  '**/build/**'
+)
+
+tracked_deps=""
+for pattern in "${patterns[@]}"; do
+  matches=$(git ls-files "$pattern")
+  if [ -n "$matches" ]; then
+    tracked_deps+=$'\n'
+    tracked_deps+="$matches"
+  fi
+done
+
+if [ -n "$tracked_deps" ]; then
+  echo "❌ Tracked dependency directories detected. Remove them from git and rely on lockfiles + npm ci:" >&2
+  echo "$tracked_deps" | sed '/^$/d' >&2
+  exit 1
+fi
+
+tracked_artifacts=""
+for pattern in "${artifact_patterns[@]}"; do
+  matches=$(git ls-files "$pattern")
+  if [ -n "$matches" ]; then
+    tracked_artifacts+=$'\n'
+    tracked_artifacts+="$matches"
+  fi
+done
+
+if [ -n "$tracked_artifacts" ]; then
+  echo "⚠️ Tracked build artifacts detected (dist/build). Prefer release artifacts instead of committing generated output:" >&2
+  echo "$tracked_artifacts" | sed '/^$/d' >&2
+  exit 1
+fi
+
+echo "✅ No tracked dependency directories or generated build artifacts detected."


### PR DESCRIPTION
### Motivation

- Prevent checked-in dependency trees and generated bundles from inflating repo size and causing inconsistent builds across environments.
- Ensure nested dependency folders and build outputs in plugin subtrees are consistently ignored and not accidentally committed.
- Provide a clear, deterministic install and lockfile policy for plugin maintainers to ensure reproducible installs.
- Fail CI early on PRs that track dependency folders or generated artifacts so fixes happen before merge.

### Description

- Remove committed dependency directories from plugin trees by cleaning `node_modules/` under `plugins/jira-orchestrator` and `plugins/claude-code-templating-plugin` and stop tracking generated bundles. 
- Add nested ignore patterns to `.gitignore` for `**/node_modules/`, `**/.pnpm/`, `**/.yarn/`, `**/dist/`, and `**/build/` to cover plugin subtrees. 
- Add a reusable check script `scripts/check-no-tracked-deps.sh` that fails when dependency folders or `dist`/`build` artifacts are tracked. 
- Add a GitHub Actions workflow `/.github/workflows/no-tracked-node-modules.yml` to run the check on `push` and `pull_request`. 
- Update plugin READMEs (`plugins/jira-orchestrator/README.md` and `plugins/claude-code-templating-plugin/README.md`) to document deterministic install instructions (`npm ci`), lockfile policy, and guidance to publish bundled output as release artifacts instead of committing generated files.

### Testing

- Ran `scripts/check-no-tracked-deps.sh` locally and it exited successfully with no tracked dependency directories detected. 
- Verified there are zero tracked files under the previous plugin `node_modules` paths via `git ls-files 'plugins/jira-orchestrator/node_modules/**' 'plugins/claude-code-templating-plugin/node_modules/**'` which returned `0` entries. 
- Confirmed the workflow `/.github/workflows/no-tracked-node-modules.yml` invokes the check script so CI will fail PRs that introduce tracked dependency folders or build artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ddca3b7b4832aae40bcfb25b63b04)