### PR TITLE
Add Confluence operations templates, indexing workflow, and coverage tests

### DIFF
--- a/plugins/jira-orchestrator/agents/confluence-documentation-creator.md
+++ b/plugins/jira-orchestrator/agents/confluence-documentation-creator.md
@@ -156,6 +156,44 @@ Search for project space by key or name. Ask user if not found.
 - Add Confluence page links to Jira issue (comment)
 - Add Confluence page links to GitHub PR (comment)
 - Include Jira/PR links in Confluence pages
+- Use canonical Confluence URLs for indexed pages from the Operations Index parent page (avoid ad-hoc editor URLs)
+
+### 3a. Write Standardized Page Properties + Labels on Create/Update
+
+For every new or updated page, always write/update page properties with these required keys:
+
+- `issue-key`
+- `release`
+- `incident`
+- `env`
+- `service`
+
+Also apply labels (when values are available):
+
+- `issue-key`
+- `release`
+- `incident`
+- `env`
+- `service`
+
+Do this on both create and update operations to keep index queries accurate.
+
+### 3b. Generator Step: Operations Index Parent Page (Per Project/Quarter)
+
+After page create/update, run an index generator step:
+
+1. Resolve `project-key` and quarter value (for example `2026-Q1`).
+2. Find or create parent page titled: `Operations Index - {project-key} - {quarter}`.
+3. Use CQL (`searchConfluenceUsingCql`) to discover child pages by:
+   - required page property keys (`issue-key`, `release`, `incident`, `env`, `service`)
+   - labels and `project-key`/quarter metadata.
+4. Rebuild parent page sections with canonical links to all discovered child pages:
+   - Release Status
+   - Incident Timeline
+   - Rollback Log
+   - SLA Breach Reports
+5. Persist a deterministic ordering (updated date desc, then title asc).
+6. Save canonical parent/child URLs for downstream Jira comments.
 
 ### 4. Content Discovery
 
@@ -182,6 +220,7 @@ Auto-populate documentation by analyzing codebase:
 - **Error Resilience:** Retry failed requests and handle missing data
 - **Page Management:** Create, update, organize documentation pages
 - **Cross-linking:** Connect related pages, issues, and PRs
+- **Operations Index Generation:** Build and refresh project/quarter index pages from CQL-discovered children
 
 ## Best Practices
 
@@ -192,6 +231,8 @@ Auto-populate documentation by analyzing codebase:
 5. Handle errors gracefully with retries
 6. Update existing pages instead of duplicating
 7. Include actual code snippets and metrics
+8. Write required page property keys + labels on every create/update
+9. Jira comments must include canonical links from the Operations Index (not ad-hoc URLs)
 
 ## Success Output
 

--- a/plugins/jira-orchestrator/commands/confluence.md
+++ b/plugins/jira-orchestrator/commands/confluence.md
@@ -30,8 +30,9 @@ description: Read, write, sync, create, or link Confluence pages to Jira issues
 1. **Validate** issue key format & fetch from Jira
 2. **Determine** Confluence space (use ${space_key} or project key)
 3. **Execute** action (read/write/sync/create/link)
-4. **Comment** on Jira with results
+4. **Comment** on Jira with canonical indexed page URLs + Operations Index URL
 5. **Create/Update** bi-directional links
+6. **Generate**/refresh `Operations Index - {project-key} - {quarter}` using CQL-discovered child pages
 
 ## Action: READ
 
@@ -79,7 +80,7 @@ description: Read, write, sync, create, or link Confluence pages to Jira issues
 2. Select template (pre-built HTML)
 3. Populate with Jira data
 4. Create via Confluence API
-5. Add labels (issue_key, type, page_type)
+5. Add labels (issue-key, release, incident, env, service) and write the same keys as page properties
 6. Link to Jira (remote + macro)
 
 ## Action: LINK

--- a/plugins/jira-orchestrator/templates/comments/confluence-linked.md.template
+++ b/plugins/jira-orchestrator/templates/comments/confluence-linked.md.template
@@ -1,6 +1,6 @@
 ---
 template: confluence-linked
