### PR TITLE
feat(jira-orchestrator): scaffold draft PRs on In Progress transitions

### DIFF
--- a/plugins/jira-orchestrator/commands/pr.md
+++ b/plugins/jira-orchestrator/commands/pr.md
@@ -74,6 +74,16 @@ mode:
 
 **Validate → Fetch Issue → Branch → Analyze Changes → Discover Confluence Docs → Generate PR (with Doc Links) → Push → Create PR → Update Jira**
 
+### Auto Draft Scaffolding Contract
+
+`/jira:work` transitioning an issue to **In Progress** should invoke this command in draft scaffolding mode.
+
+- Pre-fill draft PR body using Jira context (summary, description, acceptance criteria)
+- Create initial checklist from acceptance criteria
+- Keep checklist synced when key Jira fields update (summary/description/acceptance criteria/status)
+- Subsequent commits MUST append progress notes instead of replacing PR body
+- Respect per-issue opt-out label: `no-draft-pr`
+
 ## Quick Start
 
 ```bash

--- a/plugins/jira-orchestrator/commands/work.md
+++ b/plugins/jira-orchestrator/commands/work.md
@@ -119,6 +119,8 @@ pr_creation:
 
 1. **Validate & Fetch** - Get issue from Jira
 2. **Transition** - Set status to "In Progress"
+   - Trigger draft PR scaffolding via `commands/pr.md` unless issue has `no-draft-pr` label
+   - Pre-fill draft PR body with Jira context + initial checklist
 3. **Tag Management** - Apply domain/status/type tags
 4. **Sub-Issue Detection** - Find all subtasks/linked issues
 5. **Load PR Plan Artifact** - Read `.claude/orchestration/plans/{ISSUE-KEY}-plan.json`
@@ -134,6 +136,23 @@ pr_creation:
 15. **Commit & PR** - Smart commit with tracking
 16. **Jira Comments** - Post milestones: start, sub-count, agents, checkpoint updates, phase completions, PR, transitions, summary
 17. **Final Summary** - Audit trail with metrics
+
+## Draft PR Scaffolding on Work Start
+
+When an issue transitions to **In Progress**, orchestrator hooks should create a draft PR scaffold immediately.
+
+### Behavior
+
+- Source workflow: `/jira:work` transition event
+- PR generation command: `/jira:pr` in draft mode
+- Initial PR body content:
+  - Jira issue context (summary/description/labels)
+  - Initial acceptance checklist
+  - Progress notes section (append-only updates for later commits)
+
+### Opt-Out
+
+If issue contains label `no-draft-pr`, skip automatic draft PR creation and checklist sync.
 
 ## Success Criteria
 

--- a/plugins/jira-orchestrator/hooks/orchestration-hooks.json
+++ b/plugins/jira-orchestrator/hooks/orchestration-hooks.json
@@ -49,6 +49,11 @@
           "description": "Track time from commit timestamps",
           "enabled": false,
           "configurable": true
+        },
+        {
+          "name": "append-pr-progress-note",
+          "description": "If a draft PR scaffold exists, append commit progress notes to PR body progress section (never replace full body)",
+          "body_update_mode": "append"
         }
       ],
       "replaces_commands": [
@@ -136,6 +141,14 @@
         {
           "name": "fetch-context",
           "description": "Load related docs, PRs, commits"
+        },
+        {
+          "name": "create-draft-pr-scaffold",
+          "description": "When Jira status moves to In Progress, invoke commands/work.md + commands/pr.md draft scaffolding unless issue has no-draft-pr label",
+          "conditions": [
+            "status_transitioned_to_in_progress",
+            "label_not_present:no-draft-pr"
+          ]
         }
       ],
       "replaces_commands": [
@@ -243,6 +256,19 @@
       "replaces_commands": [
         "jira:transition",
         "jira:comment"
+      ]
+    },
+    "on-jira-update": {
+      "trigger": "When Jira issue summary/description/acceptance criteria/status changes",
+      "actions": [
+        {
+          "name": "sync-draft-pr-checklist",
+          "description": "Keep draft PR checklist in sync with Jira context for active draft PRs",
+          "conditions": [
+            "draft_pr_exists",
+            "label_not_present:no-draft-pr"
+          ]
+        }
       ]
     }
   },

--- a/plugins/jira-orchestrator/hooks/scripts/draft-pr-scaffold.ts
+++ b/plugins/jira-orchestrator/hooks/scripts/draft-pr-scaffold.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import {
+  DraftPrScaffoldingEngine,
+  type CommitProgressEvent,
+  type DraftPrScaffoldContext,
+  type JiraIssueUpdateEvent,
+  type JiraTransitionEvent,
+} from '../../lib/draft-pr-scaffolding-engine';
+
+type Payload =
+  | { eventType: 'jira-transition'; event: JiraTransitionEvent; context?: DraftPrScaffoldContext }
+  | { eventType: 'jira-update'; event: JiraIssueUpdateEvent; context?: DraftPrScaffoldContext }
+  | { eventType: 'commit-progress'; event: CommitProgressEvent; context?: DraftPrScaffoldContext };
+
+function readPayload(): Payload {
+  const arg = process.argv[2];
+  if (arg && arg.trim().startsWith('{')) {
+    return JSON.parse(arg) as Payload;
+  }
+
+  if (arg) {
+    return JSON.parse(readFileSync(arg, 'utf8')) as Payload;
+  }
+
+  const raw = readFileSync(0, 'utf8').trim();
+  if (!raw) {
+    throw new Error('Missing scaffold payload. Provide JSON via arg/file/stdin.');
+  }
+
+  return JSON.parse(raw) as Payload;
+}
+
+function main(): void {
+  const payload = readPayload();
+  const engine = new DraftPrScaffoldingEngine();
+
+  if (payload.eventType === 'jira-transition') {
+    process.stdout.write(`${JSON.stringify(engine.shouldCreateDraftPr(payload.event, payload.context))}\n`);
+    return;
+  }
+
+  if (payload.eventType === 'jira-update') {
+    process.stdout.write(`${JSON.stringify(engine.shouldSyncChecklist(payload.event, payload.context))}\n`);
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(engine.appendProgressFromCommit(payload.event, payload.context))}\n`);
+}
+
+main();

