### PR TITLE
Add blocking Jira readiness gate for PR creation

### DIFF
--- a/plugins/jira-orchestrator/config/approvals.yaml
+++ b/plugins/jira-orchestrator/config/approvals.yaml
@@ -22,6 +22,78 @@ global:
       - "security_scan == 'passed'"
       - "no_breaking_changes == true"
 
+# Jira PR Readiness Gate Policies
+jira_readiness:
+  enabled: true
+  issue_link_template: "https://jira.example.com/browse/%{issue_key}"
+  pr_tool_patterns:
+    - "gh_pr_create"
+    - "mcp__github__create_pull_request"
+    - "mcp__make_pr__make_pr"
+    - "harness_create_pull_request"
+
+  # Baseline policy used when no team/project override exists.
+  default:
+    definition_of_ready_label: "definition-of-ready"
+    acceptance_criteria_fields:
+      - "customfield_10038"
+      - "acceptance_criteria"
+    required_fields_by_issue_type:
+      Story:
+        - assignee
+        - acceptance_criteria
+        - priority
+        - component
+        - sprint
+        - definition_of_ready_label
+      Task:
+        - assignee
+        - priority
+        - component
+        - sprint
+        - definition_of_ready_label
+      Bug:
+        - assignee
+        - priority
+        - component
+        - sprint
+      default:
+        - assignee
+        - priority
+
+  # Team-level overrides. Attach with JIRA_TEAM=<team-key>.
+  teams:
+    platform:
+      definition_of_ready_label: "platform-dor"
+      acceptance_criteria_fields:
+        - "customfield_10038"
+        - "customfield_10201"
+      required_fields_by_issue_type:
+        Story:
+          - assignee
+          - acceptance_criteria
+          - priority
+          - component
+          - sprint
+          - definition_of_ready_label
+
+  # Project-level overrides by Jira project key (e.g. PROJ-123).
+  projects:
+    ENG:
+      definition_of_ready_label: "eng-dor"
+      required_fields_by_issue_type:
+        Story:
+          - assignee
+          - acceptance_criteria
+          - priority
+          - component
+          - sprint
+          - definition_of_ready_label
+        Spike:
+          - assignee
+          - priority
+          - sprint
+
 # Approval Workflows
 workflows:
   # Standard Pull Request Approval