-version: 1.0.0
+version: 1.1.0
 description: Comment template for Confluence page linking
 ---
 
@@ -9,11 +9,12 @@ description: Comment template for Confluence page linking
 **Linked By:** {{AUTHOR}}
 **Linked:** {{TIMESTAMP}}
 
-## Confluence Page
+## Canonical Confluence Links
 
-**Title:** [{{PAGE_TITLE}}]({{PAGE_URL}})
-**Space:** {{SPACE_NAME}}
-**Page ID:** {{PAGE_ID}}
+- **Indexed Page:** [{{PAGE_TITLE}}]({{CANONICAL_PAGE_URL}})
+- **Operations Index:** [{{OPERATIONS_INDEX_TITLE}}]({{OPERATIONS_INDEX_URL}})
+- **Space:** {{SPACE_NAME}}
+- **Page ID:** {{PAGE_ID}}
 
 ## Documentation Type
 

--- a/plugins/jira-orchestrator/templates/confluence/incident-timeline.md.template
+++ b/plugins/jira-orchestrator/templates/confluence/incident-timeline.md.template
@@ -1,0 +1,46 @@
+# Incident Timeline: {{INCIDENT_ID}}
+
+**Issue:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+**Service:** {{SERVICE_NAME}}
+**Environment:** {{ENV}}
+**Severity:** {{SEVERITY}}
+**Opened:** {{INCIDENT_OPENED_AT}}
+
+## Page Properties
+
+| Key | Value |
+|-----|-------|
+| issue-key | {{JIRA_KEY}} |
+| release | {{RELEASE_VERSION}} |
+| incident | {{INCIDENT_ID}} |
+| env | {{ENV}} |
+| service | {{SERVICE_NAME}} |
+| project-key | {{JIRA_PROJECT}} |
+| quarter | {{QUARTER}} |
+| doc-type | incident-timeline |
+
+## Labels
+
+`issue-key` `incident` `env` `service`
+
+## Timeline
+
+| Time (UTC) | Event | Owner | Evidence |
+|------------|-------|-------|----------|
+| {{T0}} | Incident detected | {{DETECTED_BY}} | {{EVIDENCE_T0}} |
+| {{T1}} | Triage started | {{TRIAGE_OWNER}} | {{EVIDENCE_T1}} |
+| {{T2}} | Mitigation applied | {{MITIGATION_OWNER}} | {{EVIDENCE_T2}} |
+| {{T3}} | Recovery confirmed | {{RECOVERY_OWNER}} | {{EVIDENCE_T3}} |
+
+## Impact
+
+{{INCIDENT_IMPACT}}
+
+## Linked Operations Index
+
+- Parent Index: {{OPERATIONS_INDEX_URL}}
+- Canonical Page URL: {{CANONICAL_PAGE_URL}}
+
+---
+
+**⚓ Golden Armada** | *You ask - The Fleet Ships*

--- a/plugins/jira-orchestrator/templates/confluence/release-status.md.template
+++ b/plugins/jira-orchestrator/templates/confluence/release-status.md.template
@@ -1,0 +1,49 @@
+# Release Status: {{RELEASE_NAME}}
+
+**Issue:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+**Service:** {{SERVICE_NAME}}
+**Environment:** {{ENV}}
+**Release Version:** {{RELEASE_VERSION}}
+**Report Date:** {{DATE}}
+
+## Page Properties
+
+| Key | Value |
+|-----|-------|
+| issue-key | {{JIRA_KEY}} |
+| release | {{RELEASE_VERSION}} |
+| incident | {{INCIDENT_ID}} |
+| env | {{ENV}} |
+| service | {{SERVICE_NAME}} |
+| project-key | {{JIRA_PROJECT}} |
+| quarter | {{QUARTER}} |
+| doc-type | release-status |
+
+## Labels
+
+`issue-key` `release` `env` `service`
+
+## Summary
+
+{{RELEASE_SUMMARY}}
+
+## Milestones
+
+| Milestone | Owner | Status | ETA |
+|-----------|-------|--------|-----|
+| Build complete | {{BUILD_OWNER}} | {{BUILD_STATUS}} | {{BUILD_ETA}} |
+| QA sign-off | {{QA_OWNER}} | {{QA_STATUS}} | {{QA_ETA}} |
+| Deployment | {{DEPLOY_OWNER}} | {{DEPLOY_STATUS}} | {{DEPLOY_ETA}} |
+
+## Risks & Mitigations
+
+{{RISKS_AND_MITIGATIONS}}
+
+## Linked Operations Index
+
+- Parent Index: {{OPERATIONS_INDEX_URL}}
+- Canonical Page URL: {{CANONICAL_PAGE_URL}}
+
+---
+
+**⚓ Golden Armada** | *You ask - The Fleet Ships*

