### PR TITLE
Add desktop integration support for draw.io desktop app

### DIFF
--- a/plugins/drawio-diagramming/.claude-plugin/plugin.json
+++ b/plugins/drawio-diagramming/.claude-plugin/plugin.json
@@ -42,6 +42,11 @@
     "harness",
     "azure-devops",
     "mcp",
-    "vibe-diagramming"
+    "vibe-diagramming",
+    "desktop",
+    "electron",
+    "drawio-desktop",
+    "visual-editor",
+    "wsl"
   ]
 }

--- a/plugins/drawio-diagramming/CLAUDE.md
+++ b/plugins/drawio-diagramming/CLAUDE.md
@@ -4,11 +4,55 @@
 Intelligent diagramming plugin powered by draw.io / diagrams.net. Generates production-quality diagrams with AI assistance, embeds them across 7+ platforms, and supports conditional formatting linked to live data and statuses.
 
 ## Architecture
-- **Commands**: 13 slash commands for diagram lifecycle (create, edit, embed, export, analyze, template, style, layers, data-bind, auto-diagram, batch, mcp-setup, enrich) — each with comprehensive flag system (237 flags total)
+- **Commands**: 14 slash commands for diagram lifecycle (create, edit, embed, export, **open**, analyze, template, style, layers, data-bind, auto-diagram, batch, mcp-setup, enrich) — each with comprehensive flag system (247+ flags total)
 - **Agents**: 6 specialized agents (diagram-architect, integration-specialist, style-engineer, data-connector, auto-documenter, enrichment-researcher)
-- **Skills**: 10 knowledge domains:
+- **Skills**: 11 knowledge domains:
   - Core: XML generation, diagram types, platform integrations, conditional formatting, AI generation, MCP integration
   - Extended: **diagram-catalog** (196 diagram types), **wireframes-mockups** (UI/UX), **data-structures** (CS visualizations), **network-software-mapping** (infra/architecture)
+  - Desktop: **desktop-integration** (draw.io desktop app, OS detection, CLI export, file watching)
+
+## Desktop Support (Claude Code Desktop)
+
+This plugin works on both Claude Code web and Claude Code desktop. On desktop,
+the draw.io desktop application (Electron) provides visual editing alongside
+AI-powered generation.
+
+### Quick Start (Desktop)
+
+```bash
+# Create a diagram and open it in the desktop editor
+drawio:create --type c4 --analyze src/ --output docs/architecture.drawio --open
+
+# Open an existing diagram for visual editing
+drawio:open --file docs/architecture.drawio
+
+# Export and open the result
+drawio:export docs/architecture.drawio --format svg --embed-diagram --open
+```
+
+### Desktop App Installation
+
+| Platform | Command |
+|----------|---------|
+| **macOS** | `brew install --cask drawio` |
+| **Linux (snap)** | `sudo snap install drawio` |
+| **Linux (deb)** | `sudo dpkg -i drawio-amd64-*.deb` |
+| **Windows** | `winget install JGraph.Draw` |
+
+### Iterative AI + Human Workflow
+
+1. AI generates diagram XML → `drawio:create --open`
+2. User refines visually in draw.io desktop → saves
+3. AI detects changes → `drawio:enrich` or `drawio:edit` to further improve
+4. Desktop auto-reloads the updated file
+
+### WSL Support
+
+When running Claude Code in WSL, the plugin detects this and opens diagrams
+in the Windows draw.io app automatically.
+
+See `skills/desktop-integration/SKILL.md` for full platform detection, CLI
+reference, and troubleshooting.
 
 ## MCP Server Integration
 This plugin supports two draw.io MCP servers:

--- a/plugins/drawio-diagramming/commands/create.md
+++ b/plugins/drawio-diagramming/commands/create.md
@@ -53,6 +53,7 @@ multiple output formats.
 | `--interactive` | `-i` | boolean | `false` | Prompt for confirmation at each generation step |
 | `--verbose` | `-v` | boolean | `false` | Show detailed processing output |
 | `--dry-run` | `-n` | boolean | `false` | Preview what would be created without writing files |
+| `--open` | `-O` | boolean | `false` | Open the created diagram in draw.io desktop app after generation |
 | `--overwrite` | | boolean | `false` | Overwrite existing file without prompting |
 
 ### Flag Details