--- a/plugins/jira-orchestrator/lib/draft-pr-scaffolding-engine.ts
+++ b/plugins/jira-orchestrator/lib/draft-pr-scaffolding-engine.ts
@@ -1,0 +1,129 @@
+export interface JiraIssueContext {
+  issueKey: string;
+  summary: string;
+  description?: string;
+  labels?: string[];
+  acceptanceCriteria?: string[];
+  status?: string;
+}
+
+export interface JiraTransitionEvent {
+  issue: JiraIssueContext;
+  fromStatus?: string;
+  toStatus: string;
+  occurredAt: string;
+}
+
+export interface JiraIssueUpdateEvent {
+  issue: JiraIssueContext;
+  changedFields: string[];
+  occurredAt: string;
+}
+
+export interface CommitProgressEvent {
+  issueKey: string;
+  commitSha: string;
+  commitMessage: string;
+  author?: string;
+  occurredAt: string;
+}
+
+export interface DraftPrScaffoldContext {
+  draftPrNumber?: number;
+  draftPrBody?: string;
+}
+
+export interface DraftPrAction {
+  type: 'create_draft_pr' | 'sync_checklist' | 'append_progress_note' | 'noop';
+  issueKey: string;
+  reason?: string;
+  title?: string;
+  body?: string;
+  bodyUpdateMode?: 'replace' | 'append';
+  sourceCommands?: string[];
+}
+
+const OPT_OUT_LABEL = 'no-draft-pr';
+const KEY_UPDATE_FIELDS = new Set(['summary', 'description', 'acceptanceCriteria', 'status']);
+
+export class DraftPrScaffoldingEngine {
+  shouldCreateDraftPr(event: JiraTransitionEvent, context: DraftPrScaffoldContext = {}): DraftPrAction {
+    const labels = event.issue.labels ?? [];
+    if (labels.some((label) => label.toLowerCase() === OPT_OUT_LABEL)) {
+      return { type: 'noop', issueKey: event.issue.issueKey, reason: 'opted_out_by_label' };
+    }
+
+    if (context.draftPrNumber) {
+      return { type: 'noop', issueKey: event.issue.issueKey, reason: 'draft_pr_already_exists' };
+    }
+
+    if (event.toStatus !== 'In Progress') {
+      return { type: 'noop', issueKey: event.issue.issueKey, reason: 'not_in_progress_transition' };
+    }
+
+    return {
+      type: 'create_draft_pr',
+      issueKey: event.issue.issueKey,
+      title: `[DRAFT] ${event.issue.issueKey}: ${event.issue.summary}`,
+      body: this.renderDraftBody(event.issue),
+      bodyUpdateMode: 'replace',
+      sourceCommands: ['plugins/jira-orchestrator/commands/work.md', 'plugins/jira-orchestrator/commands/pr.md'],
+    };
+  }
+
+  shouldSyncChecklist(event: JiraIssueUpdateEvent, context: DraftPrScaffoldContext = {}): DraftPrAction {
+    if (!context.draftPrNumber) {
+      return { type: 'noop', issueKey: event.issue.issueKey, reason: 'no_draft_pr' };
+    }
+
+    const labels = event.issue.labels ?? [];
+    if (labels.some((label) => label.toLowerCase() === OPT_OUT_LABEL)) {
+      return { type: 'noop', issueKey: event.issue.issueKey, reason: 'opted_out_by_label' };
+    }
+
+    const hasKeyUpdate = event.changedFields.some((field) => KEY_UPDATE_FIELDS.has(field));
+    if (!hasKeyUpdate) {
+      return { type: 'noop', issueKey: event.issue.issueKey, reason: 'no_key_fields_changed' };
+    }
+
+    return {
+      type: 'sync_checklist',
+      issueKey: event.issue.issueKey,
+      body: this.renderChecklist(event.issue),
+      bodyUpdateMode: 'replace',
+      reason: 'jira_context_updated',
+    };
+  }
+
+  appendProgressFromCommit(event: CommitProgressEvent, context: DraftPrScaffoldContext = {}): DraftPrAction {
+    if (!context.draftPrNumber) {
+      return { type: 'noop', issueKey: event.issueKey, reason: 'no_draft_pr' };
+    }
+
+    return {
+      type: 'append_progress_note',
+      issueKey: event.issueKey,
+      bodyUpdateMode: 'append',
+      body: `\n- ${event.occurredAt}: ${event.commitSha.slice(0, 8)} — ${event.commitMessage}${event.author ? ` (by ${event.author})` : ''}`,
+      reason: 'commit_progress',
+    };
+  }
+
+  private renderDraftBody(issue: JiraIssueContext): string {
+    const checklist = this.renderChecklist(issue);
+    return `## Jira Context\n- Issue: ${issue.issueKey}\n- Summary: ${issue.summary}\n- Status: ${issue.status ?? 'In Progress'}\n\n## Description\n${issue.description?.trim() || '_No description provided._'}\n\n${checklist}\n\n## Progress Notes\n- Draft PR scaffolding created from /jira:work transition to In Progress.`;
+  }
+
+  private renderChecklist(issue: JiraIssueContext): string {
+    const criteria = issue.acceptanceCriteria?.length
+      ? issue.acceptanceCriteria
+      : ['Clarify acceptance criteria in Jira issue'];
+
+    const lines = criteria.map((criterion, index) => `- [ ] AC${index + 1}: ${criterion}`);
+    return `## Initial Checklist\n${lines.join('\n')}`;
+  }
+}
+
+export const DraftPrScaffoldingConstants = {
+  optOutLabel: OPT_OUT_LABEL,
+};