--- a/plugins/jira-orchestrator/templates/confluence/rollback-log.md.template
+++ b/plugins/jira-orchestrator/templates/confluence/rollback-log.md.template
@@ -1,0 +1,45 @@
+# Rollback Log: {{RELEASE_VERSION}}
+
+**Issue:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+**Service:** {{SERVICE_NAME}}
+**Environment:** {{ENV}}
+**Rollback Started:** {{ROLLBACK_STARTED_AT}}
+
+## Page Properties
+
+| Key | Value |
+|-----|-------|
+| issue-key | {{JIRA_KEY}} |
+| release | {{RELEASE_VERSION}} |
+| incident | {{INCIDENT_ID}} |
+| env | {{ENV}} |
+| service | {{SERVICE_NAME}} |
+| project-key | {{JIRA_PROJECT}} |
+| quarter | {{QUARTER}} |
+| doc-type | rollback-log |
+
+## Labels
+
+`issue-key` `release` `incident` `env` `service`
+
+## Rollback Steps
+
+| Step | Action | Status | Owner | Timestamp |
+|------|--------|--------|-------|-----------|
+| 1 | Disable new traffic | {{STEP_1_STATUS}} | {{STEP_1_OWNER}} | {{STEP_1_TIME}} |
+| 2 | Revert deployment | {{STEP_2_STATUS}} | {{STEP_2_OWNER}} | {{STEP_2_TIME}} |
+| 3 | Validate health checks | {{STEP_3_STATUS}} | {{STEP_3_OWNER}} | {{STEP_3_TIME}} |
+| 4 | Close incident comms | {{STEP_4_STATUS}} | {{STEP_4_OWNER}} | {{STEP_4_TIME}} |
+
+## Validation
+
+{{ROLLBACK_VALIDATION}}
+
+## Linked Operations Index
+
+- Parent Index: {{OPERATIONS_INDEX_URL}}
+- Canonical Page URL: {{CANONICAL_PAGE_URL}}
+
+---
+
+**⚓ Golden Armada** | *You ask - The Fleet Ships*

--- a/plugins/jira-orchestrator/templates/confluence/sla-breach-report.md.template
+++ b/plugins/jira-orchestrator/templates/confluence/sla-breach-report.md.template
@@ -1,0 +1,47 @@
+# SLA Breach Report: {{SLA_BREACH_ID}}
+
+**Issue:** [{{JIRA_KEY}}]({{JIRA_URL}}/browse/{{JIRA_KEY}})
+**Service:** {{SERVICE_NAME}}
+**Environment:** {{ENV}}
+**SLA Policy:** {{SLA_POLICY_NAME}}
+
+## Page Properties
+
+| Key | Value |
+|-----|-------|
+| issue-key | {{JIRA_KEY}} |
+| release | {{RELEASE_VERSION}} |
+| incident | {{INCIDENT_ID}} |
+| env | {{ENV}} |
+| service | {{SERVICE_NAME}} |
+| project-key | {{JIRA_PROJECT}} |
+| quarter | {{QUARTER}} |
+| doc-type | sla-breach-report |
+
+## Labels
+
+`issue-key` `incident` `env` `service`
+
+## Breach Summary
+
+- **Breach Window:** {{BREACH_START}} → {{BREACH_END}}
+- **Target SLA:** {{TARGET_SLA}}
+- **Observed SLA:** {{OBSERVED_SLA}}
+- **User Impact:** {{USER_IMPACT}}
+
+## Root Cause
+
+{{ROOT_CAUSE}}
+
+## Corrective Actions
+
+{{CORRECTIVE_ACTIONS}}
+
+## Linked Operations Index
+
+- Parent Index: {{OPERATIONS_INDEX_URL}}
+- Canonical Page URL: {{CANONICAL_PAGE_URL}}
+
+---
+
+**⚓ Golden Armada** | *You ask - The Fleet Ships*