@@ -79,6 +80,7 @@ multiple output formats.
 - **`--dry-run`** (`-n`): Preview the diagram type, element count, and output path without creating any files. Useful for validating auto-detection.
 - **`--verbose`** (`-v`): Show step-by-step processing: context analysis, type selection, template resolution, XML generation, and export.
 - **`--interactive`** (`-i`): Pause after type selection and style application to allow manual overrides before writing.
+- **`--open`** (`-O`): After creating the `.drawio` file, open it in the draw.io desktop application for visual editing. Auto-detects the editor on macOS, Linux, and Windows (including WSL). Falls back to the browser editor at `https://app.diagrams.net` if the desktop app is not installed. See `drawio:open` for editor detection details.
 - **`--overwrite`**: Skip the confirmation prompt when the output file already exists.
 
 #### Examples with Flags

--- a/plugins/drawio-diagramming/commands/export.md
+++ b/plugins/drawio-diagramming/commands/export.md
@@ -60,6 +60,7 @@ Mermaid.js for text-based diagram portability.
 | `--page-width <in>` | | number | auto | PDF page width in inches |
 | `--page-height <in>` | | number | auto | PDF page height in inches |
 | `--export` | | boolean | `true` | Explicit export flag (used by draw.io CLI) |
+| `--open` | `-O` | boolean | `false` | Open the exported file in the default viewer or draw.io desktop after export |
 | `--verbose` | `-v` | boolean | `false` | Show detailed export progress and file sizes |
 | `--dry-run` | `-n` | boolean | `false` | Preview export operations without writing files |
 
@@ -94,6 +95,9 @@ Mermaid.js for text-based diagram portability.
 - **`--include <glob>`**: File pattern for batch mode. Default `*.drawio`. Example: `--include "docs/**/*.drawio"`.
 - **`--ci`**: Headless operation mode. Suppresses interactive prompts, uses xvfb wrapper automatically, returns non-zero exit code on failure.
 - **`--no-sandbox`**: Required in Docker containers and some CI runners where Chromium sandboxing is not available.
+
+#### Desktop Integration Flags
+- **`--open`** (`-O`): After exporting, open the output file. For `.drawio` and `.drawio.svg` files, opens in draw.io desktop. For `.png`, `.pdf`, and `.svg` files, opens in the OS default viewer. Auto-detects platform (macOS `open`, Linux `xdg-open`, Windows `start`). See `drawio:open` for details.
 
 #### Examples with Flags
 