--- a/plugins/jira-orchestrator/tests/integration-contracts/draft-pr-scaffolding-engine.test.ts
+++ b/plugins/jira-orchestrator/tests/integration-contracts/draft-pr-scaffolding-engine.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { DraftPrScaffoldingConstants, DraftPrScaffoldingEngine } from '../../lib/draft-pr-scaffolding-engine';
+
+describe('draft pr scaffolding engine', () => {
+  it('creates draft PR scaffolding exactly when issue transitions to In Progress', () => {
+    const engine = new DraftPrScaffoldingEngine();
+
+    const todoTransition = engine.shouldCreateDraftPr({
+      issue: {
+        issueKey: 'PROJ-201',
+        summary: 'Add auto draft PR',
+        acceptanceCriteria: ['Draft PR created on work start'],
+      },
+      fromStatus: 'Backlog',
+      toStatus: 'To Do',
+      occurredAt: '2026-02-01T10:00:00.000Z',
+    });
+
+    const inProgressTransition = engine.shouldCreateDraftPr({
+      issue: {
+        issueKey: 'PROJ-201',
+        summary: 'Add auto draft PR',
+        description: 'Scaffold PR body from Jira context',
+        acceptanceCriteria: ['Draft PR created on work start', 'Checklist prefilled from Jira'],
+      },
+      fromStatus: 'To Do',
+      toStatus: 'In Progress',
+      occurredAt: '2026-02-01T10:05:00.000Z',
+    });
+
+    expect(todoTransition.type).toBe('noop');
+    expect(todoTransition.reason).toBe('not_in_progress_transition');
+
+    expect(inProgressTransition.type).toBe('create_draft_pr');
+    expect(inProgressTransition.title).toContain('PROJ-201');
+    expect(inProgressTransition.body).toContain('## Jira Context');
+    expect(inProgressTransition.body).toContain('## Initial Checklist');
+    expect(inProgressTransition.sourceCommands).toEqual([
+      'plugins/jira-orchestrator/commands/work.md',
+      'plugins/jira-orchestrator/commands/pr.md',
+    ]);
+  });
+
+  it('syncs checklist when key Jira fields change and appends commit progress notes', () => {
+    const engine = new DraftPrScaffoldingEngine();
+
+    const sync = engine.shouldSyncChecklist(
+      {
+        issue: {
+          issueKey: 'PROJ-202',
+          summary: 'Keep checklist in sync',
+          acceptanceCriteria: ['Sync on acceptance criteria updates', 'Sync on description updates'],
+        },
+        changedFields: ['acceptanceCriteria'],
+        occurredAt: '2026-02-01T11:00:00.000Z',
+      },
+      { draftPrNumber: 77 },
+    );
+
+    const append = engine.appendProgressFromCommit(
+      {
+        issueKey: 'PROJ-202',
+        commitSha: 'abcdef1234567890',
+        commitMessage: 'Add checklist sync handler',
+        author: 'Dev User',
+        occurredAt: '2026-02-01T11:15:00.000Z',
+      },
+      { draftPrNumber: 77 },
+    );
+
+    expect(sync.type).toBe('sync_checklist');
+    expect(sync.bodyUpdateMode).toBe('replace');
+    expect(sync.body).toContain('AC1');
+
+    expect(append.type).toBe('append_progress_note');
+    expect(append.bodyUpdateMode).toBe('append');
+    expect(append.body).toContain('abcdef12');
+  });
+
+  it('respects no-draft-pr opt-out label for creation and sync', () => {
+    const engine = new DraftPrScaffoldingEngine();
+
+    const create = engine.shouldCreateDraftPr({
+      issue: {
+        issueKey: 'PROJ-203',
+        summary: 'Skip draft PR',
+        labels: [DraftPrScaffoldingConstants.optOutLabel],
+      },
+      fromStatus: 'To Do',
+      toStatus: 'In Progress',
+      occurredAt: '2026-02-01T12:00:00.000Z',
+    });
+
+    const sync = engine.shouldSyncChecklist(
+      {
+        issue: {
+          issueKey: 'PROJ-203',
+          summary: 'Skip draft PR',
+          labels: [DraftPrScaffoldingConstants.optOutLabel],
+        },
+        changedFields: ['summary'],
+        occurredAt: '2026-02-01T12:05:00.000Z',
+      },
+      { draftPrNumber: 88 },
+    );
+
+    expect(create.type).toBe('noop');
+    expect(create.reason).toBe('opted_out_by_label');
+    expect(sync.type).toBe('noop');
+    expect(sync.reason).toBe('opted_out_by_label');
+  });
+});