--- a/plugins/jira-orchestrator/templates/registry.json
+++ b/plugins/jira-orchestrator/templates/registry.json
@@ -84,7 +84,11 @@
       "description": "Confluence page templates",
       "templates": [
         {"name": "tdd", "file": "tdd.md.template", "required": true},
-        {"name": "runbook", "file": "runbook.md.template", "required": true}
+        {"name": "runbook", "file": "runbook.md.template", "required": true},
+        {"name": "release-status", "file": "release-status.md.template", "required": true},
+        {"name": "incident-timeline", "file": "incident-timeline.md.template", "required": true},
+        {"name": "rollback-log", "file": "rollback-log.md.template", "required": true},
+        {"name": "sla-breach-report", "file": "sla-breach-report.md.template", "required": true}
       ]
     },
     "helm": {

--- a/plugins/jira-orchestrator/tests/confluence-templates.test.ts
+++ b/plugins/jira-orchestrator/tests/confluence-templates.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const confluenceTemplateDir = path.resolve(__dirname, '../templates/confluence');
+
+const requiredPropertyKeys = ['issue-key', 'release', 'incident', 'env', 'service'];
+const templates = [
+  'release-status.md.template',
+  'incident-timeline.md.template',
+  'rollback-log.md.template',
+  'sla-breach-report.md.template',
+];
+
+const templateVariables: Record<string, string> = {
+  RELEASE_NAME: 'Q1 Hardening',
+  JIRA_KEY: 'OPS-42',
+  JIRA_URL: 'https://jira.example.com',
+  SERVICE_NAME: 'edge-gateway',
+  ENV: 'prod',
+  RELEASE_VERSION: '2026.03.1',
+  DATE: '2026-02-01',
+  INCIDENT_ID: 'INC-1001',
+  JIRA_PROJECT: 'OPS',
+  QUARTER: '2026-Q1',
+  RELEASE_SUMMARY: 'Release shipped with canary validation.',
+  BUILD_OWNER: 'build-bot',
+  BUILD_STATUS: 'done',
+  BUILD_ETA: '2026-02-01T10:00:00Z',
+  QA_OWNER: 'qa-team',
+  QA_STATUS: 'done',
+  QA_ETA: '2026-02-01T11:00:00Z',
+  DEPLOY_OWNER: 'sre',
+  DEPLOY_STATUS: 'in-progress',
+  DEPLOY_ETA: '2026-02-01T12:00:00Z',
+  RISKS_AND_MITIGATIONS: 'None open.',
+  OPERATIONS_INDEX_URL: 'https://confluence.example.com/ops-index',
+  CANONICAL_PAGE_URL: 'https://confluence.example.com/canonical',
+  SEVERITY: 'SEV-2',
+  INCIDENT_OPENED_AT: '2026-02-01T08:00:00Z',
+  T0: '2026-02-01T08:00:00Z',
+  T1: '2026-02-01T08:05:00Z',
+  T2: '2026-02-01T08:20:00Z',
+  T3: '2026-02-01T08:40:00Z',
+  DETECTED_BY: 'monitoring',
+  TRIAGE_OWNER: 'oncall',
+  MITIGATION_OWNER: 'sre',
+  RECOVERY_OWNER: 'incident-commander',
+  EVIDENCE_T0: 'Datadog alert #123',
+  EVIDENCE_T1: 'Slack timeline',
+  EVIDENCE_T2: 'Deploy rollback event',
+  EVIDENCE_T3: 'SLO recovered',
+  INCIDENT_IMPACT: 'Elevated 5xx for 8 minutes.',
+  ROLLBACK_STARTED_AT: '2026-02-01T08:15:00Z',
+  STEP_1_STATUS: 'done',
+  STEP_1_OWNER: 'oncall',
+  STEP_1_TIME: '2026-02-01T08:16:00Z',
+  STEP_2_STATUS: 'done',
+  STEP_2_OWNER: 'release-manager',
+  STEP_2_TIME: '2026-02-01T08:21:00Z',
+  STEP_3_STATUS: 'done',
+  STEP_3_OWNER: 'qa-team',
+  STEP_3_TIME: '2026-02-01T08:28:00Z',
+  STEP_4_STATUS: 'done',
+  STEP_4_OWNER: 'incident-commander',
+  STEP_4_TIME: '2026-02-01T08:35:00Z',
+  ROLLBACK_VALIDATION: 'Error rate returned under threshold.',
+  SLA_BREACH_ID: 'SLA-77',
+  SLA_POLICY_NAME: 'API Availability',
+  BREACH_START: '2026-02-01T08:00:00Z',
+  BREACH_END: '2026-02-01T08:09:00Z',
+  TARGET_SLA: '99.9%',
+  OBSERVED_SLA: '97.2%',
+  USER_IMPACT: 'Login failures for EU region.',
+  ROOT_CAUSE: 'Regression in auth cache invalidation.',
+  CORRECTIVE_ACTIONS: 'Rollback + added deployment guard.',
+};
+
+const renderTemplate = (template: string): string =>
+  template.replace(/{{([A-Z0-9_]+)}}/g, (_match, key: string) => templateVariables[key] ?? `{{${key}}}`);
+
+describe('confluence operations templates', () => {
+  it('include required page property keys in every operations template', () => {
+    for (const templateFile of templates) {
+      const raw = readFileSync(path.join(confluenceTemplateDir, templateFile), 'utf8');
+      for (const key of requiredPropertyKeys) {
+        expect(raw, `${templateFile} missing property key ${key}`).toContain(`| ${key} |`);
+      }
+    }
+  });
+
+  it('render without unresolved placeholders when provided fixture variables', () => {
+    for (const templateFile of templates) {
+      const raw = readFileSync(path.join(confluenceTemplateDir, templateFile), 'utf8');
+      const rendered = renderTemplate(raw);
+      expect(rendered).not.toMatch(/{{[A-Z0-9_]+}}/);
+      expect(rendered).toContain('⚓ Golden Armada');
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Standardize operational Confluence pages (release status, incident timeline, rollback log, SLA breach) with a consistent set of page property keys to enable reliable indexing and discovery.
- Ensure Jira comments reference canonical, indexed Confluence URLs (not ad-hoc editor links) and provide an index page per project/quarter for easy navigation. 
- Provide regression coverage for templates to prevent accidental removal of required metadata keys.

### Description

- Added four new Confluence templates under `plugins/jira-orchestrator/templates/confluence/`: `release-status.md.template`, `incident-timeline.md.template`, `rollback-log.md.template`, and `sla-breach-report.md.template`, each including page properties and label usage for the keys: `issue-key`, `release`, `incident`, `env`, and `service`.
- Updated `plugins/jira-orchestrator/agents/confluence-documentation-creator.md` to require writing/updating standardized page properties and labels on create/update and to document a generator step that builds/refreshes a project/quarter `Operations Index` parent page using CQL (`searchConfluenceUsingCql`) to discover child pages and persist canonical URLs.
- Updated `plugins/jira-orchestrator/commands/confluence.md` to require adding the standardized labels/page properties on create and to include canonical indexed page URLs + Operations Index URL when commenting on Jira issues.
- Reworked the Confluence comment template at `plugins/jira-orchestrator/templates/comments/confluence-linked.md.template` to prefer canonical indexed page and Operations Index links, and registered the new templates in `plugins/jira-orchestrator/templates/registry.json` so they are discoverable.
- Added `plugins/jira-orchestrator/tests/confluence-templates.test.ts` which verifies each new template contains the required page property keys and that rendering with a fixture set of variables produces no unresolved placeholders.

### Testing

- Ran the new template tests with `npx vitest run tests/confluence-templates.test.ts`, which passed (`2 tests` passed).
- Verified the changes are present in the template registry and documentation files by running the test command and inspecting the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e11fbfa80832a9ce974a3d728d349)