### PR TITLE
Require plugin CLAUDE.md runbooks and add missing guides

### DIFF
--- a/plugins/ahling-command-center/CLAUDE.md
+++ b/plugins/ahling-command-center/CLAUDE.md
@@ -1,0 +1,43 @@
+# Ahling Command Center Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/ahling-command-center`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `acc-agent` (see `commands/acc-agent.md`)
+- `acc-compose` (see `commands/acc-compose.md`)
+- `acc-config` (see `commands/acc-config.md`)
+- `acc-deploy` (see `commands/acc-deploy.md`)
+- `acc-ha` (see `commands/acc-ha.md`)
+- `acc-init` (see `commands/acc-init.md`)
+- `acc-knowledge` (see `commands/acc-knowledge.md`)
+- `acc-logs` (see `commands/acc-logs.md`)
+- `acc-ollama` (see `commands/acc-ollama.md`)
+- `acc-orchestrate` (see `commands/acc-orchestrate.md`)
+- `acc-repo` (see `commands/acc-repo.md`)
+- `acc-resource` (see `commands/acc-resource.md`)
+- `acc-status` (see `commands/acc-status.md`)
+- `acc-vault` (see `commands/acc-vault.md`)
+- `acc-voice` (see `commands/acc-voice.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/ahling-command-center`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/aws-eks-helm-keycloak/CLAUDE.md
+++ b/plugins/aws-eks-helm-keycloak/CLAUDE.md
@@ -1,0 +1,35 @@
+# Aws Eks Helm Keycloak Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/aws-eks-helm-keycloak`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `debug` (see `commands/debug.md`)
+- `dev-up` (see `commands/dev-up.md`)
+- `pipeline-scaffold` (see `commands/pipeline-scaffold.md`)
+- `preview` (see `commands/preview.md`)
+- `service-onboard` (see `commands/service-onboard.md`)
+- `setup` (see `commands/setup.md`)
+- `ship` (see `commands/ship.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/aws-eks-helm-keycloak`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/deployment-pipeline/CLAUDE.md
+++ b/plugins/deployment-pipeline/CLAUDE.md
@@ -1,0 +1,33 @@
+# Deployment Pipeline Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/deployment-pipeline`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `approve` (see `commands/approve.md`)
+- `history` (see `commands/history.md`)
+- `rollback` (see `commands/rollback.md`)
+- `start` (see `commands/start.md`)
+- `status` (see `commands/status.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/deployment-pipeline`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/exec-automator/CLAUDE.md
+++ b/plugins/exec-automator/CLAUDE.md
@@ -1,0 +1,41 @@
+# Exec Automator Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/exec-automator`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `analyze` (see `commands/analyze.md`)
+- `customize` (see `commands/customize.md`)
+- `dashboard` (see `commands/dashboard.md`)
+- `deploy` (see `commands/deploy.md`)
+- `export` (see `commands/export.md`)
+- `generate` (see `commands/generate.md`)
+- `integrate` (see `commands/integrate.md`)
+- `map` (see `commands/map.md`)
+- `orchestrate` (see `commands/orchestrate.md`)
+- `report` (see `commands/report.md`)
+- `score` (see `commands/score.md`)
+- `simulate` (see `commands/simulate.md`)
+- `template` (see `commands/template.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/exec-automator`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/fastapi-backend/CLAUDE.md
+++ b/plugins/fastapi-backend/CLAUDE.md
@@ -1,0 +1,38 @@
+# Fastapi Backend Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/fastapi-backend`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `deploy` (see `commands/deploy.md`)
+- `dev` (see `commands/dev.md`)
+- `docker` (see `commands/docker.md`)
+- `endpoint` (see `commands/endpoint.md`)
+- `migrate` (see `commands/migrate.md`)
+- `model` (see `commands/model.md`)
+- `scaffold` (see `commands/scaffold.md`)
+- `task` (see `commands/task.md`)
+- `test` (see `commands/test.md`)
+- `ws` (see `commands/ws.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/fastapi-backend`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/frontend-design-system/CLAUDE.md
+++ b/plugins/frontend-design-system/CLAUDE.md
@@ -1,0 +1,36 @@
+# Frontend Design System Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/frontend-design-system`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `audit` (see `commands/audit.md`)
+- `component` (see `commands/component.md`)
+- `convert` (see `commands/convert.md`)
+- `keycloak` (see `commands/keycloak.md`)
+- `palette` (see `commands/palette.md`)
+- `style` (see `commands/style.md`)
+- `theme` (see `commands/theme.md`)
+- `tokens` (see `commands/tokens.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/frontend-design-system`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/fullstack-iac/CLAUDE.md
+++ b/plugins/fullstack-iac/CLAUDE.md
@@ -1,0 +1,36 @@
+# Fullstack Iac Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/fullstack-iac`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `ansible` (see `commands/ansible.md`)
+- `api` (see `commands/api.md`)
+- `docker` (see `commands/docker.md`)
+- `frontend` (see `commands/frontend.md`)
+- `infra` (see `commands/infra.md`)
+- `k8s` (see `commands/k8s.md`)
+- `monorepo` (see `commands/monorepo.md`)
+- `new` (see `commands/new.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/fullstack-iac`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/home-assistant-architect/CLAUDE.md
+++ b/plugins/home-assistant-architect/CLAUDE.md
@@ -1,0 +1,37 @@
+# Home Assistant Architect Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/home-assistant-architect`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `ha-automation` (see `commands/ha-automation.md`)
+- `ha-camera` (see `commands/ha-camera.md`)
+- `ha-control` (see `commands/ha-control.md`)
+- `ha-dashboard` (see `commands/ha-dashboard.md`)
+- `ha-deploy` (see `commands/ha-deploy.md`)
+- `ha-energy` (see `commands/ha-energy.md`)
+- `ha-mcp` (see `commands/ha-mcp.md`)
+- `ha-sensor` (see `commands/ha-sensor.md`)
+- `ollama-setup` (see `commands/ollama-setup.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/home-assistant-architect`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/jira-orchestrator/CLAUDE.md
+++ b/plugins/jira-orchestrator/CLAUDE.md
@@ -1,0 +1,74 @@
+# Jira Orchestrator Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/jira-orchestrator`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `approve` (see `commands/approve.md`)
+- `batch` (see `commands/batch.md`)
+- `branch` (see `commands/branch.md`)
+- `bulk-commit` (see `commands/bulk-commit.md`)
+- `cancel` (see `commands/cancel.md`)
+- `commit-template` (see `commands/commit-template.md`)
+- `commit` (see `commands/commit.md`)
+- `compliance` (see `commands/compliance.md`)
+- `confluence` (see `commands/confluence.md`)
+- `council` (see `commands/council.md`)
+- `create-repo` (see `commands/create-repo.md`)
+- `deploy` (see `commands/deploy.md`)
+- `docs-external` (see `commands/docs-external.md`)
+- `docs` (see `commands/docs.md`)
+- `enterprise` (see `commands/enterprise.md`)
+- `events` (see `commands/events.md`)
+- `export` (see `commands/export.md`)
+- `harness-review` (see `commands/harness-review.md`)
+- `infra` (see `commands/infra.md`)
+- `install-hooks` (see `commands/install-hooks.md`)
+- `intelligence` (see `commands/intelligence.md`)
+- `iterate` (see `commands/iterate.md`)
+- `metrics` (see `commands/metrics.md`)
+- `notify` (see `commands/notify.md`)
+- `orchestrate-advanced` (see `commands/orchestrate-advanced.md`)
+- `plan-prs` (see `commands/plan-prs.md`)
+- `portfolio` (see `commands/portfolio.md`)
+- `pr-fix` (see `commands/pr-fix.md`)
+- `pr` (see `commands/pr.md`)
+- `prepare` (see `commands/prepare.md`)
+- `process-worklogs` (see `commands/process-worklogs.md`)
+- `qa-review` (see `commands/qa-review.md`)
+- `quality` (see `commands/quality.md`)
+- `reason` (see `commands/reason.md`)
+- `release` (see `commands/release.md`)
+- `review` (see `commands/review.md`)
+- `setup` (see `commands/setup.md`)
+- `ship` (see `commands/ship.md`)
+- `sla` (see `commands/sla.md`)
+- `sprint-plan` (see `commands/sprint-plan.md`)
+- `sprint` (see `commands/sprint.md`)
+- `status` (see `commands/status.md`)
+- `sync` (see `commands/sync.md`)
+- `team` (see `commands/team.md`)
+- `triage` (see `commands/triage.md`)
+- `work` (see `commands/work.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/jira-orchestrator`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/lobbi-platform-manager/CLAUDE.md
+++ b/plugins/lobbi-platform-manager/CLAUDE.md
@@ -1,0 +1,36 @@
+# Lobbi Platform Manager Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/lobbi-platform-manager`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `env-generate` (see `commands/env-generate.md`)
+- `env-validate` (see `commands/env-validate.md`)
+- `health` (see `commands/health.md`)
+- `keycloak-setup` (see `commands/keycloak-setup.md`)
+- `keycloak-theme` (see `commands/keycloak-theme.md`)
+- `keycloak-user` (see `commands/keycloak-user.md`)
+- `service` (see `commands/service.md`)
+- `test-gen` (see `commands/test-gen.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/lobbi-platform-manager`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/marketplace-pro/CLAUDE.md
+++ b/plugins/marketplace-pro/CLAUDE.md
@@ -1,0 +1,40 @@
+# Marketplace Pro Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/marketplace-pro`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `compose` (see `commands/compose.md`)
+- `dev` (see `commands/dev.md`)
+- `help` (see `commands/help.md`)
+- `lock` (see `commands/lock.md`)
+- `policy` (see `commands/policy.md`)
+- `quick` (see `commands/quick.md`)
+- `recommend` (see `commands/recommend.md`)
+- `registry` (see `commands/registry.md`)
+- `setup` (see `commands/setup.md`)
+- `status` (see `commands/status.md`)
+- `trust` (see `commands/trust.md`)
+- `verify` (see `commands/verify.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/marketplace-pro`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/marketplace-pro/agents/marketplace-advisor.md
+++ b/plugins/marketplace-pro/agents/marketplace-advisor.md
@@ -195,7 +195,7 @@ A: Lockfile drift means the versions or checksums in `plugin-lock.json` no longe
 A: Yes. Federation (multi-registry) is optional. By default, marketplace-pro reads from the local `plugins/` directory only. You only need federation if you want to pull plugins from remote registries (org or public).
 
 **Q: How do I create a new plugin?**
-A: Use `/mp:dev start` to scaffold a new plugin with a manifest, directory structure, and test harness. The minimum requirement is a `.claude-plugin/plugin.json` manifest in a directory under `plugins/`.
+A: Use `/mp:dev start` to scaffold a new plugin with a manifest, directory structure, and test harness. Day-one required files are `.claude-plugin/plugin.json`, `CLAUDE.md` (purpose/commands/guardrails/context budget/escalation), and `CONTEXT_SUMMARY.md` in a directory under `plugins/`.
 
 ## Behavioral Guidelines
 

--- a/plugins/marketplace-pro/skills/devstudio/SKILL.md
+++ b/plugins/marketplace-pro/skills/devstudio/SKILL.md
@@ -111,6 +111,34 @@ EOF
 ```
 
 ```bash
+# Create required operator runbook
+cat > my-plugin/CLAUDE.md << 'EOF'
+# My Plugin Guide
+
+## Purpose
+- Brief description of plugin intent.
+
+## Supported Commands
+- command-name (commands/command-name.md)
+
+## Prohibited Actions
+- List destructive or out-of-scope operations.
+
+## Required Validation Checks
+- npm run check:plugin-context
+- npm run check:plugin-schema
+
+## Context Budget
+1. CONTEXT_SUMMARY.md
+2. commands/index (or commands/)
+3. README.md and only task-relevant deep docs
+
+## Escalation Path
+- Describe who reviews risky or blocking changes.
+EOF
+```
+
+```bash
 
 # Create operator context entrypoint (keep concise)
 cat > my-plugin/CONTEXT.md << 'EOF'
@@ -197,6 +225,7 @@ Fix all errors before publishing. Warnings are advisory but should be addressed.
 | `version` field | error | Must be a non-empty string |
 | `description` field | error | Must be a non-empty string |
 | `contextEntry` field | error | Must reference `CONTEXT.md` or `PLUGIN_CONTEXT.md` |
+| `CLAUDE.md` present | error | Plugin root must include CLAUDE.md runbook |
 | `capabilities` present | warning | Plugin should declare capabilities |
 | `capabilities.provides` is array | error | Must be an array of strings |
 | `capabilities.requires` is array | error | Must be an array of strings |
@@ -217,6 +246,7 @@ Fix all errors before publishing. Warnings are advisory but should be addressed.
 plugin-root/
   .claude-plugin/
     plugin.json          # Plugin manifest (validated by HotReloader)
+  CLAUDE.md              # Required operator runbook and context budget
   CONTEXT.md             # Minimal operator context entrypoint
   commands/
     *.md                 # Slash commands (validated for frontmatter)

--- a/plugins/react-animation-studio/CLAUDE.md
+++ b/plugins/react-animation-studio/CLAUDE.md
@@ -1,0 +1,40 @@
+# React Animation Studio Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/react-animation-studio`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `animate-3d` (see `commands/animate-3d.md`)
+- `animate-audit` (see `commands/animate-audit.md`)
+- `animate-background` (see `commands/animate-background.md`)
+- `animate-component` (see `commands/animate-component.md`)
+- `animate-effects` (see `commands/animate-effects.md`)
+- `animate-export` (see `commands/animate-export.md`)
+- `animate-preset` (see `commands/animate-preset.md`)
+- `animate-scroll` (see `commands/animate-scroll.md`)
+- `animate-sequence` (see `commands/animate-sequence.md`)
+- `animate-text` (see `commands/animate-text.md`)
+- `animate-transition` (see `commands/animate-transition.md`)
+- `animate` (see `commands/animate.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/react-animation-studio`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/team-accelerator/CLAUDE.md
+++ b/plugins/team-accelerator/CLAUDE.md
@@ -1,0 +1,36 @@
+# Team Accelerator Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/team-accelerator`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `deploy` (see `commands/deploy.md`)
+- `docs` (see `commands/docs.md`)
+- `integrate` (see `commands/integrate.md`)
+- `perf` (see `commands/perf.md`)
+- `quality` (see `commands/quality.md`)
+- `status` (see `commands/status.md`)
+- `test` (see `commands/test.md`)
+- `workflow` (see `commands/workflow.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/team-accelerator`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/plugins/tvs-microsoft-deploy/CLAUDE.md
+++ b/plugins/tvs-microsoft-deploy/CLAUDE.md
@@ -1,0 +1,46 @@
+# Tvs Microsoft Deploy Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/tvs-microsoft-deploy`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `browser-fallback` (see `commands/browser-fallback.md`)
+- `cost-report` (see `commands/cost-report.md`)
+- `deploy-all` (see `commands/deploy-all.md`)
+- `deploy-azure` (see `commands/deploy-azure.md`)
+- `deploy-dataverse` (see `commands/deploy-dataverse.md`)
+- `deploy-fabric` (see `commands/deploy-fabric.md`)
+- `deploy-identity` (see `commands/deploy-identity.md`)
+- `deploy-portal` (see `commands/deploy-portal.md`)
+- `deploy-teams` (see `commands/deploy-teams.md`)
+- `extract-a3` (see `commands/extract-a3.md`)
+- `health` (see `commands/health.md`)
+- `identity-attestation` (see `commands/identity-attestation.md`)
+- `identity-drift` (see `commands/identity-drift.md`)
+- `normalize-carriers` (see `commands/normalize-carriers.md`)
+- `orchestrate-planner` (see `commands/orchestrate-planner.md`)
+- `quick-start` (see `commands/quick-start.md`)
+- `status-check` (see `commands/status-check.md`)
+- `taia-readiness` (see `commands/taia-readiness.md`)
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- If code/scripts changed in this plugin, run targeted tests for `plugins/tvs-microsoft-deploy`.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. `commands/index` (or list files in `commands/`)
+3. `README.md` and only the specific docs needed for the current task
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If validation fails and root cause is unclear, escalate with failing command output and touched files.
+- For production-impacting changes, request maintainer review before release/publish steps.

--- a/scripts/check-plugin-context.mjs
+++ b/scripts/check-plugin-context.mjs
@@ -45,6 +45,12 @@ for (const pluginName of pluginDirs) {
     continue;
   }
 
+  const claudeGuidePath = path.join(pluginRoot, 'CLAUDE.md');
+  if (!fs.existsSync(claudeGuidePath)) {
+    fail(`${pluginName}: plugin cannot be published without CLAUDE.md`);
+    continue;
+  }
+
   const contextPath = path.join(pluginRoot, bootstrapFiles[0]);
 
   if (!fs.existsSync(contextPath)) {


### PR DESCRIPTION
### Motivation
- Ensure every published plugin includes a concise operator runbook (CLAUDE.md) that captures purpose, supported commands, prohibited actions, required validation checks, context budget, and an escalation path so maintainers and automated agents have a predictable on-ramp.
- Enforce the presence of that runbook as a repo lint/publish gate to reduce onboarding friction and accidental unsafe edits.
- Update the scaffold and authoring guidance so new plugins include the runbook from day one.

### Description
- Added `CLAUDE.md` runbooks to plugin roots that were missing them under `plugins/*` (short, structured guides with purpose, supported commands, prohibited actions, validation checks, context budget, and escalation path). 
- Updated `scripts/check-plugin-context.mjs` to fail when a plugin has a `.claude-plugin/plugin.json` manifest but is missing `CLAUDE.md` (lint gate enforcement).
- Updated the Dev Studio scaffold and validation docs in `plugins/marketplace-pro/skills/devstudio/SKILL.md` to create and require `CLAUDE.md` and to include `CLAUDE.md` in the canonical file-structure and manifest validation rules.
- Updated plugin authoring Q&A in `plugins/marketplace-pro/agents/marketplace-advisor.md` to state day-one required files: `.claude-plugin/plugin.json`, `CLAUDE.md`, and `CONTEXT_SUMMARY.md`.

### Testing
- Ran `npm run check:plugin-context` which executed `scripts/check-plugin-context.mjs` and reported success (`✅ Plugin context entry checks passed.`).
- Ran `npm run check:plugin-schema` which validated plugins against the canonical plugin and hooks schemas and reported success (`Validated 15 plugins ...`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df52f12dc832abb683ea38b8ab7e4)