--- a/plugins/jira-orchestrator/hooks/hooks.json
+++ b/plugins/jira-orchestrator/hooks/hooks.json
@@ -67,6 +67,25 @@
       ]
     },
     {
+      "id": "pretooluse-jira-readiness-pr-gate",
+      "event": "PreToolUse",
+      "severity": "blocking",
+      "description": "Block PR creation until Jira Definition of Ready fields are complete.",
+      "trigger": {
+        "scope": "tool",
+        "command_patterns": [
+          "gh_pr_create|mcp__github__create_pull_request|mcp__make_pr__make_pr|harness_create_pull_request"
+        ]
+      },
+      "handlers": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/jira-readiness-gate.sh",
+          "timeout": 10000
+        }
+      ]
+    },
+    {
       "id": "stop-5",
       "event": "Stop",
       "severity": "advisory",

--- a/plugins/jira-orchestrator/hooks/scripts/jira-readiness-gate.sh
+++ b/plugins/jira-orchestrator/hooks/scripts/jira-readiness-gate.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Jira Readiness Gate
+# Blocks PR creation when required Jira fields are missing.
+
+set -euo pipefail
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$(dirname "$0")")")}" 
+CONFIG_PATH="${JIRA_APPROVALS_CONFIG:-$PLUGIN_ROOT/config/approvals.yaml}"
+
+HOOK_INPUT=""
+if [ ! -t 0 ]; then
+  HOOK_INPUT="$(cat || true)"
+fi
+export HOOK_INPUT
+
+ruby <<'RUBY'
+require 'yaml'
+require 'json'
+require 'open3'
+
+plugin_root = ENV['CLAUDE_PLUGIN_ROOT'] || File.expand_path('../..', __dir__)
+config_path = ENV['JIRA_APPROVALS_CONFIG'] || File.join(plugin_root, 'config', 'approvals.yaml')
+hook_input = ENV['HOOK_INPUT'] || ''
+
+unless File.exist?(config_path)
+  warn "❌ Jira readiness gate misconfigured: approvals config not found at #{config_path}"
+  exit 1
+end
+
+config = YAML.load_file(config_path) || {}
+readiness = config.fetch('jira_readiness', {})
+
+unless readiness.fetch('enabled', true)
+  puts 'JIRA_READINESS_SKIPPED: jira_readiness.enabled=false'
+  exit 0
+end
+
+input_json = {}
+begin
+  input_json = hook_input.strip.empty? ? {} : JSON.parse(hook_input)
+rescue JSON::ParserError
+  input_json = {}
+end
+
+tool_name = input_json['tool_name'] || input_json['tool'] || input_json['name'] || ENV['TOOL_NAME'] || ''
+pr_patterns = readiness.fetch('pr_tool_patterns', [])
+unless pr_patterns.empty?
+  matches = pr_patterns.any? { |p| Regexp.new(p).match?(tool_name.to_s) rescue false }
+  unless matches || tool_name.empty?
+    puts "JIRA_READINESS_SKIPPED: tool '#{tool_name}' is outside PR scope"
+    exit 0
+  end
+end
+
+issue_key_regex = /\b[A-Z][A-Z0-9]+-\d+\b/
+issue_key = ENV['JIRA_ISSUE_KEY']
+
+if issue_key.to_s.empty?
+  payload_text = [hook_input, input_json.dig('arguments').to_s, input_json.dig('input').to_s, input_json.dig('params').to_s].join(' ')
+  issue_key = payload_text[issue_key_regex]
+end
+
+if issue_key.to_s.empty?
+  branch, _ = Open3.capture2('git rev-parse --abbrev-ref HEAD')
+  issue_key = branch[issue_key_regex] if branch
+end
+
+if issue_key.to_s.empty?
+  warn '❌ Jira readiness gate could not determine a Jira issue key. Include issue key in branch name, tool payload, or set JIRA_ISSUE_KEY.'
+  exit 1
+end
+
+project_key = issue_key.split('-').first
+team_key = ENV['JIRA_TEAM']
+
+policy = readiness.fetch('default', {}).dup
+if team_key && readiness['teams'].is_a?(Hash) && readiness['teams'][team_key].is_a?(Hash)
+  policy.merge!(readiness['teams'][team_key])
+end
+if readiness['projects'].is_a?(Hash) && readiness['projects'][project_key].is_a?(Hash)
+  policy.merge!(readiness['projects'][project_key])
+end
+
+issue_json = nil
+if ENV['JIRA_ISSUE_JSON'] && !ENV['JIRA_ISSUE_JSON'].empty?
+  issue_json = JSON.parse(ENV['JIRA_ISSUE_JSON'])
+elsif ENV['JIRA_ISSUE_FILE'] && File.exist?(ENV['JIRA_ISSUE_FILE'])
+  issue_json = JSON.parse(File.read(ENV['JIRA_ISSUE_FILE']))
+elsif ENV['JIRA_BASE_URL'] && ENV['JIRA_API_TOKEN'] && ENV['JIRA_EMAIL']
+  url = "#{ENV['JIRA_BASE_URL'].sub(%r{/+$}, '')}/rest/api/3/issue/#{issue_key}?expand=names"
+  cmd = [
+    'curl', '-sS', '--fail',
+    '-u', "#{ENV['JIRA_EMAIL']}:#{ENV['JIRA_API_TOKEN']}",
+    '-H', 'Accept: application/json',
+    url
+  ]
+  stdout, stderr, status = Open3.capture3(*cmd)
+  unless status.success?
+    warn "❌ Jira readiness gate failed to fetch issue #{issue_key}: #{stderr.strip}"
+    exit 1
+  end
+  issue_json = JSON.parse(stdout)
+else
+  warn "❌ Jira readiness gate cannot fetch issue #{issue_key}. Set JIRA_ISSUE_JSON/JIRA_ISSUE_FILE for tests or Jira API credentials for live checks."
+  exit 1
+end
+
+fields = issue_json.fetch('fields', {})
+issue_type = fields.dig('issuetype', 'name') || 'default'
+required_map = policy.fetch('required_fields_by_issue_type', {})
+required_fields = required_map[issue_type] || required_map['default'] || []
+label_name = policy['definition_of_ready_label'] || 'definition-of-ready'
+acceptance_keys = policy['acceptance_criteria_fields'] || ['acceptance_criteria', 'customfield_acceptance_criteria']
+
+names = issue_json['names'] || {}
+missing = []
+
+required_fields.each do |field_name|
+  case field_name
+  when 'assignee'
+    missing << 'assignee' if fields['assignee'].nil?
+  when 'acceptance_criteria'
+    present = acceptance_keys.any? do |candidate|
+      direct = fields[candidate]
+      by_name_key = names.key(candidate)
+      by_name = by_name_key ? fields[by_name_key] : nil
+      [direct, by_name].compact.any? { |v| !v.to_s.strip.empty? }
+    end
+    # fallback: description contains acceptance criteria heading
+    unless present
+      description = fields['description']
+      present = description.to_s.match?(/acceptance criteria/i)
+    end
+    missing << "acceptance criteria (one of: #{acceptance_keys.join(', ')})" unless present
+  when 'priority'
+    missing << 'priority' if fields.dig('priority', 'name').to_s.strip.empty?
+  when 'component'
+    components = fields['components'] || []
+    missing << 'component' if !components.is_a?(Array) || components.empty?
+  when 'sprint'
+    sprint = fields['sprint']
+    if sprint.nil? && names.is_a?(Hash)
+      sprint_key = names.key('Sprint') || names.key('sprint')
+      sprint = fields[sprint_key] if sprint_key
+    end
+    missing << 'sprint' if sprint.nil? || (sprint.respond_to?(:empty?) && sprint.empty?)
+  when 'definition_of_ready_label'
+    labels = fields['labels'] || []
+    missing << "Definition of Ready label '#{label_name}'" unless labels.include?(label_name)
+  else
+    value = fields[field_name]
+    blank = value.nil? || (value.respond_to?(:empty?) && value.empty?) || value.to_s.strip.empty?
+    missing << field_name if blank
+  end
+end
+
+issue_link_template = readiness['issue_link_template'] || ENV['JIRA_BASE_URL']&.then { |base| "#{base.sub(%r{/+$}, '')}/browse/%{issue_key}" } || "https://jira.example.com/browse/%{issue_key}"
+issue_url = format(issue_link_template, issue_key: issue_key)
+
+if missing.empty?
+  puts "✅ Jira readiness check passed for #{issue_key} (#{issue_type})."
+  puts "Issue: #{issue_url}"
+  exit 0
+end
+
+warn "❌ Jira readiness check failed for #{issue_key} (#{issue_type})."
+warn "Issue: #{issue_url}"
+warn 'The following required fields are missing:'
+missing.each_with_index do |item, idx|
+  warn "  #{idx + 1}. #{item}"
+end
+warn ''
+warn 'How to fix:'
+warn "1) Open the Jira issue: #{issue_url}"
+warn '2) Populate the missing fields above.'
+warn '3) Re-run PR creation after updating Jira.'
+exit 1
+RUBY

