### PR TITLE
Add Draw.io Diagramming skill pack to marketplace catalog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -384,6 +384,35 @@
         "fingerprinting",
         "heatmap"
       ]
+    },
+    {
+      "name": "drawio-diagramming",
+      "description": "Intelligent draw.io diagramming plugin with AI-powered diagram generation, multi-platform embedding (GitHub, Confluence, Azure DevOps, Notion, Teams, Harness), conditional formatting, live data binding, and MCP server integration. 13 commands, 6 agents, 10 skills.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Markus Ahling"
+      },
+      "source": "./plugins/drawio-diagramming",
+      "category": "diagramming",
+      "tags": [
+        "drawio",
+        "diagrams",
+        "draw.io",
+        "flowchart",
+        "uml",
+        "bpmn",
+        "c4",
+        "architecture",
+        "network",
+        "cloud",
+        "kubernetes",
+        "wireframe",
+        "mcp",
+        "ai-diagrams",
+        "conditional-formatting",
+        "live-data",
+        "embedding"
+      ]
     }
   ]
 }

--- a/.claude/rules/lessons-learned.md
+++ b/.claude/rules/lessons-learned.md
@@ -1141,3 +1141,27 @@ cat /root/.config/gh/config.yml 2>/dev/null`
 - **Input:** `/root/.claude/projects/-home-user-claude/memory/MEMORY.md`
 - **Error:** File does not exist. Note: your current working directory is /home/user/claude.
 - **Status:** NEEDS_FIX - Claude should document the fix here after resolving
+
+### Error: Bash failure (2026-03-16T02:09:58Z)
+- **Tool:** Bash
+- **Input:** `python3 -c "
+import json
+d = json.load(open('/home/user/claude/.claude/registry/index.json'))
+# Check if drawio appears in quickLookup
+ql = d.get('quickLookup', {})
+drawio_triggers = {k: v for k, v in ql.get('byTrigger', {}).items() if 'drawio' in v.lower() or 'draw' in k.lower() or 'diagram' in k.lower()}
+print('=== drawio triggers in quickLookup ===')
+print(json.dumps(drawio_triggers, indent=2))
+print()
+# check categories
+cats = d.get('categories', {})
+print('=== categories ===')
+for cat, items in cats.items():
+    print(f'{cat}: {list(items.keys())[:5]}')
+" 2>/dev/null`
+- **Error:** Exit code 1
+=== drawio triggers in quickLookup ===
+{}
+
+=== categories ===
+- **Status:** NEEDS_FIX - Claude should document the fix here after resolving

--- a/plugins/cowork-marketplace/catalog.json
+++ b/plugins/cowork-marketplace/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Cowork marketplace item catalog. All items are backed by real plugin agents, skills, and commands.",
-  "totalItems": 17,
+  "totalItems": 18,
   "items": [
     {
       "id": "fastapi-scaffold",
@@ -688,6 +688,67 @@
           ],
           "commands": [
             "theme"
+          ]
+        }
+      }
+    },
+    {
+      "id": "drawio-diagramming",
+      "name": "Draw.io Diagramming",
+      "type": "skill_pack",
+      "category": "design",
+      "difficulty": "beginner",
+      "description": "AI-powered draw.io diagramming with 196 diagram types, multi-platform embedding (GitHub, Confluence, Azure DevOps, Notion, Teams, Harness), conditional formatting, live data binding, and MCP integration.",
+      "tags": [
+        "drawio",
+        "diagrams",
+        "flowchart",
+        "uml",
+        "architecture",
+        "c4",
+        "bpmn",
+        "wireframe",
+        "mcp",
+        "embedding"
+      ],
+      "rating": 4.7,
+      "trustGrade": "A",
+      "pluginBindings": {
+        "drawio-diagramming": {
+          "agents": [
+            "diagram-architect",
+            "integration-specialist",
+            "style-engineer",
+            "data-connector",
+            "auto-documenter",
+            "enrichment-researcher"
+          ],
+          "skills": [
+            "xml-generation",
+            "diagram-types",
+            "platform-integrations",
+            "conditional-formatting",
+            "ai-generation",
+            "mcp-integration",
+            "diagram-catalog",
+            "wireframes-mockups",
+            "data-structures",
+            "network-software-mapping"
+          ],
+          "commands": [
+            "create",
+            "edit",
+            "embed",
+            "export",
+            "analyze",
+            "template",
+            "style",
+            "layers",
+            "data-bind",
+            "auto-diagram",
+            "batch",
+            "mcp-setup",
+            "enrich"
           ]
         }
       }


### PR DESCRIPTION
## Summary
This PR adds the Draw.io Diagramming skill pack to the cowork marketplace catalog and plugin registry, enabling AI-powered diagram generation with support for 196 diagram types and multi-platform embedding.

## Key Changes
- **Catalog Update**: Added new "drawio-diagramming" skill pack entry to `plugins/cowork-marketplace/catalog.json` with comprehensive metadata including:
  - 6 specialized agents (diagram-architect, integration-specialist, style-engineer, data-connector, auto-documenter, enrichment-researcher)
  - 10 skills covering XML generation, diagram types, platform integrations, conditional formatting, and data binding
  - 13 commands for diagram creation, editing, embedding, export, and automation
  - Support for GitHub, Confluence, Azure DevOps, Notion, Teams, and Harness embedding
  - Rating of 4.7 with "A" trust grade

- **Plugin Registry**: Added corresponding entry to `.claude-plugin/marketplace.json` with plugin metadata, author information (Markus Ahling), and expanded tag set for discoverability

- **Documentation**: Updated `.claude/rules/lessons-learned.md` to log a bash execution error encountered during registry validation

## Implementation Details
- The skill pack is categorized as "design" with "beginner" difficulty level
- Includes MCP (Model Context Protocol) integration support
- Comprehensive tag coverage includes diagram types (flowchart, UML, BPMN, C4), platforms, and features (conditional-formatting, live-data, embedding)
- Total marketplace items incremented from 17 to 18

https://claude.ai/code/session_01XLg274c7BiwRjTBjgHi9DJ