--- a/plugins/drawio-diagramming/commands/index.json
+++ b/plugins/drawio-diagramming/commands/index.json
@@ -135,6 +135,20 @@
       "path": "commands/layers.md"
     },
     {
+      "name": "drawio:open",
+      "intent": "Open draw.io diagrams in the desktop application or browser editor",
+      "tags": [
+        "drawio-diagramming",
+        "command",
+        "open",
+        "desktop"
+      ],
+      "inputs": [],
+      "risk": "low",
+      "cost": "low",
+      "path": "commands/open.md"
+    },
+    {
       "name": "drawio:mcp-setup",
       "intent": "Configure draw.io MCP servers for AI-powered diagramming",
       "tags": [

--- a/plugins/drawio-diagramming/commands/open.md
+++ b/plugins/drawio-diagramming/commands/open.md
@@ -1,0 +1,357 @@
+---
+name: drawio:open
+intent: Open draw.io diagrams in the desktop application or browser editor
+tags:
+  - drawio-diagramming
+  - command
+  - open
+  - desktop
+inputs: []
+risk: low
+cost: low
+description: >
+  Opens .drawio diagram files in the draw.io desktop application (Electron) or
+  falls back to the browser-based editor at app.diagrams.net. Supports OS
+  detection (macOS, Windows, Linux), custom editor paths, file watching for
+  live reload, and opening specific pages within multi-page diagrams. Essential
+  for desktop Claude Code workflows where users want visual editing alongside
+  AI-powered generation.
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+---
+
+# drawio:open — Open Diagrams in Desktop Editor
+
+## Overview
+
+Opens `.drawio` files in the draw.io desktop application for visual editing. When
+the desktop app is not installed, falls back to the browser editor at
+`https://app.diagrams.net`. Designed for Claude Code desktop workflows where the
+AI generates or edits diagram XML and the user wants to immediately see and
+refine the result visually.
+
+## Flags
+
+| Flag | Alias | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--file <path>` | `-f` | string | none | Path to the .drawio file to open |
+| `--page <n>` | `-p` | number | `0` | Zero-based page index to open (for multi-page diagrams) |
+| `--editor <path>` | `-e` | string | auto-detect | Custom path to the draw.io desktop executable |
+| `--browser` | `-b` | boolean | `false` | Force open in browser editor instead of desktop app |
+| `--watch` | `-w` | boolean | `false` | Watch the file for changes and report back to the conversation |
+| `--new-window` | `-N` | boolean | `false` | Open in a new window instead of reusing existing |
+| `--verbose` | `-v` | boolean | `false` | Show detection steps and editor path resolution |
+| `--dry-run` | `-n` | boolean | `false` | Show what would be opened without launching the editor |
+
+### Flag Details
+
+#### File Selection
+- **`--file <path>`** (`-f`): Path to the `.drawio` file. If omitted, searches the
+  current directory for `.drawio` files. If exactly one is found, opens it; if
+  multiple are found, lists them and asks for selection.
+- **`--page <n>`** (`-p`): For multi-page diagrams, open a specific page. The desktop
+  app supports page selection via command-line on some platforms.
+
+#### Editor Configuration
+- **`--editor <path>`** (`-e`): Override the auto-detected editor path. Useful when
+  draw.io is installed in a non-standard location.
+- **`--browser`** (`-b`): Skip desktop app detection and open in the default browser
+  at `https://app.diagrams.net`. The file is loaded via a `file://` URL or the
+  user manually loads it.
+- **`--new-window`** (`-N`): Force a new window. By default, the desktop app reuses
+  existing windows.
+
+#### Monitoring
+- **`--watch`** (`-w`): After opening, watch the file for modifications. When the
+  user saves changes in the desktop editor, report the changes back. Useful for
+  an iterative workflow: AI generates → user refines visually → AI picks up changes.
+
+## Execution Flow
+
+### Step 1: Detect Operating System
+
+```bash
+# Detect OS
+OS="$(uname -s)"
+case "$OS" in
+    Darwin)  PLATFORM="macos" ;;
+    Linux)   PLATFORM="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) PLATFORM="windows" ;;
+    *)       PLATFORM="unknown" ;;
+esac
+
+# For Windows detection in non-MSYS environments
+if [[ -n "${USERPROFILE:-}" ]] || [[ -d "/mnt/c/Users" ]]; then
+    PLATFORM="windows"
+fi
+```
+
+### Step 2: Locate draw.io Desktop Application
+
+```bash
+# macOS
+MACOS_PATHS=(
+    "/Applications/draw.io.app/Contents/MacOS/draw.io"
+    "$HOME/Applications/draw.io.app/Contents/MacOS/draw.io"
+)
+
+# Linux
+LINUX_PATHS=(
+    "/usr/bin/drawio"
+    "/usr/local/bin/drawio"
+    "/snap/bin/drawio"
+    "/opt/drawio/drawio"
+    "$HOME/.local/bin/drawio"
+)
+
+# Windows (from WSL or native)
+WINDOWS_PATHS=(
+    "/mnt/c/Program Files/draw.io/draw.io.exe"
+    "$LOCALAPPDATA/Programs/draw.io/draw.io.exe"
+    "$PROGRAMFILES/draw.io/draw.io.exe"
+)
+
+# Check each path for the detected platform
+find_drawio() {
+    local paths=()
+    case "$PLATFORM" in
+        macos)   paths=("${MACOS_PATHS[@]}") ;;
+        linux)   paths=("${LINUX_PATHS[@]}") ;;
+        windows) paths=("${WINDOWS_PATHS[@]}") ;;
+    esac
+
+    for p in "${paths[@]}"; do
+        if [[ -x "$p" ]] || [[ -f "$p" ]]; then
+            echo "$p"
+            return 0
+        fi
+    done
+
+    # Try PATH lookup
+    if command -v drawio &>/dev/null; then
+        command -v drawio
+        return 0
+    fi
+
+    return 1
+}
+```
+
+### Step 3: Open the Diagram
+
+```bash
+# Desktop app available
+open_desktop() {
+    local file="$1"
+    local editor="$2"
+
+    case "$PLATFORM" in
+        macos)
+            open -a "draw.io" "$file" 2>/dev/null || "$editor" "$file" &
+            ;;
+        linux)
+            "$editor" "$file" &
+            ;;
+        windows)
+            # From WSL
+            if [[ -f "/mnt/c/Program Files/draw.io/draw.io.exe" ]]; then
+                cmd.exe /C "start \"\" \"$(wslpath -w "$file")\"" 2>/dev/null
+            else
+                "$editor" "$file" &
+            fi
+            ;;
+    esac
+}
+
+# Browser fallback
+open_browser() {
+    local file="$1"
+    local url="https://app.diagrams.net/"
+
+    case "$PLATFORM" in
+        macos)   open "$url" ;;
+        linux)   xdg-open "$url" 2>/dev/null || sensible-browser "$url" ;;
+        windows) cmd.exe /C "start $url" 2>/dev/null || explorer.exe "$url" ;;
+    esac
+
+    echo "Browser opened at $url"
+    echo "Load your file manually: $file"
+    echo ""
+    echo "Tip: Install draw.io desktop for seamless opening:"
+    echo "  macOS:  brew install --cask drawio"
+    echo "  Linux:  sudo snap install drawio"
+    echo "  Windows: winget install JGraph.Draw"
+}
+```
+
+### Step 4: MCP Tool Server Integration
+
+When the `@drawio/mcp` Tool Server is configured, prefer using its `open_diagram`
+tool for the most reliable desktop integration:
+
+```json
+{
+  "tool": "open_diagram",
+  "arguments": {
+    "path": "/absolute/path/to/diagram.drawio"
+  }
+}
+```
+
+The MCP Tool Server handles editor detection internally and works across all
+platforms. Check if the MCP server is available before falling back to direct
+CLI invocation.
+
+### Step 5: File Watching (--watch)
+
+```bash
+# Watch for changes and report back
+watch_file() {
+    local file="$1"
+    local last_hash
+    last_hash=$(md5sum "$file" 2>/dev/null || md5 -q "$file" 2>/dev/null)
+
+    echo "Watching $file for changes... (Ctrl+C to stop)"
+
+    while true; do
+        sleep 2
+        local current_hash
+        current_hash=$(md5sum "$file" 2>/dev/null || md5 -q "$file" 2>/dev/null)
+
+        if [[ "$current_hash" != "$last_hash" ]]; then
+            echo "File changed at $(date '+%H:%M:%S')"
+            last_hash="$current_hash"
+        fi
+    done
+}
+```
+
+## Desktop Installation Guide
+
+### macOS
+
+```bash
+# Homebrew (recommended)
+brew install --cask drawio
+
+# Or download directly
+# https://github.com/jgraph/drawio-desktop/releases/latest
+```
+
+### Linux
+
+```bash
+# Snap (recommended)
+sudo snap install drawio
+
+# Debian/Ubuntu (.deb)
+wget https://github.com/jgraph/drawio-desktop/releases/download/v24.7.17/drawio-amd64-24.7.17.deb
+sudo dpkg -i drawio-amd64-24.7.17.deb
+
+# Flatpak
+flatpak install flathub com.jgraph.drawio.desktop
+```
+
+### Windows
+
+```powershell
+# Winget (recommended)
+winget install JGraph.Draw
+
+# Chocolatey
+choco install drawio
+
+# Or download from:
+# https://github.com/jgraph/drawio-desktop/releases/latest
+```
+
+## Examples
+
+```bash
+# Open a diagram (auto-detects editor)
+drawio:open --file docs/architecture.drawio
+
+# Open in browser instead of desktop app
+drawio:open --file docs/architecture.drawio --browser
+
+# Open with custom editor path
+drawio:open --file docs/architecture.drawio --editor /opt/drawio/drawio
+
+# Open specific page of a multi-page diagram
+drawio:open --file docs/c4-model.drawio --page 2
+
+# Open and watch for changes
+drawio:open --file docs/architecture.drawio --watch
+
+# Dry run - show what would happen
+drawio:open --file docs/architecture.drawio --dry-run --verbose
+```
+
+## Integration with Other Commands
+
+### Create and Open
+
+```bash
+# Create a diagram then open it for visual editing
+drawio:create --type c4 --analyze src/ --output docs/architecture.drawio --open
+```
+
+### Export and Open
+
+```bash
+# Export to SVG and open the result
+drawio:export --file docs/architecture.drawio --format svg --open
+```
+
+### Iterative Workflow (AI + Desktop)
+
+1. AI generates diagram: `drawio:create --output diagram.drawio`
+2. User opens in desktop: `drawio:open --file diagram.drawio --watch`
+3. User makes visual tweaks in the desktop editor and saves
+4. AI detects changes via `--watch` and can further refine
+5. AI enriches: `drawio:enrich --level 2 diagram.drawio`
+6. User sees updated diagram live in the desktop editor
+
+## Troubleshooting
+
+### "draw.io not found"
+
+```bash
+# Check if it's installed
+which drawio 2>/dev/null || echo "Not in PATH"
+
+# Check common locations
+ls /Applications/draw.io.app 2>/dev/null        # macOS
+ls /snap/bin/drawio 2>/dev/null                  # Linux snap
+ls /usr/bin/drawio 2>/dev/null                   # Linux deb
+ls "$LOCALAPPDATA/Programs/draw.io" 2>/dev/null  # Windows
+```
+
+### WSL (Windows Subsystem for Linux)
+
+When running Claude Code in WSL, open diagrams in the Windows draw.io app:
+
+```bash
+# Convert WSL path to Windows path and open
+WINPATH=$(wslpath -w "/home/user/project/docs/arch.drawio")
+"/mnt/c/Program Files/draw.io/draw.io.exe" "$WINPATH"
+
+# Or use Windows file association
+cmd.exe /C "start \"\" \"$WINPATH\""
+```
+
+### Headless / Container Environments
+
+When no desktop is available (CI/CD, Docker, remote SSH without X11):
+
+```bash
+# Use the browser-based editor with a tunnel
+drawio:open --browser --file diagram.drawio
+
+# Or use MCP App Server for inline rendering
+# Configure in .mcp.json:
+# { "mcpServers": { "drawio-app": { "url": "https://mcp.draw.io/mcp" } } }
+```

--- a/plugins/drawio-diagramming/skills/desktop-integration/SKILL.md
+++ b/plugins/drawio-diagramming/skills/desktop-integration/SKILL.md
@@ -1,0 +1,397 @@
+---
+description: "draw.io desktop app integration for Claude Code — OS detection, editor paths, CLI export, file watching, and iterative AI+human workflows"
+triggers:
+  - drawio desktop
+  - draw.io desktop
+  - open diagram
+  - desktop editor
+  - drawio electron
+  - drawio app
+  - visual editor
+globs:
+  - "**/*.drawio"
+  - "**/*.drawio.svg"
+  - "**/*.drawio.png"
+---
+
+# draw.io Desktop Integration
+
+## Overview
+
+This skill covers the integration between Claude Code (running on desktop) and
+the draw.io desktop application (Electron-based). It enables a seamless workflow
+where the AI generates/edits diagram XML and the user visually refines it in the
+desktop editor.
+
+## Platform Detection
+
+### OS Detection Logic
+
+```bash
+detect_platform() {
+    local os="$(uname -s 2>/dev/null || echo unknown)"
+    case "$os" in
+        Darwin)                    echo "macos" ;;
+        Linux)
+            # Check if running in WSL
+            if grep -qi microsoft /proc/version 2>/dev/null; then
+                echo "wsl"
+            else
+                echo "linux"
+            fi
+            ;;
+        MINGW*|MSYS*|CYGWIN*)     echo "windows" ;;
+        *)
+            # Fallback: check for Windows env vars
+            if [[ -n "${USERPROFILE:-}" ]]; then
+                echo "windows"
+            else
+                echo "unknown"
+            fi
+            ;;
+    esac
+}
+```
+
+### draw.io Executable Locations
+
+| Platform | Common Paths |
+|----------|-------------|
+| **macOS** | `/Applications/draw.io.app/Contents/MacOS/draw.io` |
+| | `~/Applications/draw.io.app/Contents/MacOS/draw.io` |
+| **Linux** | `/usr/bin/drawio` (apt/deb) |
+| | `/snap/bin/drawio` (snap) |
+| | `/opt/drawio/drawio` (manual) |
+| | `~/.local/bin/drawio` (user install) |
+| | Flatpak: `flatpak run com.jgraph.drawio.desktop` |
+| **Windows** | `%LOCALAPPDATA%\Programs\draw.io\draw.io.exe` |
+| | `%PROGRAMFILES%\draw.io\draw.io.exe` |
+| **WSL** | `/mnt/c/Program Files/draw.io/draw.io.exe` |
+| | `/mnt/c/Users/<user>/AppData/Local/Programs/draw.io/draw.io.exe` |
+
+### Detection Priority
+
+1. Check `DRAWIO_EDITOR_PATH` environment variable (user override)
+2. Check `PATH` with `command -v drawio`
+3. Check platform-specific common paths
+4. Check for MCP Tool Server (`@drawio/mcp`) as alternative opener
+5. Fall back to browser (`https://app.diagrams.net`)
+
+## draw.io Desktop CLI Reference
+
+The draw.io desktop app supports command-line operations:
+
+### Export Commands
+
+```bash
+# Export to SVG
+drawio --export --format svg input.drawio -o output.svg
+
+# Export to PNG with 2x scale (retina)
+drawio --export --format png --scale 2 input.drawio -o output.png
+
+# Export to PDF
+drawio --export --format pdf input.drawio -o output.pdf
+
+# Export with embedded diagram XML (re-editable)
+drawio --export --format svg --embed-diagram input.drawio -o output.drawio.svg
+
+# Export specific page (0-indexed)
+drawio --export --format svg --page-index 2 input.drawio -o page3.svg
+
+# Export with transparent background
+drawio --export --format png --transparent input.drawio -o output.png
+
+# Export with border padding
+drawio --export --format png --border 10 input.drawio -o output.png
+
+# Export cropped to content
+drawio --export --format svg --crop input.drawio -o output.svg
+
+# Export all pages
+drawio --export --format png --all-pages input.drawio -o output.png
+```
+
+### Headless Export (Linux CI/CD)
+
+When no display is available (SSH, Docker, CI), use `xvfb-run`:
+
+```bash
+# Install xvfb
+sudo apt-get install -y xvfb
+
+# Export with virtual framebuffer
+xvfb-run -a drawio --export --format svg input.drawio -o output.svg
+
+# Batch export all diagrams
+for f in docs/*.drawio; do
+    xvfb-run -a drawio --export --format svg --embed-diagram "$f" \
+        -o "${f%.drawio}.drawio.svg"
+done
+```
+
+### Version Check
+
+```bash
+drawio --version
+# Example output: 24.7.17
+```
+
+## Desktop Workflows
+
+### Workflow 1: AI Creates → User Refines
+
+```
+Claude Code                         draw.io Desktop
+─────────────                       ───────────────
+1. drawio:create --output arch.drawio
+   ↓ writes XML file
+2. drawio:open --file arch.drawio
+   ↓ launches desktop app ──────→   3. User sees diagram
+                                    4. User drags/resizes/adds
+                                    5. User saves (Ctrl+S)
+   ↓ detects file change
+6. Read the updated XML
+7. drawio:enrich --level 2 arch.drawio
+   ↓ writes enriched XML ───────→   8. Desktop auto-reloads
+```
+
+### Workflow 2: User Designs → AI Exports
+
+```
+draw.io Desktop                     Claude Code
+───────────────                     ─────────────
+1. User creates diagram visually
+2. User saves as project.drawio
+                                    3. drawio:analyze project.drawio
+                                       → quality report
+                                    4. drawio:export --format svg
+                                       --embed-diagram
+                                    5. drawio:embed --platform github
+```
+
+### Workflow 3: Side-by-Side Editing
+
+```
+Claude Code (terminal)              draw.io Desktop (window)
+──────────────────────              ────────────────────────
+1. drawio:edit --add-vertex         Auto-reload shows new shape
+   "Auth Service"
+2. drawio:edit --connect-to         Auto-reload shows connection
+   "auth-svc" "api-gw"
+3. drawio:style --preset dark       Auto-reload shows dark theme
+```
+
+### Workflow 4: WSL Integration
+
+When running Claude Code in WSL but want to use Windows draw.io:
+
+```bash
+# Convert WSL path to Windows path
+WINPATH=$(wslpath -w "$PWD/docs/architecture.drawio")
+
+# Open in Windows draw.io
+"/mnt/c/Program Files/draw.io/draw.io.exe" "$WINPATH" &
+
+# Or use Windows file association
+cmd.exe /C "start \"\" \"$WINPATH\"" 2>/dev/null
+```
+
+## Installation Guides
+
+### macOS
+
+```bash
+# Homebrew (recommended)
+brew install --cask drawio
+
+# Verify
+/Applications/draw.io.app/Contents/MacOS/draw.io --version
+```
+
+### Ubuntu/Debian
+
+```bash
+# Snap (auto-updates)
+sudo snap install drawio
+
+# Or .deb package
+DRAWIO_VERSION="24.7.17"
+wget "https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWIO_VERSION}/drawio-amd64-${DRAWIO_VERSION}.deb"
+sudo dpkg -i "drawio-amd64-${DRAWIO_VERSION}.deb"
+sudo apt-get install -f  # fix dependencies if needed
+
+# Verify
+drawio --version
+```
+
+### Fedora/RHEL
+
+```bash
+# Snap
+sudo dnf install snapd
+sudo snap install drawio
+
+# Or Flatpak
+flatpak install flathub com.jgraph.drawio.desktop
+```
+
+### Windows
+
+```powershell
+# Winget (recommended)
+winget install JGraph.Draw
+
+# Chocolatey
+choco install drawio
+
+# Verify
+& "$env:LOCALAPPDATA\Programs\draw.io\draw.io.exe" --version
+```
+
+### Arch Linux
+
+```bash
+# AUR
+yay -S drawio-desktop-bin
+```
+
+## MCP + Desktop Combined Setup
+
+For the richest desktop experience, combine the MCP Tool Server with desktop app:
+
+### Claude Code (.mcp.json)
+
+```json
+{
+  "mcpServers": {
+    "drawio": {
+      "command": "npx",
+      "args": ["@drawio/mcp"],
+      "env": {
+        "DRAWIO_EDITOR_PATH": "/usr/bin/drawio"
+      }
+    }
+  }
+}
+```
+
+The MCP Tool Server's `open_diagram` tool will use the configured editor path.
+
+### Claude Desktop (claude_desktop_config.json)
+
+```json
+{
+  "mcpServers": {
+    "drawio-app": {
+      "url": "https://mcp.draw.io/mcp"
+    },
+    "drawio-tool": {
+      "command": "npx",
+      "args": ["@drawio/mcp"]
+    }
+  }
+}
+```
+
+## File Watching
+
+### Native File Watching with fswatch (macOS)
+
+```bash
+fswatch -o docs/architecture.drawio | while read _; do
+    echo "[$(date '+%H:%M:%S')] Diagram changed — re-analyzing..."
+    # Trigger re-analysis or export
+done
+```
+
+### inotifywait (Linux)
+
+```bash
+inotifywait -m -e modify docs/architecture.drawio | while read _; do
+    echo "[$(date '+%H:%M:%S')] Diagram changed"
+done
+```
+
+### PowerShell (Windows)
+
+```powershell
+$watcher = New-Object System.IO.FileSystemWatcher
+$watcher.Path = "docs"
+$watcher.Filter = "*.drawio"
+$watcher.EnableRaisingEvents = $true
+Register-ObjectEvent $watcher Changed -Action {
+    Write-Host "Diagram changed at $(Get-Date -Format 'HH:mm:ss')"
+}
+```
+
+## Auto-Reload Behavior
+
+The draw.io desktop app monitors open files for external changes:
+
+- **Default**: Prompts the user when an external change is detected
+- **Setting**: `Extras → Edit Configuration` → add `"autoSave": true` for auto-reload
+- **draw.io config file** (`.drawio.json` in user home):
+
+```json
+{
+  "autoSave": true,
+  "autoSaveDelay": 500
+}
+```
+
+This enables the workflow where Claude Code edits XML → desktop app auto-reloads.
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DRAWIO_EDITOR_PATH` | Custom path to draw.io executable | `/opt/drawio/drawio` |
+| `DRAWIO_EXPORT_FORMAT` | Default export format | `svg` |
+| `DRAWIO_EXPORT_SCALE` | Default export scale | `2` |
+| `DISPLAY` | X11 display (Linux, needed for GUI) | `:0` |
+| `WAYLAND_DISPLAY` | Wayland display (Linux) | `wayland-0` |
+
+## Troubleshooting
+
+### "Cannot open display" (Linux)
+
+```bash
+# Check display
+echo $DISPLAY
+# If empty, set it
+export DISPLAY=:0
+
+# For Wayland
+echo $WAYLAND_DISPLAY
+
+# For headless export without display
+xvfb-run -a drawio --export --format svg input.drawio -o output.svg
+```
+
+### "draw.io crashes on open" (Linux Snap)
+
+```bash
+# Snap needs connected interfaces
+snap connections drawio
+# If missing:
+sudo snap connect drawio:removable-media
+```
+
+### File permissions (macOS)
+
+```bash
+# If macOS blocks the app
+xattr -cr /Applications/draw.io.app
+# Or allow in System Preferences → Security & Privacy
+```
+
+### WSL cannot open Windows apps
+
+```bash
+# Ensure interop is enabled
+cat /proc/sys/fs/binfmt_misc/WSLInterop
+# If missing, add to /etc/wsl.conf:
+# [interop]
+# enabled = true
+```


### PR DESCRIPTION
## Summary

This PR adds comprehensive desktop application support to the draw.io diagramming plugin, enabling seamless integration with the draw.io Electron desktop app on Claude Code desktop. Users can now create diagrams in Claude Code and immediately open them in the desktop editor for visual refinement, with support for all major platforms (macOS, Linux, Windows, WSL).

## Key Changes

- **New `drawio:open` command** (`commands/open.md`): Opens .drawio files in the draw.io desktop application with automatic OS detection, fallback to browser editor, file watching support, and multi-page diagram navigation. Includes comprehensive platform-specific editor path detection and WSL integration.

- **New desktop integration skill** (`skills/desktop-integration/SKILL.md`): Complete reference documentation covering:
  - OS detection logic (macOS, Linux, Windows, WSL)
  - draw.io executable locations across all platforms
  - CLI export commands with examples (SVG, PNG, PDF with various options)
  - Headless export for CI/CD environments using xvfb
  - Four iterative workflow patterns (AI creates → user refines, user designs → AI exports, side-by-side editing, WSL integration)
  - Installation guides for all platforms
  - MCP + Desktop combined setup
  - File watching with platform-specific tools (fswatch, inotifywait, PowerShell)
  - Auto-reload configuration
  - Environment variables reference
  - Troubleshooting guide for common issues

- **Updated plugin metadata**:
  - Added `drawio:open` command to `commands/index.json`
  - Updated `CLAUDE.md` with desktop support overview, quick start examples, and iterative AI+human workflow documentation
  - Added desktop-related tags to `plugin.json` (desktop, electron, drawio-desktop, visual-editor, wsl)
  - Updated command count from 13 to 14 and flag count to 247+

- **Enhanced existing commands**: Added `--open` flag documentation to `create.md` and `export.md` for launching the desktop editor after diagram generation/export

## Implementation Details

- **Cross-platform detection**: Robust OS detection using `uname` with fallbacks for Windows environment variables and WSL detection via `/proc/version`
- **Editor path resolution**: Multi-level fallback chain (environment variable → PATH lookup → platform-specific common paths → MCP Tool Server → browser)
- **WSL support**: Automatic Windows path conversion using `wslpath` for seamless Windows draw.io app launching from WSL
- **File watching**: Platform-specific implementations (fswatch for macOS, inotifywait for Linux, PowerShell for Windows)
- **Headless export**: xvfb-run support for CI/CD environments without display servers
- **MCP integration**: Coordination with @drawio/mcp Tool Server for reliable desktop integration

This enables the core desktop workflow: AI generates diagram XML → user opens in desktop editor → user makes visual refinements → AI detects changes and can further enhance.

https://claude.ai/code/session_01QsAR8f85cqrxnx4KkwVFyB