--- a/plugins/jira-orchestrator/tests/hook-foundation/jira_readiness_gate.test.ts
+++ b/plugins/jira-orchestrator/tests/hook-foundation/jira_readiness_gate.test.ts
@@ -1,0 +1,104 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+describe('jira-readiness-gate hook', () => {
+  const pluginRoot = path.resolve(__dirname, '../..');
+  const scriptPath = path.join(pluginRoot, 'hooks', 'scripts', 'jira-readiness-gate.sh');
+
+  const baseIssue = {
+    key: 'ENG-123',
+    fields: {
+      issuetype: { name: 'Story' },
+      assignee: { accountId: 'abc' },
+      priority: { name: 'High' },
+      components: [{ name: 'Platform' }],
+      sprint: { id: 10, name: 'Sprint 10' },
+      labels: ['eng-dor'],
+      customfield_10038: 'Given/When/Then criteria',
+    },
+  };
+
+  const hookPayload = JSON.stringify({
+    tool_name: 'mcp__make_pr__make_pr',
+    input: { title: 'ENG-123 Add validator' },
+  });
+
+  function runGate(configContent: string, issue: unknown) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jira-readiness-'));
+    const configPath = path.join(tempDir, 'approvals.yaml');
+    fs.writeFileSync(configPath, configContent, 'utf8');
+
+    const result = spawnSync('bash', [scriptPath], {
+      input: hookPayload,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+        JIRA_APPROVALS_CONFIG: configPath,
+        JIRA_ISSUE_JSON: JSON.stringify(issue),
+      },
+    });
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    return result;
+  }
+
+  it('passes when all required fields are present', () => {
+    const config = `
+jira_readiness:
+  enabled: true
+  issue_link_template: "https://jira.example.com/browse/%{issue_key}"
+  default:
+    definition_of_ready_label: "definition-of-ready"
+    acceptance_criteria_fields: ["customfield_10038"]
+    required_fields_by_issue_type:
+      default: [assignee]
+  projects:
+    ENG:
+      definition_of_ready_label: "eng-dor"
+      required_fields_by_issue_type:
+        Story: [assignee, acceptance_criteria, priority, component, sprint, definition_of_ready_label]
+`;
+
+    const result = runGate(config, baseIssue);
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Jira readiness check passed/);
+  });
+
+  it('fails with actionable output when required fields are missing', () => {
+    const config = `
+jira_readiness:
+  enabled: true
+  issue_link_template: "https://jira.example.com/browse/%{issue_key}"
+  default:
+    definition_of_ready_label: "definition-of-ready"
+    acceptance_criteria_fields: ["customfield_10038"]
+    required_fields_by_issue_type:
+      Story: [assignee, acceptance_criteria, priority, component, sprint, definition_of_ready_label]
+`;
+
+    const issueMissing = {
+      ...baseIssue,
+      fields: {
+        ...baseIssue.fields,
+        assignee: null,
+        components: [],
+        labels: [],
+        customfield_10038: '',
+      },
+    };
+
+    const result = runGate(config, issueMissing);
+    assert.strictEqual(result.status, 1, result.stdout);
+    const output = `${result.stdout}\n${result.stderr}`;
+    assert.match(output, /The following required fields are missing:/);
+    assert.match(output, /assignee/);
+    assert.match(output, /acceptance criteria/);
+    assert.match(output, /component/);
+    assert.match(output, /Definition of Ready label/);
+    assert.match(output, /https:\/\/jira\.example\.com\/browse\/ENG-123/);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent PR creation when Jira issues are missing key readiness fields so PRs are opened only for work that meets team Definition of Ready requirements. 
- Make the readiness checks configurable per team, project and issue type so different workflows can enforce different fields. 
- Provide actionable, developer-facing feedback that points to the Jira issue and exactly which fields need to be filled to unblock PR creation.

### Description
- Add a new gate script `hooks/scripts/jira-readiness-gate.sh` that resolves the Jira issue key (from payload/env/branch), loads `jira_readiness` policy from `config/approvals.yaml`, fetches or accepts issue JSON via `JIRA_ISSUE_JSON`/`JIRA_ISSUE_FILE` or the Jira API, and validates required fields such as `assignee`, `acceptance_criteria`, `priority`, `component`, `sprint`, and the Definition of Ready label. 
- Wire the script into `hooks/hooks.json` as a blocking `PreToolUse` hook (`id: pretooluse-jira-readiness-pr-gate`) that triggers for PR creation tools (`gh_pr_create`, `mcp__github__create_pull_request`, `mcp__make_pr__make_pr`, `harness_create_pull_request`). 
- Extend `config/approvals.yaml` with a `jira_readiness` section that defines `pr_tool_patterns`, `issue_link_template`, `default` policy, `teams` overrides, `projects` overrides, `acceptance_criteria_fields` aliases, and `required_fields_by_issue_type` to allow customizable enforcement. 
- Add unit tests `tests/hook-foundation/jira_readiness_gate.test.ts` that exercise a passing scenario and a failing scenario (asserting actionable missing-field output and issue link) by invoking the script with `JIRA_ISSUE_JSON` and a temporary config file.

### Testing
- Ran the new unit tests with `npx vitest run tests/hook-foundation/jira_readiness_gate.test.ts`, and the tests passed (2 tests, 2 passed). 
- Verified the gate script syntax with `bash -n plugins/jira-orchestrator/hooks/scripts/jira-readiness-gate.sh`, which returned without errors. 
- Validated the modified hooks manifest with `jq . plugins/jira-orchestrator/hooks/hooks.json` to ensure JSON correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e14084694832a8ec07b691e6f38fb)