### PR DESCRIPTION
### Motivation

- Automate early pull-request scaffolding when work starts so engineers have a pre-filled draft PR (context + checklist) and progress notes for the lifecycle. 
- Keep PR checklists in sync with Jira canonical data and ensure subsequent commits append progress notes instead of overwriting the PR body. 
- Allow teams to opt out per-issue with a label (`no-draft-pr`).

### Description

- Add a decision engine `DraftPrScaffoldingEngine` that decides when to: create a draft PR scaffold, sync the checklist, or append commit progress notes; supports opt-out label `no-draft-pr` (new file `lib/draft-pr-scaffolding-engine.ts`).
- Add a hook script entrypoint `hooks/scripts/draft-pr-scaffold.ts` that accepts `jira-transition`, `jira-update`, and `commit-progress` payloads and routes them to the engine.
- Update orchestration hooks to invoke the scaffold flow on work start and to append-only post-commit PR progress notes via `hooks/orchestration-hooks.json`.
- Update command docs to declare the contract: `commands/work.md` now documents auto-draft scaffolding on transition to `In Progress`, and `commands/pr.md` documents the draft scaffolding contract and append-only progress note behavior.
- Add integration-contract tests `tests/integration-contracts/draft-pr-scaffolding-engine.test.ts` that assert creation timing, checklist sync behavior, append-only commit progress updates, and opt-out handling.

### Testing

- Ran the new integration tests with Vitest: `cd plugins/jira-orchestrator && npx vitest run tests/integration-contracts/draft-pr-scaffolding-engine.test.ts tests/integration-contracts/pr-jira-transition-engine.test.ts` and all tests passed.
- Test summary: 2 test files executed, 7 tests total, all 7 passed.
- The tests cover: draft PR creation timing on `In Progress` transition, checklist sync when key Jira fields change, append behavior for commit progress notes, and respecting the `no-draft-pr` opt-out label.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e16e4ea00832aa970b39003543381)