### PR TITLE
Add integration contract validator, fixtures, tests, CI script, and docs

### DIFF
--- a/plugins/jira-orchestrator/INSTALLATION.md
+++ b/plugins/jira-orchestrator/INSTALLATION.md
@@ -564,3 +564,17 @@ Happy orchestrating!
 ---
 
 **⚓ Golden Armada** | *You ask - The Fleet Ships*
+
+## Integration Contract Validation (Setup + CI)
+
+Run integration validation as part of setup and CI checks:
+
+```bash
+npm run setup
+npm run validate:integrations
+npm run ci
+```
+
+The validator writes a machine-readable report to `sessions/reports/integration-health.json` and exits non-zero when `error`-severity issues are detected.
+
+For fixture authoring and remediation workflow details, see `docs/ADVANCED-INTEGRATION-VALIDATION.md`.

--- a/plugins/jira-orchestrator/README.md
+++ b/plugins/jira-orchestrator/README.md
@@ -27,7 +27,8 @@ npm ci
 # Install plugin wiring (sets up hooks automatically)
 bash scripts/install.sh
 
-# Verify
+# Validate integration contracts and verify
+npm run validate:integrations
 claude /jira:setup
 ```
 
@@ -36,6 +37,19 @@ claude /jira:setup
 - Commit `package-lock.json` and use `npm ci` for local development and CI.
 - Use `npm install` only when intentionally changing dependencies, then commit the updated lockfile in the same PR.
 - Never commit `node_modules/`, `dist/`, or `build/` directories; publish generated bundles as release artifacts instead.
+
+---
+
+
+## CI Validation Flow
+
+Run the plugin CI checks (including integration contract validation):
+
+```bash
+npm run ci
+```
+
+`npm run validate:integrations` writes a machine-readable report to `sessions/reports/integration-health.json` for CI ingestion and release gates.
 
 ---
 

--- a/plugins/jira-orchestrator/docs/ADVANCED-INTEGRATION-VALIDATION.md
+++ b/plugins/jira-orchestrator/docs/ADVANCED-INTEGRATION-VALIDATION.md
@@ -1,0 +1,61 @@
+# Advanced Integration Validation
+
+This guide explains how to run and extend integration contract validation for Jira, Automation, Confluence, and Harness orchestration.
+
+## What the validator checks
+
+`npm run validate:integrations` executes `scripts/validate-integrations.ts` against fixture scenarios in `tests/integration-contracts/fixtures/`.
+
+Validation dimensions:
+
+1. **Jira required fields/properties**
+   - Required issue fields must exist in scenario payloads.
+   - Required issue properties (integration metadata) must be present.
+2. **Automation rule template completeness**
+   - Required steps must be present in each template.
+   - Each declared step should include an action.
+3. **Confluence template schema**
+   - Required template properties must exist.
+   - Property types must match expected schema types.
+4. **Harness transition map coverage**
+   - Required Jira transitions must map to Harness execution stages.
+
+## Contributor workflow
+
+1. Update or add fixtures under `tests/integration-contracts/fixtures/*.json`.
+2. Run validator locally:
+
+   ```bash
+   npm run validate:integrations
+   ```
+
+3. Review `sessions/reports/integration-health.json`.
+4. Run focused tests:
+
+   ```bash
+   npm run test -- tests/integration-contracts/validate-integrations.test.ts
+   ```
+
+5. Run CI bundle before opening PR:
+
+   ```bash
+   npm run ci
+   ```
+
+## Report format
+
+The validator emits `sessions/reports/integration-health.json` with:
+
+- `summary.totalScenarios`
+- `summary.passedScenarios`
+- `summary.issuesBySeverity` (`info`, `warning`, `error`)
+- `issues[]` entries with:
+  - `scenario`
+  - `area`
+  - `severity`
+  - `message`
+  - `remediation`
+
+## Adding new scenarios
+
+Use existing fixtures as templates for new release states (for example, hotfix, partial rollback, or security exception workflows). Keep scenarios deterministic and avoid environment-specific IDs.

--- a/plugins/jira-orchestrator/package.json
+++ b/plugins/jira-orchestrator/package.json
@@ -15,11 +15,13 @@
     "db:setup": "npm run db:generate && npm run db:push",
     "temporal:worker": "tsx lib/worker.ts",
     "temporal:start": "tsx scripts/start-orchestration.ts",
-    "setup": "npm run db:setup",
+    "setup": "npm run db:setup && npm run validate:integrations",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "lint": "eslint lib/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "validate:integrations": "tsx scripts/validate-integrations.ts",
+    "ci": "npm run lint && npm run typecheck && npm run test && npm run validate:integrations"
   },
   "dependencies": {
     "@prisma/client": "^6.3.0",

--- a/plugins/jira-orchestrator/scripts/validate-integrations.ts
+++ b/plugins/jira-orchestrator/scripts/validate-integrations.ts
@@ -1,0 +1,207 @@
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type Severity = 'info' | 'warning' | 'error';
+
+export interface IntegrationIssue {
+  scenario: string;
+  area: 'jira' | 'automation' | 'confluence' | 'harness';
+  severity: Severity;
+  message: string;
+  remediation: string;
+}
+
+export interface IntegrationFixture {
+  scenario: string;
+  jira: {
+    requiredFields: string[];
+    fields: Record<string, unknown>;
+    requiredProperties: string[];
+    properties: Record<string, unknown>;
+  };
+  automation: {
+    templateName: string;
+    requiredSteps: string[];
+    steps: Array<{ id: string; action?: string }>;
+  };
+  confluence: {
+    templateName: string;
+    requiredProperties: Record<string, string>;
+    properties: Record<string, { type: string; required?: boolean }>;
+  };
+  harness: {
+    requiredTransitions: string[];
+    transitionMap: Record<string, string>;
+  };
+}
+
+export interface IntegrationHealthReport {
+  generatedAt: string;
+  fixturesPath: string;
+  summary: {
+    totalScenarios: number;
+    passedScenarios: number;
+    issuesBySeverity: Record<Severity, number>;
+  };
+  issues: IntegrationIssue[];
+}
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const defaultFixturesPath = path.resolve(dirname, '../tests/integration-contracts/fixtures');
+const reportPath = path.resolve(dirname, '../sessions/reports/integration-health.json');
+
+export function validateFixture(fixture: IntegrationFixture): IntegrationIssue[] {
+  const issues: IntegrationIssue[] = [];
+
+  const missingJiraFields = fixture.jira.requiredFields.filter((field) => fixture.jira.fields[field] == null);
+  for (const field of missingJiraFields) {
+    issues.push({
+      scenario: fixture.scenario,
+      area: 'jira',
+      severity: 'error',
+      message: `Missing required Jira field: ${field}`,
+      remediation: `Populate Jira field \"${field}\" in the release orchestration issue payload.`,
+    });
+  }
+
+  const missingJiraProperties = fixture.jira.requiredProperties.filter(
+    (property) => fixture.jira.properties[property] == null,
+  );
+  for (const property of missingJiraProperties) {
+    issues.push({
+      scenario: fixture.scenario,
+      area: 'jira',
+      severity: 'error',
+      message: `Missing required Jira issue property: ${property}`,
+      remediation: `Ensure Jira automation sets issue property \"${property}\" before transition execution.`,
+    });
+  }
+
+  const presentSteps = new Set(fixture.automation.steps.map((step) => step.id));
+  for (const step of fixture.automation.requiredSteps) {
+    if (!presentSteps.has(step)) {
+      issues.push({
+        scenario: fixture.scenario,
+        area: 'automation',
+        severity: 'error',
+        message: `Automation template ${fixture.automation.templateName} is missing required step: ${step}`,
+        remediation: `Add step \"${step}\" to automation template \"${fixture.automation.templateName}\".`,
+      });
+    }
+  }
+
+  for (const step of fixture.automation.steps) {
+    if (!step.action || !step.action.trim()) {
+      issues.push({
+        scenario: fixture.scenario,
+        area: 'automation',
+        severity: 'warning',
+        message: `Automation step ${step.id} has no action configured.`,
+        remediation: `Define a concrete action for automation step \"${step.id}\".`,
+      });
+    }
+  }
+
+  for (const [property, expectedType] of Object.entries(fixture.confluence.requiredProperties)) {
+    const actual = fixture.confluence.properties[property];
+    if (!actual) {
+      issues.push({
+        scenario: fixture.scenario,
+        area: 'confluence',
+        severity: 'error',
+        message: `Confluence template ${fixture.confluence.templateName} is missing property: ${property}`,
+        remediation: `Add property \"${property}\" with type \"${expectedType}\" to template metadata.`,
+      });
+      continue;
+    }
+
+    if (actual.type !== expectedType) {
+      issues.push({
+        scenario: fixture.scenario,
+        area: 'confluence',
+        severity: 'error',
+        message: `Confluence property ${property} has type ${actual.type}, expected ${expectedType}.`,
+        remediation: `Update Confluence template property \"${property}\" to type \"${expectedType}\".`,
+      });
+    }
+  }
+
+  for (const transition of fixture.harness.requiredTransitions) {
+    if (!fixture.harness.transitionMap[transition]) {
+      issues.push({
+        scenario: fixture.scenario,
+        area: 'harness',
+        severity: 'error',
+        message: `Harness transition map missing coverage for transition: ${transition}`,
+        remediation: `Map transition \"${transition}\" to a Harness pipeline stage or rollback workflow.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function validateFixtures(fixtures: IntegrationFixture[], fixturesPath = defaultFixturesPath): IntegrationHealthReport {
+  const issues = fixtures.flatMap(validateFixture);
+  const issueCounts = issues.reduce(
+    (acc, issue) => {
+      acc[issue.severity] += 1;
+      return acc;
+    },
+    { info: 0, warning: 0, error: 0 } as Record<Severity, number>,
+  );
+
+  const scenarioIssueMap = new Map<string, number>();
+  for (const issue of issues) {
+    scenarioIssueMap.set(issue.scenario, (scenarioIssueMap.get(issue.scenario) ?? 0) + 1);
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    fixturesPath,
+    summary: {
+      totalScenarios: fixtures.length,
+      passedScenarios: fixtures.length - scenarioIssueMap.size,
+      issuesBySeverity: issueCounts,
+    },
+    issues,
+  };
+}
+
+export function loadFixtures(fixturesPath = defaultFixturesPath): IntegrationFixture[] {
+  return readdirSync(fixturesPath)
+    .filter((file) => file.endsWith('.json'))
+    .sort()
+    .map((file) => {
+      const fullPath = path.join(fixturesPath, file);
+      const content = readFileSync(fullPath, 'utf-8');
+      return JSON.parse(content) as IntegrationFixture;
+    });
+}
+
+export function writeReport(report: IntegrationHealthReport, outputPath = reportPath) {
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf-8');
+}
+
+export function runValidation(fixturesPath = defaultFixturesPath, outputPath = reportPath): IntegrationHealthReport {
+  const fixtures = loadFixtures(fixturesPath);
+  const report = validateFixtures(fixtures, fixturesPath);
+  writeReport(report, outputPath);
+  return report;
+}
+
+const isEntrypoint = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isEntrypoint) {
+  const report = runValidation();
+  const hasErrors = report.summary.issuesBySeverity.error > 0;
+  console.log(`Validated ${report.summary.totalScenarios} integration scenarios.`);
+  console.log(`Report written to ${reportPath}`);
+  console.log(`Issues: ${JSON.stringify(report.summary.issuesBySeverity)}`);
+
+  if (hasErrors) {
+    process.exitCode = 1;
+  }
+}

--- a/plugins/jira-orchestrator/sessions/reports/integration-health.json
+++ b/plugins/jira-orchestrator/sessions/reports/integration-health.json
@@ -1,0 +1,14 @@
+{
+  "generatedAt": "2026-02-24T20:21:43.802Z",
+  "fixturesPath": "/workspace/claude/plugins/jira-orchestrator/tests/integration-contracts/fixtures",
+  "summary": {
+    "totalScenarios": 4,
+    "passedScenarios": 4,
+    "issuesBySeverity": {
+      "info": 0,
+      "warning": 0,
+      "error": 0
+    }
+  },
+  "issues": []
+}

--- a/plugins/jira-orchestrator/src/test/setup.ts
+++ b/plugins/jira-orchestrator/src/test/setup.ts
@@ -1,0 +1,1 @@
+// Test setup placeholder for plugin-local Vitest execution.

--- a/plugins/jira-orchestrator/tests/integration-contracts/fixtures/failed-release.json
+++ b/plugins/jira-orchestrator/tests/integration-contracts/fixtures/failed-release.json
@@ -1,0 +1,85 @@
+{
+  "scenario": "failed-release",
+  "jira": {
+    "requiredFields": [
+      "summary",
+      "description",
+      "fixVersions",
+      "assignee"
+    ],
+    "fields": {
+      "summary": "Release 7.5.1 deployment failed",
+      "description": "Deploy failed in smoke tests",
+      "fixVersions": [
+        "7.5.1"
+      ],
+      "assignee": "release-bot"
+    },
+    "requiredProperties": [
+      "release.type",
+      "release.window",
+      "harness.executionId"
+    ],
+    "properties": {
+      "release.type": "failed",
+      "release.window": "weekly",
+      "harness.executionId": "exec-1002"
+    }
+  },
+  "automation": {
+    "templateName": "release-failure-handler",
+    "requiredSteps": [
+      "capture-logs",
+      "notify-owners",
+      "mark-failed"
+    ],
+    "steps": [
+      {
+        "id": "capture-logs",
+        "action": "harness.logs:collect"
+      },
+      {
+        "id": "notify-owners",
+        "action": "slack.notify:#release-alerts"
+      },
+      {
+        "id": "mark-failed",
+        "action": "jira.transition:Failed"
+      }
+    ]
+  },
+  "confluence": {
+    "templateName": "release-failure-summary",
+    "requiredProperties": {
+      "releaseVersion": "string",
+      "failureReason": "string",
+      "owner": "string"
+    },
+    "properties": {
+      "releaseVersion": {
+        "type": "string",
+        "required": true
+      },
+      "failureReason": {
+        "type": "string",
+        "required": true
+      },
+      "owner": {
+        "type": "string",
+        "required": true
+      }
+    }
+  },
+  "harness": {
+    "requiredTransitions": [
+      "Ready for Deploy",
+      "Failed",
+      "Rollback Required"
+    ],
+    "transitionMap": {
+      "Ready for Deploy": "stage.deploy",
+      "Failed": "stage.failover",
+      "Rollback Required": "stage.rollback"
+    }
+  }
+}

--- a/plugins/jira-orchestrator/tests/integration-contracts/fixtures/incident-escalation.json
+++ b/plugins/jira-orchestrator/tests/integration-contracts/fixtures/incident-escalation.json
@@ -1,0 +1,85 @@
+{
+  "scenario": "incident-escalation",
+  "jira": {
+    "requiredFields": [
+      "summary",
+      "description",
+      "fixVersions",
+      "assignee"
+    ],
+    "fields": {
+      "summary": "Release incident escalation",
+      "description": "Incident bridge opened due to sustained outage",
+      "fixVersions": [
+        "7.5.1"
+      ],
+      "assignee": "incident-commander"
+    },
+    "requiredProperties": [
+      "release.type",
+      "release.window",
+      "harness.executionId"
+    ],
+    "properties": {
+      "release.type": "incident",
+      "release.window": "immediate",
+      "harness.executionId": "exec-1004"
+    }
+  },
+  "automation": {
+    "templateName": "incident-escalation",
+    "requiredSteps": [
+      "page-oncall",
+      "open-bridge",
+      "update-statuspage"
+    ],
+    "steps": [
+      {
+        "id": "page-oncall",
+        "action": "pagerduty.trigger:P1"
+      },
+      {
+        "id": "open-bridge",
+        "action": "slack.create-channel:#incident"
+      },
+      {
+        "id": "update-statuspage",
+        "action": "statuspage.incident:create"
+      }
+    ]
+  },
+  "confluence": {
+    "templateName": "incident-postmortem",
+    "requiredProperties": {
+      "incidentId": "string",
+      "severity": "string",
+      "timeline": "string"
+    },
+    "properties": {
+      "incidentId": {
+        "type": "string",
+        "required": true
+      },
+      "severity": {
+        "type": "string",
+        "required": true
+      },
+      "timeline": {
+        "type": "string",
+        "required": true
+      }
+    }
+  },
+  "harness": {
+    "requiredTransitions": [
+      "Incident",
+      "Mitigated",
+      "Postmortem"
+    ],
+    "transitionMap": {
+      "Incident": "stage.escalate",
+      "Mitigated": "stage.mitigate",
+      "Postmortem": "stage.postmortem"
+    }
+  }
+}

--- a/plugins/jira-orchestrator/tests/integration-contracts/fixtures/normal-release.json
+++ b/plugins/jira-orchestrator/tests/integration-contracts/fixtures/normal-release.json
@@ -1,0 +1,49 @@
+{
+  "scenario": "normal-release",
+  "jira": {
+    "requiredFields": ["summary", "description", "fixVersions", "assignee"],
+    "fields": {
+      "summary": "Release 7.5.1 deployment",
+      "description": "Standard production deployment",
+      "fixVersions": ["7.5.1"],
+      "assignee": "release-bot"
+    },
+    "requiredProperties": ["release.type", "release.window", "harness.executionId"],
+    "properties": {
+      "release.type": "normal",
+      "release.window": "weekly",
+      "harness.executionId": "exec-1001"
+    }
+  },
+  "automation": {
+    "templateName": "release-orchestration",
+    "requiredSteps": ["validate-change", "deploy", "verify", "close-release"],
+    "steps": [
+      { "id": "validate-change", "action": "jira.transition:Ready for Deploy" },
+      { "id": "deploy", "action": "harness.pipeline:prod-deploy" },
+      { "id": "verify", "action": "jira.comment:verification complete" },
+      { "id": "close-release", "action": "jira.transition:Done" }
+    ]
+  },
+  "confluence": {
+    "templateName": "release-summary",
+    "requiredProperties": {
+      "releaseVersion": "string",
+      "riskLevel": "string",
+      "owner": "string"
+    },
+    "properties": {
+      "releaseVersion": { "type": "string", "required": true },
+      "riskLevel": { "type": "string", "required": true },
+      "owner": { "type": "string", "required": true }
+    }
+  },
+  "harness": {
+    "requiredTransitions": ["Ready for Deploy", "Verifying", "Done"],
+    "transitionMap": {
+      "Ready for Deploy": "stage.deploy",
+      "Verifying": "stage.verify",
+      "Done": "stage.complete"
+    }
+  }
+}

--- a/plugins/jira-orchestrator/tests/integration-contracts/fixtures/rollback.json
+++ b/plugins/jira-orchestrator/tests/integration-contracts/fixtures/rollback.json
@@ -1,0 +1,85 @@
+{
+  "scenario": "rollback",
+  "jira": {
+    "requiredFields": [
+      "summary",
+      "description",
+      "fixVersions",
+      "assignee"
+    ],
+    "fields": {
+      "summary": "Release 7.5.1 rollback",
+      "description": "Rollback initiated after canary failure",
+      "fixVersions": [
+        "7.5.1"
+      ],
+      "assignee": "release-bot"
+    },
+    "requiredProperties": [
+      "release.type",
+      "release.window",
+      "harness.executionId"
+    ],
+    "properties": {
+      "release.type": "rollback",
+      "release.window": "emergency",
+      "harness.executionId": "exec-1003"
+    }
+  },
+  "automation": {
+    "templateName": "rollback-orchestration",
+    "requiredSteps": [
+      "trigger-rollback",
+      "verify-rollback",
+      "close-incident"
+    ],
+    "steps": [
+      {
+        "id": "trigger-rollback",
+        "action": "harness.pipeline:rollback"
+      },
+      {
+        "id": "verify-rollback",
+        "action": "jira.comment:rollback verified"
+      },
+      {
+        "id": "close-incident",
+        "action": "jira.transition:Recovered"
+      }
+    ]
+  },
+  "confluence": {
+    "templateName": "rollback-report",
+    "requiredProperties": {
+      "releaseVersion": "string",
+      "rollbackStart": "string",
+      "rollbackOwner": "string"
+    },
+    "properties": {
+      "releaseVersion": {
+        "type": "string",
+        "required": true
+      },
+      "rollbackStart": {
+        "type": "string",
+        "required": true
+      },
+      "rollbackOwner": {
+        "type": "string",
+        "required": true
+      }
+    }
+  },
+  "harness": {
+    "requiredTransitions": [
+      "Rollback Required",
+      "Rollback In Progress",
+      "Recovered"
+    ],
+    "transitionMap": {
+      "Rollback Required": "stage.rollback",
+      "Rollback In Progress": "stage.monitor",
+      "Recovered": "stage.complete"
+    }
+  }
+}

--- a/plugins/jira-orchestrator/tests/integration-contracts/validate-integrations.test.ts
+++ b/plugins/jira-orchestrator/tests/integration-contracts/validate-integrations.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  type IntegrationFixture,
+  loadFixtures,
+  runValidation,
+  validateFixture,
+  validateFixtures,
+} from '../../scripts/validate-integrations';
+
+describe('integration contract validation', () => {
+  const fixturesPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+  it('loads all release lifecycle fixtures', () => {
+    const fixtures = loadFixtures(fixturesPath);
+    const scenarios = fixtures.map((fixture) => fixture.scenario);
+
+    expect(scenarios).toEqual([
+      'failed-release',
+      'incident-escalation',
+      'normal-release',
+      'rollback',
+    ]);
+  });
+
+  it('keeps baseline fixtures healthy across all scenarios', () => {
+    const fixtures = loadFixtures(fixturesPath);
+
+    for (const fixture of fixtures) {
+      expect(validateFixture(fixture), `scenario ${fixture.scenario}`).toEqual([]);
+    }
+  });
+
+  it('detects contract regressions by integration area', () => {
+    const [fixture] = loadFixtures(fixturesPath);
+    const brokenFixture: IntegrationFixture = {
+      ...fixture,
+      jira: {
+        ...fixture.jira,
+        properties: {
+          ...fixture.jira.properties,
+          'harness.executionId': undefined,
+        },
+      },
+      automation: {
+        ...fixture.automation,
+        steps: fixture.automation.steps.map((step, index) =>
+          index === 0 ? { ...step, action: '' } : step,
+        ),
+      },
+      confluence: {
+        ...fixture.confluence,
+        properties: {
+          ...fixture.confluence.properties,
+          owner: { type: 'number' },
+        },
+      },
+      harness: {
+        ...fixture.harness,
+        transitionMap: {},
+      },
+    };
+
+    const issues = validateFixture(brokenFixture);
+    expect(issues.some((issue) => issue.area === 'jira')).toBe(true);
+    expect(issues.some((issue) => issue.area === 'automation')).toBe(true);
+    expect(issues.some((issue) => issue.area === 'confluence')).toBe(true);
+    expect(issues.some((issue) => issue.area === 'harness')).toBe(true);
+  });
+
+  it('produces machine-readable report with severity summary', () => {
+    const fixtures = loadFixtures(fixturesPath);
+    const report = validateFixtures(fixtures, fixturesPath);
+
+    expect(report.summary.totalScenarios).toBe(4);
+    expect(report.summary.passedScenarios).toBe(4);
+    expect(report.summary.issuesBySeverity).toEqual({
+      info: 0,
+      warning: 0,
+      error: 0,
+    });
+  });
+
+  it('writes report JSON for downstream CI processing', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'integration-validation-'));
+    const outputPath = path.join(tempDir, 'integration-health.json');
+
+    const report = runValidation(fixturesPath, outputPath);
+    const persisted = JSON.parse(readFileSync(outputPath, 'utf-8')) as typeof report;
+
+    expect(persisted.summary).toEqual(report.summary);
+    expect(Array.isArray(persisted.issues)).toBe(true);
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide automated validation that integration contracts for Jira, automation rules, Confluence templates, and Harness transition mappings remain complete and consistent across release scenarios. 
- Make validation machine-readable so CI and release gates can fail fast on integration contract regressions.

### Description
- Add a validator script at `scripts/validate-integrations.ts` that checks required Jira fields/properties, automation template completeness, Confluence template property schema, and Harness transition map coverage and emits a structured report. 
- Add fixture-driven scenarios under `tests/integration-contracts/fixtures/` for `normal-release`, `failed-release`, `rollback`, and `incident-escalation` and a test suite at `tests/integration-contracts/validate-integrations.test.ts` to validate loading, baseline health, regression detection, and report persistence. 
- Wire a `validate:integrations` npm script into `package.json`, include it in `setup` and a new `ci` aggregate script, and document usage in `docs/ADVANCED-INTEGRATION-VALIDATION.md`, `README.md`, and `INSTALLATION.md`. 
- Emit a machine-readable report to `sessions/reports/integration-health.json` and add a small `src/test/setup.ts` placeholder so Vitest runs in the plugin scope.

### Testing
- Ran `npm run validate:integrations` which executed the validator and produced `sessions/reports/integration-health.json`; after fixture fixes the validator completed with `issuesBySeverity` showing zero `error` and zero `warning`. (final run succeeded). 
- Ran the fixture-driven unit tests with Vitest via `npm run test -- --run tests/integration-contracts/validate-integrations.test.ts` which executed 5 tests and they all passed. 
- A first `npm run test` attempt failed due to a missing test setup file, which was resolved by adding `src/test/setup.ts`, after which the targeted tests passed. 
- Attempts to run `npm run check:plugin-context` and `npm run check:plugin-schema` were executed but failed because those scripts are not defined in this package's `package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0761de54832abc1274301e43ff03)