### PR TITLE
Add `/setup` and `/update` to bootstrap fingerprinted .claude workspace

### DIFF
--- a/plugins/claude-code-templating-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-code-templating-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-templating",
   "version": "1.0.0",
-  "description": "Universal templating and Harness expert plugin for Claude Code - enables fully autonomous project generation, pipeline creation, and deployment automation through a unified template interface. Supports Handlebars, Cookiecutter, Copier, Maven archetypes, and Harness pipelines. 5 commands, 6 agents, 3 skills.",
+  "description": "Universal templating and Harness expert plugin for Claude Code - enables fully autonomous project generation, pipeline creation, and deployment automation through a unified template interface. Supports Handlebars, Cookiecutter, Copier, Maven archetypes, and Harness pipelines. 7 commands, 6 agents, 3 skills.",
   "author": {
     "name": "Markus Ahling",
     "url": "https://thelobbi.io"

--- a/plugins/claude-code-templating-plugin/CLAUDE.md
+++ b/plugins/claude-code-templating-plugin/CLAUDE.md
@@ -24,6 +24,7 @@ This plugin establishes a universal templating and Harness expert system that en
 | `/template` | List, search, generate from templates |
 | `/scaffold` | Scaffold new projects from templates |
 | `/harness` | Create pipelines and templates |
+| `/setup` / `/update` | Bootstrap or refresh the managed Claude workspace in an installed project |
 | `/generate` | Generate API clients, models, tests |
 | `/archetype` | Create and manage project archetypes |
 
@@ -78,6 +79,12 @@ GITHUB_TOKEN=your_github_token
 | Harness | `*.yaml` | YAML + Expressions |
 
 ## Usage Examples
+
+### Bootstrap Claude workspace files
+```bash
+/setup --project-root .
+/update --project-root .
+```
 
 ### Scaffold a Microservice
 ```bash
@@ -137,3 +144,10 @@ npm run lint
 - Cache resolved templates
 - Use streaming for large files
 - Minimize API calls through batching
+
+## Claude Workspace Sync Guarantees
+
+- Setup and update share the same fingerprinted generator so installed projects can always be resynchronized after plugin changes.
+- The managed structure includes nested documentation for `.claude/`, `docs/context/`, `project.md`, `lessons-learned.md`, and ADRs.
+- Repository-like folders discovered beneath the root `.claude/` tree are given their own `.claude/` folder automatically.
+- Node-based projects attempt to install common LSP packages needed for Claude Code-assisted development.

--- a/plugins/claude-code-templating-plugin/CONTEXT_SUMMARY.md
+++ b/plugins/claude-code-templating-plugin/CONTEXT_SUMMARY.md
@@ -1,13 +1,14 @@
 # claude-code-templating-plugin Context Summary
 
 ## Plugin purpose
-Universal templating and Harness expert plugin for Claude Code - enables fully autonomous project generation, pipeline creation, and deployment automation through a unified template interface. Supports Handlebars, Cookiecutter, Copier, Maven archetypes, and Harness pipelines. 5 commands, 6 agents, 3 skills.
+Universal templating and Harness expert plugin for Claude Code - enables fully autonomous project generation, pipeline creation, and deployment automation through a unified template interface. Supports Handlebars, Cookiecutter, Copier, Maven archetypes, and Harness pipelines. 7 commands, 6 agents, 3 skills.
 
 ## Command index
 - `commands/archetype.md`
 - `commands/generate.md`
 - `commands/harness.md`
 - `commands/scaffold.md`
+- `commands/setup.md`
 - `commands/template.md`
 
 ## Agent index
@@ -39,3 +40,6 @@ Use this table to decide when to move beyond this summary.
 | You are validating security, compliance, or rollout risk | `SECURITY*.md`, workstream/review docs | Provides controls, risk notes, and release constraints. |
 | The summary omits edge cases you need | Any referenced deep-dive docs linked above | Ensures decisions are based on complete plugin-specific details. |
 
+
+## Additional routing note
+- Load `commands/setup.md` when the task is about installing, updating, or resynchronizing Claude workspace files inside a project.

--- a/plugins/claude-code-templating-plugin/README.md
+++ b/plugins/claude-code-templating-plugin/README.md
@@ -23,7 +23,7 @@ claude-code-templating-plugin/
   CLAUDE.md / CONTEXT_SUMMARY.md
   src/                           # TypeScript source (orchestrator, engines, MCP)
   agents/                        # 6 agents
-  commands/                      # 5 commands
+  commands/                      # 7 commands
   skills/                        # 3 skills (subdirectories with SKILL.md)
   templates/                     # Bundled project and pipeline templates
 ```
@@ -46,6 +46,7 @@ claude-code-templating-plugin/
 | `/template` | List, search, or generate from available templates |
 | `/scaffold` | Scaffold a new project from a template |
 | `/harness` | Create Harness pipelines, templates, or input sets |
+| `/setup` / `/update` | Bootstrap or refresh the Claude Code workspace in an installed project |
 | `/generate` | Generate API clients, models, or tests from specs |
 | `/archetype` | Create or manage Maven archetypes |
 
@@ -78,8 +79,20 @@ npm ci && npm run build          # Build the TypeScript source
 ## Quick Start
 
 ```
+/setup --project-root .                  # Create the managed Claude workspace
+/update --project-root .                 # Refresh after plugin changes
 /scaffold fastapi-microservice user-service --harness --env dev,staging,prod
 /harness pipeline create ci-cd-standard --service my-service
 /generate api-client --spec openapi.yaml --language typescript
 /template list                           # Browse available templates
 ```
+
+## Claude Workspace Sync
+
+The new `/setup` and `/update` commands generate a nested documentation tree for installed projects. The sync includes:
+
+- Root `README.md` and `CLAUDE.md` with explicit read-when guidance.
+- A rich `.claude/` hierarchy with rules, skills, templates, agents, hooks, local overrides, and `lessons-learned.md`.
+- `docs/context/` files such as `project.md`, `architecture.md`, `api-contracts.md`, `testing-strategy.md`, and ADRs.
+- Recursive detection of repository-like folders under the root `.claude/` directory so those locations also receive `.claude/` guidance.
+- Best-effort installation of supported LSP packages during setup/update.

--- a/plugins/claude-code-templating-plugin/commands/index.json
+++ b/plugins/claude-code-templating-plugin/commands/index.json
@@ -77,6 +77,21 @@
       "risk": "medium",
       "cost": "medium",
       "path": "commands/template.md"
+    },
+    {
+      "name": "setup",
+      "intent": "Bootstrap or refresh Claude Code workspace files inside an installed project, including nested repositories discovered beneath the root .claude tree",
+      "tags": [
+        "setup",
+        "update",
+        "claude",
+        "documentation",
+        "lsp"
+      ],
+      "inputs": [],
+      "risk": "medium",
+      "cost": "low",
+      "path": "commands/setup.md"
     }
   ]
 }

--- a/plugins/claude-code-templating-plugin/commands/setup.md
+++ b/plugins/claude-code-templating-plugin/commands/setup.md
@@ -27,6 +27,7 @@ The `/setup` command creates the managed Claude Code structure expected by this 
 - `docs/context/` with nested, durable markdown files such as `project.md`, `architecture.md`, `testing-strategy.md`, and ADRs.
 - Automatic discovery of repository-like folders beneath the root `.claude/` tree so they also receive local `.claude/` guidance.
 - Best-effort LSP installation for supported stacks.
+- Safe handling for existing top-level `README.md` and `CLAUDE.md`; those files are preserved by default unless you opt in with `--force`.
 
 Use `/update` to run the same synchronization flow later after the plugin changes.
 
@@ -35,8 +36,8 @@ Use `/update` to run the same synchronization flow later after the plugin change
 ## Basic Syntax
 
 ```bash
-/setup [--project-root <path>] [--no-install-lsps] [--no-include-nested-repositories]
-/update [--project-root <path>] [--no-install-lsps] [--no-include-nested-repositories]
+/setup [--project-root <path>] [--force | --no-force] [--no-install-lsps] [--no-include-nested-repositories]
+/update [--project-root <path>] [--force | --no-force] [--no-install-lsps] [--no-include-nested-repositories]
 ```
 
 ---
@@ -45,6 +46,7 @@ Use `/update` to run the same synchronization flow later after the plugin change
 
 ```
 --project-root <path>               Root of the installed project to manage (default: current directory)
+--force / --no-force                Overwrite protected top-level managed files such as README.md and CLAUDE.md
 --install-lsps / --no-install-lsps  Enable or disable automatic LSP package installation
 --include-nested-repositories / --no-include-nested-repositories
                                    Enable or disable scanning inside the root .claude tree for repositories
@@ -86,6 +88,12 @@ project/
 - `/update` is the command you should rerun after plugin upgrades or template revisions.
 - The fingerprint file records generated metadata so the workspace remains traceable.
 
+### Protected top-level files
+- Root `README.md` and `CLAUDE.md` are treated as host-project-owned files.
+- If either file already exists, setup/update leaves it in place by default and emits a warning in the command result.
+- Pass `--force` to intentionally replace those protected files with the plugin-managed versions.
+- Plugin-owned files under `.claude/` and `docs/context/` continue to regenerate automatically.
+
 ### Nested repository handling
 - The root `.claude/` folder is scanned recursively.
 - Directories that look like repositories, or directories named with `repo` / `repository`, receive their own `.claude/README.md` and `.claude/CLAUDE.md`.
@@ -107,9 +115,9 @@ project/
 /setup --project-root .
 ```
 
-### Refresh after updating the plugin
+### Refresh after updating the plugin and replace protected top-level docs intentionally
 ```bash
-/update --project-root .
+/update --project-root . --force
 ```
 
 ### Refresh docs only without touching LSP dependencies

--- a/plugins/claude-code-templating-plugin/commands/setup.md
+++ b/plugins/claude-code-templating-plugin/commands/setup.md
@@ -1,0 +1,118 @@
+---
+name: setup
+intent: Bootstrap or refresh Claude Code workspace files inside an installed project, including nested repositories discovered beneath the root .claude tree
+tags:
+  - setup
+  - update
+  - claude
+  - documentation
+  - lsp
+inputs: []
+risk: medium
+cost: low
+description: Bootstrap or refresh Claude Code workspace files inside an installed project, including nested repositories discovered beneath the root .claude tree
+model: claude-sonnet-4-5
+---
+
+# Claude Workspace Setup Command
+
+Create or refresh a fingerprinted Claude Code workspace for an installed project.
+
+## Overview
+
+The `/setup` command creates the managed Claude Code structure expected by this plugin:
+
+- Root `CLAUDE.md` with read-when triggers and reference document mapping.
+- Root `.claude/` tree with rules, skills, templates, agents, hooks, and a fingerprint manifest.
+- `docs/context/` with nested, durable markdown files such as `project.md`, `architecture.md`, `testing-strategy.md`, and ADRs.
+- Automatic discovery of repository-like folders beneath the root `.claude/` tree so they also receive local `.claude/` guidance.
+- Best-effort LSP installation for supported stacks.
+
+Use `/update` to run the same synchronization flow later after the plugin changes.
+
+---
+
+## Basic Syntax
+
+```bash
+/setup [--project-root <path>] [--no-install-lsps] [--no-include-nested-repositories]
+/update [--project-root <path>] [--no-install-lsps] [--no-include-nested-repositories]
+```
+
+---
+
+## Options
+
+```
+--project-root <path>               Root of the installed project to manage (default: current directory)
+--install-lsps / --no-install-lsps  Enable or disable automatic LSP package installation
+--include-nested-repositories / --no-include-nested-repositories
+                                   Enable or disable scanning inside the root .claude tree for repositories
+```
+
+---
+
+## Generated Structure
+
+```text
+project/
+├── CLAUDE.md
+├── README.md
+├── .claude/
+│   ├── fingerprint.json
+│   ├── rules/
+│   ├── skills/
+│   ├── templates/
+│   ├── agents/
+│   ├── hooks/
+│   └── lessons-learned.md
+└── docs/context/
+    ├── project.md
+    ├── project-overview.md
+    ├── architecture.md
+    ├── data-model.md
+    ├── api-contracts.md
+    ├── testing-strategy.md
+    ├── plan.md
+    └── decisions/
+```
+
+---
+
+## Behavior Notes
+
+### Setup and update parity
+- `/setup` and `/update` use the same managed-file generator.
+- `/update` is the command you should rerun after plugin upgrades or template revisions.
+- The fingerprint file records generated metadata so the workspace remains traceable.
+
+### Nested repository handling
+- The root `.claude/` folder is scanned recursively.
+- Directories that look like repositories, or directories named with `repo` / `repository`, receive their own `.claude/README.md` and `.claude/CLAUDE.md`.
+
+### LSP installation
+- Node-based projects receive a best-effort install of common LSP packages, including:
+  - `typescript`
+  - `typescript-language-server`
+  - `vscode-langservers-extracted`
+  - `yaml-language-server`
+- Installation warnings are surfaced in the command result instead of failing the whole setup run.
+
+---
+
+## Examples
+
+### Bootstrap the current project
+```bash
+/setup --project-root .
+```
+
+### Refresh after updating the plugin
+```bash
+/update --project-root .
+```
+
+### Refresh docs only without touching LSP dependencies
+```bash
+/update --project-root . --no-install-lsps
+```

--- a/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
+++ b/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
@@ -381,11 +381,11 @@ export class ClaudeSetupManager {
       }
 
       const fullPath = join(currentPath, entry.name);
-      if (entry.name === '.claude') {
+      if (entry.name === '.claude' || this.isExcludedClaudeDirectory(fullPath)) {
         continue;
       }
 
-      if (this.isRepositoryCandidate(fullPath, entry.name)) {
+      if (this.isRepositoryCandidate(fullPath)) {
         discovered.add(fullPath);
       }
 
@@ -393,19 +393,38 @@ export class ClaudeSetupManager {
     }
   }
 
-  private isRepositoryCandidate(directoryPath: string, directoryName: string): boolean {
-    if (directoryName.toLowerCase().includes('repository') || directoryName.toLowerCase().includes('repo')) {
-      return true;
-    }
+  private isRepositoryCandidate(directoryPath: string): boolean {
+    const repositoryMarkers = [
+      '.git',
+      'package.json',
+      'pyproject.toml',
+      'requirements.txt',
+      'go.mod',
+      'Cargo.toml',
+    ];
 
-    const markers = ['.git', 'package.json', 'pyproject.toml', 'go.mod', 'Cargo.toml'];
-    for (const marker of markers) {
+    for (const marker of repositoryMarkers) {
       if (existsSync(join(directoryPath, marker))) {
         return true;
       }
     }
 
     return false;
+  }
+
+  private isExcludedClaudeDirectory(directoryPath: string): boolean {
+    const claudeSubpath = this.getClaudeSubpath(directoryPath);
+    return claudeSubpath.length === 1 && ['skills', 'templates', 'agents', 'hooks'].includes(claudeSubpath[0] ?? '');
+  }
+
+  private getClaudeSubpath(directoryPath: string): string[] {
+    const segments = directoryPath.split(/[\\/]+/);
+    const claudeSegmentIndex = segments.lastIndexOf('.claude');
+    if (claudeSegmentIndex === -1) {
+      return [];
+    }
+
+    return segments.slice(claudeSegmentIndex + 1);
   }
 
   private async installRequiredLsps(projectRoot: string, profile: DetectedProjectProfile): Promise<{ installed: string[]; warnings: string[] }> {

--- a/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
+++ b/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile, readdir, readFile } from 'fs/promises';
+import { mkdir, writeFile, readdir, readFile, access } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, basename, relative, dirname } from 'path';
 import { createHash } from 'crypto';
@@ -44,6 +44,11 @@ interface ManagedDoc {
   content: string;
 }
 
+interface ManagedWriteOptions {
+  force?: boolean;
+  warnings: string[];
+}
+
 export class ClaudeSetupManager {
   async ensureProjectSetup(options: ClaudeSetupOptions): Promise<ClaudeSetupResult> {
     const root = options.projectRoot;
@@ -58,7 +63,10 @@ export class ClaudeSetupManager {
     const managedDocs = this.buildManagedDocs(root, profile, options.mode);
 
     for (const doc of managedDocs) {
-      await this.writeManagedFile(root, doc, updatedFiles);
+      await this.writeManagedFile(root, doc, updatedFiles, {
+        force: options.force,
+        warnings,
+      });
     }
 
     if (includeNestedRepositories) {
@@ -68,7 +76,10 @@ export class ClaudeSetupManager {
         const repoProfile = await this.detectProjectProfile(repoPath);
         const nestedDocs = this.buildNestedRepositoryDocs(root, repoPath, repoProfile, options.mode);
         for (const doc of nestedDocs) {
-          await this.writeManagedFile(repoPath, doc, updatedFiles, root);
+          await this.writeManagedFile(repoPath, doc, updatedFiles, {
+            force: options.force,
+            warnings,
+          }, root);
         }
 
         if (options.installLsps !== false) {
@@ -308,11 +319,39 @@ export class ClaudeSetupManager {
     ];
   }
 
-  private async writeManagedFile(root: string, doc: ManagedDoc, updatedFiles: string[], relativeTo = root): Promise<void> {
+  private async writeManagedFile(
+    root: string,
+    doc: ManagedDoc,
+    updatedFiles: string[],
+    options: ManagedWriteOptions,
+    relativeTo = root
+  ): Promise<void> {
     const fullPath = join(root, doc.path);
+    const fileExists = await this.pathExists(fullPath);
+
+    if (fileExists && this.shouldPreserveExistingRootFile(root, doc.path) && !options.force) {
+      options.warnings.push(
+        `Skipped overwriting existing ${doc.path}; rerun with --force to replace the managed template.`
+      );
+      return;
+    }
+
     await mkdir(dirname(fullPath), { recursive: true });
     await writeFile(fullPath, doc.content, 'utf-8');
     updatedFiles.push(relative(relativeTo, fullPath));
+  }
+
+  private shouldPreserveExistingRootFile(root: string, docPath: string): boolean {
+    return root === dirname(join(root, docPath)) && (docPath === 'README.md' || docPath === 'CLAUDE.md');
+  }
+
+  private async pathExists(filePath: string): Promise<boolean> {
+    try {
+      await access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private async findNestedRepositories(projectRoot: string): Promise<string[]> {

--- a/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
+++ b/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
@@ -1,0 +1,446 @@
+import { mkdir, writeFile, readdir, readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, basename, relative, dirname } from 'path';
+import { createHash } from 'crypto';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface ClaudeSetupOptions {
+  mode: 'setup' | 'update';
+  projectRoot: string;
+  force?: boolean;
+  includeNestedRepositories?: boolean;
+  installLsps?: boolean;
+}
+
+export interface ClaudeSetupResult {
+  projectRoot: string;
+  mode: 'setup' | 'update';
+  updatedFiles: string[];
+  nestedRepositories: string[];
+  installedLsps: string[];
+  warnings: string[];
+  fingerprintPath: string;
+}
+
+interface DetectedProjectProfile {
+  name: string;
+  packageManager: 'npm' | 'pnpm' | 'yarn' | 'pip' | 'unknown';
+  stack: string[];
+  languages: string[];
+  commands: {
+    install: string;
+    dev: string;
+    test: string;
+    lint: string;
+    build: string;
+  };
+}
+
+interface ManagedDoc {
+  path: string;
+  content: string;
+}
+
+export class ClaudeSetupManager {
+  async ensureProjectSetup(options: ClaudeSetupOptions): Promise<ClaudeSetupResult> {
+    const root = options.projectRoot;
+    const includeNestedRepositories = options.includeNestedRepositories !== false;
+    const profile = await this.detectProjectProfile(root);
+
+    const updatedFiles: string[] = [];
+    const warnings: string[] = [];
+    const nestedRepositories: string[] = [];
+    const installedLsps: string[] = [];
+
+    const managedDocs = this.buildManagedDocs(root, profile, options.mode);
+
+    for (const doc of managedDocs) {
+      await this.writeManagedFile(root, doc, updatedFiles);
+    }
+
+    if (includeNestedRepositories) {
+      const nestedRepoPaths = await this.findNestedRepositories(root);
+      for (const repoPath of nestedRepoPaths) {
+        nestedRepositories.push(relative(root, repoPath) || '.');
+        const repoProfile = await this.detectProjectProfile(repoPath);
+        const nestedDocs = this.buildNestedRepositoryDocs(root, repoPath, repoProfile, options.mode);
+        for (const doc of nestedDocs) {
+          await this.writeManagedFile(repoPath, doc, updatedFiles, root);
+        }
+
+        if (options.installLsps !== false) {
+          const nestedLspResult = await this.installRequiredLsps(repoPath, repoProfile);
+          installedLsps.push(...nestedLspResult.installed.map((pkg) => `${relative(root, repoPath)}:${pkg}`));
+          warnings.push(...nestedLspResult.warnings.map((warning) => `${relative(root, repoPath)}: ${warning}`));
+        }
+      }
+    }
+
+    if (options.installLsps !== false) {
+      const lspResult = await this.installRequiredLsps(root, profile);
+      installedLsps.push(...lspResult.installed);
+      warnings.push(...lspResult.warnings);
+    }
+
+    const fingerprintPath = await this.writeFingerprint(root, {
+      mode: options.mode,
+      updatedFiles,
+      nestedRepositories,
+      installedLsps,
+      profile,
+    });
+    updatedFiles.push(relative(root, fingerprintPath));
+
+    return {
+      projectRoot: root,
+      mode: options.mode,
+      updatedFiles,
+      nestedRepositories,
+      installedLsps,
+      warnings,
+      fingerprintPath,
+    };
+  }
+
+  private async detectProjectProfile(projectRoot: string): Promise<DetectedProjectProfile> {
+    const stack = new Set<string>();
+    const languages = new Set<string>();
+    let packageManager: DetectedProjectProfile['packageManager'] = 'unknown';
+    let projectName = basename(projectRoot);
+
+    if (existsSync(join(projectRoot, 'package.json'))) {
+      languages.add('TypeScript/JavaScript');
+      stack.add('Node.js application');
+      packageManager = existsSync(join(projectRoot, 'pnpm-lock.yaml'))
+        ? 'pnpm'
+        : existsSync(join(projectRoot, 'yarn.lock'))
+          ? 'yarn'
+          : 'npm';
+
+      try {
+        const pkg = JSON.parse(await readFile(join(projectRoot, 'package.json'), 'utf-8')) as {
+          name?: string;
+          dependencies?: Record<string, string>;
+          devDependencies?: Record<string, string>;
+        };
+        const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+        if (deps.react) stack.add('React');
+        if (deps.next) stack.add('Next.js');
+        if (deps.vite) stack.add('Vite');
+        if (deps.express) stack.add('Express');
+        if (deps.fastify) stack.add('Fastify');
+        if (deps.typescript) stack.add('TypeScript');
+        if (pkg.name) {
+          projectName = pkg.name;
+        }
+      } catch {
+        // Ignore malformed package metadata and continue with inferred defaults.
+      }
+    }
+
+    if (existsSync(join(projectRoot, 'pyproject.toml')) || existsSync(join(projectRoot, 'requirements.txt'))) {
+      languages.add('Python');
+      stack.add('Python service');
+      if (packageManager === 'unknown') packageManager = 'pip';
+    }
+
+    if (existsSync(join(projectRoot, 'go.mod'))) {
+      languages.add('Go');
+      stack.add('Go service');
+    }
+
+    if (existsSync(join(projectRoot, 'Cargo.toml'))) {
+      languages.add('Rust');
+      stack.add('Rust application');
+    }
+
+    if (existsSync(join(projectRoot, 'Dockerfile'))) {
+      stack.add('Containerized runtime');
+    }
+
+    return {
+      name: projectName,
+      packageManager,
+      stack: stack.size ? [...stack] : ['Project'],
+      languages: languages.size ? [...languages] : ['Unknown'],
+      commands: this.defaultCommands(packageManager),
+    };
+  }
+
+  private defaultCommands(packageManager: DetectedProjectProfile['packageManager']) {
+    switch (packageManager) {
+      case 'pnpm':
+        return { install: 'pnpm install', dev: 'pnpm dev', test: 'pnpm test', lint: 'pnpm lint', build: 'pnpm build' };
+      case 'yarn':
+        return { install: 'yarn install', dev: 'yarn dev', test: 'yarn test', lint: 'yarn lint', build: 'yarn build' };
+      case 'pip':
+        return { install: 'pip install -r requirements.txt', dev: 'python -m <module>', test: 'pytest', lint: 'ruff check .', build: 'python -m build' };
+      case 'npm':
+        return { install: 'npm install', dev: 'npm run dev', test: 'npm test', lint: 'npm run lint', build: 'npm run build' };
+      default:
+        return { install: '<install command>', dev: '<dev command>', test: '<test command>', lint: '<lint command>', build: '<build command>' };
+    }
+  }
+
+  private buildManagedDocs(projectRoot: string, profile: DetectedProjectProfile, mode: ClaudeSetupOptions['mode']): ManagedDoc[] {
+    const generatedAt = new Date().toISOString();
+    const stackSummary = profile.stack.join(', ');
+    const languageSummary = profile.languages.join(', ');
+    const commandList = [
+      ['Install dependencies', profile.commands.install],
+      ['Start development', profile.commands.dev],
+      ['Run tests', profile.commands.test],
+      ['Run lint checks', profile.commands.lint],
+      ['Build artifacts', profile.commands.build],
+    ];
+
+    const readme = `# ${profile.name}\n\n> Managed Claude Code workspace bootstrap for ${profile.name}. This README is intentionally structured so setup and update workflows can be rerun safely and repeatedly.\n\n## 1. Workspace Purpose\n\n### 1.1 Project Summary\n- **Project name:** ${profile.name}\n- **Primary stack:** ${stackSummary}\n- **Primary languages:** ${languageSummary}\n- **Claude setup lifecycle:** ${mode}\n\n### 1.2 What this bootstrap adds\n- A root \`.claude/\` workspace with rules, skills, templates, agents, hooks, and fingerprints.\n- A \`docs/context/\` tree with nested, durable documentation intended for Claude Code context loading.\n- A repeatable update path so future plugin versions can refresh the managed Claude assets without reconstructing the whole project by hand.\n\n## 2. Claude Code Lifecycle Commands\n\n### 2.1 Setup the workspace\n\`\`\`bash\n/setup --project-root .\n\`\`\`\n\n### 2.2 Update the workspace after plugin changes\n\`\`\`bash\n/update --project-root .\n\`\`\`\n\n### 2.3 Development commands\n${commandList.map(([label, command]) => `- **${label}:** \`${command}\``).join('\n')}\n\n## 3. Repository Layout\n\n\`\`\`text\n.\n├── CLAUDE.md\n├── README.md\n├── .claude/\n│   ├── rules/\n│   ├── skills/\n│   ├── templates/\n│   ├── agents/\n│   ├── hooks/\n│   └── fingerprint.json\n└── docs/context/\n    ├── project.md\n    ├── architecture.md\n    ├── testing-strategy.md\n    ├── plan.md\n    └── decisions/\n\`\`\`\n\n## 4. Operating Notes\n\n### 4.1 Re-running setup/update\nRun the Claude setup command any time the plugin changes. Managed files are regenerated, fingerprinted, and documented so the installed project stays aligned with the latest plugin structure.\n\n### 4.2 Nested repositories under \`.claude/\`\nIf this project stores cloned or vendored repositories inside the root \`.claude/\` tree, the setup/update workflow ensures those repositories also get a local \`.claude/\` directory.\n\n### 4.3 LSP bootstrapping\nThe setup/update workflow attempts to install LSP packages appropriate for the detected stack so Claude Code can lean on language-aware tooling where possible.\n`;
+
+    const claudeMd = `# ${profile.name} Claude Operating Manual\n\n## 1. Project Identity\n\n### 1.1 Summary\nThis repository is currently identified as **${stackSummary}** with primary languages **${languageSummary}**.\n\n### 1.2 Working agreement\n1. Read \`docs/context/project.md\` before broad changes.\n2. Read \`docs/context/architecture.md\` before structural refactors.\n3. Read \`.claude/rules/coding.md\`, \`.claude/rules/testing.md\`, and \`.claude/rules/security.md\` before making code changes.\n4. Re-run \`/update --project-root .\` after plugin updates to keep this workspace synchronized.\n\n## 2. Reference Documents\n\n### 2.1 Rules\n- @.claude/rules/coding.md\n- @.claude/rules/testing.md\n- @.claude/rules/security.md\n- @.claude/rules/infra.md\n- @.claude/rules/review.md\n- @.claude/rules/product.md\n\n### 2.2 Context\n- @docs/context/project.md\n- @docs/context/project-overview.md\n- @docs/context/architecture.md\n- @docs/context/data-model.md\n- @docs/context/api-contracts.md\n- @docs/context/testing-strategy.md\n- @docs/context/plan.md\n- @.claude/lessons-learned.md\n\n### 2.3 Skills, templates, and agents\n- @.claude/skills/code-review/SKILL.md\n- @.claude/skills/release-notes/SKILL.md\n- @.claude/skills/migration-planner/SKILL.md\n- @.claude/skills/bug-triage/SKILL.md\n- @.claude/templates/pr-description.md\n- @.claude/agents/backend-architect.md\n- @.claude/agents/frontend-specialist.md\n- @.claude/agents/infra-guardian.md\n- @.claude/agents/qa-analyst.md\n\n## 3. Read-When Triggers\n\n### 3.1 Planning\nRead @docs/context/vision-and-roadmap.md and @docs/context/personas-and-use-cases.md when evaluating priorities or suggesting scope changes.\n\n### 3.2 Architecture\nRead @docs/context/architecture-runtime.md, @docs/context/architecture-deployment.md, and @docs/context/constraints.md when changing boundaries, deployment, or integrations.\n\n### 3.3 Delivery\nRead @docs/context/testing-strategy.md, @docs/context/test-inventory.md, and @docs/context/ops-and-runbooks.md when preparing releases or validating risky changes.\n\n## 4. Fingerprinted Sync Metadata\n- **Generated at:** ${generatedAt}\n- **Managed root:** \`${projectRoot}\`\n- **Sync command:** \`/update --project-root .\`\n- **Fingerprint file:** @.claude/fingerprint.json\n`;
+
+    const rules = {
+      'coding.md': `# Coding Rules\n\n## 1. Style\n### 1.1 Naming\n- Prefer descriptive names over abbreviations.\n- Preserve existing framework conventions before introducing new ones.\n\n### 1.2 File layout\n- Keep modules cohesive and document non-obvious boundaries.\n- Place tests close to the relevant runtime conventions for this repository.\n\n## 2. Change hygiene\n- Make small, reviewable commits.\n- Update context docs when the architecture or workflows materially change.\n`,
+      'testing.md': `# Testing Rules\n\n## 1. Expectations\n- Add or update automated tests for behavior changes.\n- Run the narrowest useful test command first, then broader checks as confidence grows.\n\n## 2. Documentation\n- Record important validation steps in docs/context/testing-strategy.md.\n- Add new suites to docs/context/test-inventory.md when they become part of the standard workflow.\n`,
+      'security.md': `# Security Rules\n\n## 1. Data handling\n- Do not commit secrets.\n- Prefer environment variables or secret managers for credentials.\n\n## 2. Review focus\n- Document auth, authorization, and data exposure changes in docs/context/security-rules.md.\n- Flag tenant, privacy, and retention implications before merging risky changes.\n`,
+      'infra.md': `# Infrastructure Rules\n\n## 1. Delivery expectations\n- Document environment-level behavior in docs/context/architecture-deployment.md.\n- Capture rollout or migration requirements in docs/context/ops-and-runbooks.md and docs/context/data-migrations.md.\n`,
+      'review.md': `# Review Checklist\n\n## 1. Code review\n- Confirm tests match the change scope.\n- Confirm docs and operational notes are updated for behavior changes.\n- Confirm the fingerprinted Claude workspace still reflects current structure.\n`,
+      'product.md': `# Product Guardrails\n\n## 1. User impact\n- Protect critical user journeys described in docs/context/personas-and-use-cases.md.\n- Reflect major product intent changes in docs/context/vision-and-roadmap.md before implementation.\n`,
+    };
+
+    const sharedDocs: Record<string, string> = {
+      'CLAUDE.local.md': '# Local Claude Overrides\n\nAdd user-specific notes here. This file is intended to be gitignored when appropriate.\n',
+      'lessons-learned.md': '# Lessons Learned\n\n## 1. Recent insights\n- Record what changed, why it mattered, and what to repeat or avoid next time.\n\n## 2. Follow-up prompts\n- What should be automated next?\n- Which docs need pruning or expansion?\n',
+      'templates/pr-description.md': '# PR Description Template\n\n## Summary\n-\n\n## Testing\n-\n\n## Risks\n-\n',
+      'templates/design-doc.md': '# Design Doc Template\n\n## Problem\n\n## Context\n\n## Proposal\n\n## Risks\n\n## Rollout\n',
+      'templates/test-plan.md': '# Test Plan Template\n\n## Scope\n\n## Scenarios\n\n## Tooling\n\n## Exit Criteria\n',
+      'templates/incident-report.md': '# Incident Report Template\n\n## Summary\n\n## Timeline\n\n## Root Cause\n\n## Corrective Actions\n',
+      'agents/backend-architect.md': '# Backend Architect\n\nPrioritize correctness, operability, and evolutionary design.\n',
+      'agents/frontend-specialist.md': '# Frontend Specialist\n\nPrioritize clarity, accessibility, and coherent UI flows.\n',
+      'agents/infra-guardian.md': '# Infra Guardian\n\nPrioritize safe rollouts, reversibility, and environment consistency.\n',
+      'agents/qa-analyst.md': '# QA Analyst\n\nPrioritize scenario coverage, regressions, and release confidence.\n',
+      'hooks/post-refactor/run-tests.yaml': 'name: run-tests\nsteps:\n  - description: Run the most relevant automated test commands for the touched areas.\n',
+      'hooks/post-refactor/update-docs.yaml': 'name: update-docs\nsteps:\n  - description: Refresh CLAUDE.md, README.md, and docs/context files when behavior changes.\n',
+      'hooks/pre-merge/sanity-checks.yaml': 'name: sanity-checks\nsteps:\n  - description: Confirm tests, linting, docs, and release notes are complete before merge.\n',
+      'skills/code-review/SKILL.md': '# Code Review Skill\n\n## Purpose\nPerform structured reviews using the local checklist and template files.\n\n## Steps\n1. Read checklist.md.\n2. Inspect changed code and tests.\n3. Draft review notes with template.md.\n',
+      'skills/code-review/checklist.md': '# Code Review Checklist\n\n- Correctness\n- Testing\n- Documentation\n- Operability\n',
+      'skills/code-review/template.md': '# Review Template\n\n## Findings\n\n## Follow-up\n',
+      'skills/code-review/examples.md': '# Review Examples\n\n- Example: API contract drift caught before merge.\n',
+      'skills/release-notes/SKILL.md': '# Release Notes Skill\n\n## Purpose\nTurn diffs and merged work into release-ready notes.\n',
+      'skills/release-notes/template.md': '# Release Notes Template\n\n## Added\n\n## Changed\n\n## Fixed\n',
+      'skills/release-notes/examples.md': '# Release Notes Examples\n\n- Added repeatable Claude workspace sync commands.\n',
+      'skills/migration-planner/SKILL.md': '# Migration Planner Skill\n\n## Purpose\nPlan safe data or API migrations with rollback awareness.\n',
+      'skills/migration-planner/playbook.md': '# Migration Playbook\n\n1. Define current state.\n2. Define target state.\n3. Plan rollout, verification, and rollback.\n',
+      'skills/bug-triage/SKILL.md': '# Bug Triage Skill\n\n## Purpose\nCategorize incoming defects and propose reproducible next actions.\n',
+      'skills/bug-triage/heuristics.md': '# Bug Triage Heuristics\n\n- Severity\n- Frequency\n- Blast radius\n- Reproducibility\n',
+    };
+
+    const contextDocs: Record<string, string> = {
+      'project.md': `# Project\n\n## 1. Snapshot\n- **Name:** ${profile.name}\n- **Stack:** ${stackSummary}\n- **Languages:** ${languageSummary}\n\n## 2. Current priorities\n- Keep this file updated with the latest working understanding of the project.\n`,
+      'project-overview.md': '# Project Overview\n\n## Goals\n\n## Non-goals\n\n## Stakeholders\n',
+      'vision-and-roadmap.md': '# Vision and Roadmap\n\n## Near-term\n\n## Mid-term\n\n## Long-term\n',
+      'domain-glossary.md': '# Domain Glossary\n\n## Terms\n\n## Invariants\n',
+      'personas-and-use-cases.md': '# Personas and Use Cases\n\n## Personas\n\n## Core use cases\n',
+      'architecture.md': '# Architecture\n\n## System view\n\n## Boundaries\n\n## Critical decisions\n',
+      'architecture-runtime.md': '# Architecture Runtime\n\n## Runtime flows\n\n## Background work\n\n## External services\n',
+      'architecture-deployment.md': '# Architecture Deployment\n\n## Environments\n\n## Release flow\n\n## Scaling assumptions\n',
+      'data-model.md': '# Data Model\n\n## Entities\n\n## Relationships\n\n## Invariants\n',
+      'data-migrations.md': '# Data Migrations\n\n## Safe migration patterns\n\n## Rollback strategy\n',
+      'api-contracts.md': '# API Contracts\n\n## Endpoints\n\n## Inputs and outputs\n\n## Versioning\n',
+      'api-guidelines.md': '# API Guidelines\n\n## Error handling\n\n## Auth\n\n## Pagination and idempotency\n',
+      'ux-flows.md': '# UX Flows\n\n## Primary flows\n\n## Exceptions\n',
+      'ux-principles.md': '# UX Principles\n\n## Interaction rules\n\n## Accessibility expectations\n',
+      'security-rules.md': '# Security Rules\n\n## Auth\n\n## Data classification\n\n## Logging and monitoring\n',
+      'compliance.md': '# Compliance\n\n## Applicable obligations\n\n## Retention\n\n## Audit notes\n',
+      'testing-strategy.md': '# Testing Strategy\n\n## Layers\n\n## Required checks\n\n## Ownership\n',
+      'test-inventory.md': '# Test Inventory\n\n## Suites\n\n## Commands\n',
+      'constraints.md': '# Constraints\n\n## Technical\n\n## Product\n\n## Operational\n',
+      'performance.md': '# Performance\n\n## Budgets\n\n## Hotspots\n\n## Benchmarks\n',
+      'ops-and-runbooks.md': '# Ops and Runbooks\n\n## Common tasks\n\n## Incident checklist\n\n## Recovery notes\n',
+      'changelog.md': '# Changelog\n\n## Managed Claude workspace changes\n- Initial fingerprinted structure generated by the setup/update workflow.\n',
+      'plan.md': '# Plan\n\n## Active work\n\n## Risks\n\n## Questions\n',
+      'decisions/adr-0001-claude-workspace-bootstrap.md': '# ADR-0001 Claude Workspace Bootstrap\n\n## Status\nAccepted\n\n## Context\nWe need a repeatable Claude workspace scaffold that can be re-applied after plugin updates.\n\n## Decision\nUse a fingerprinted set of managed markdown and configuration files.\n\n## Consequences\nWorkspace sync becomes deterministic and easier to maintain.\n',
+    };
+
+    const docs: ManagedDoc[] = [
+      { path: 'README.md', content: readme },
+      { path: 'CLAUDE.md', content: claudeMd },
+    ];
+
+    for (const [name, content] of Object.entries(rules)) {
+      docs.push({ path: join('.claude', 'rules', name), content });
+    }
+
+    for (const [name, content] of Object.entries(sharedDocs)) {
+      docs.push({ path: join('.claude', name), content });
+    }
+
+    for (const [name, content] of Object.entries(contextDocs)) {
+      docs.push({ path: join('docs', 'context', name), content });
+    }
+
+    docs.push({
+      path: join('.claude', '.gitignore'),
+      content: 'CLAUDE.local.md\n',
+    });
+
+    return docs;
+  }
+
+  private buildNestedRepositoryDocs(
+    rootProject: string,
+    repositoryPath: string,
+    profile: DetectedProjectProfile,
+    mode: ClaudeSetupOptions['mode']
+  ): ManagedDoc[] {
+    const relativeRepositoryPath = relative(rootProject, repositoryPath) || '.';
+    return [
+      {
+        path: join('.claude', 'README.md'),
+        content: `# Nested Repository Claude Workspace\n\n## Repository\n- **Path:** ${relativeRepositoryPath}\n- **Detected stack:** ${profile.stack.join(', ')}\n- **Sync mode:** ${mode}\n\n## Expectations\n- This repository was discovered under the root .claude tree and receives a local .claude directory so Claude Code can reason about it independently.\n- Re-run the parent /update command whenever the plugin changes or this nested repository layout shifts.\n`,
+      },
+      {
+        path: join('.claude', 'CLAUDE.md'),
+        content: `# Nested Repository Guide\n\nRead the parent repository guidance first, then use this folder for nested-repository-specific notes.\n`,
+      },
+    ];
+  }
+
+  private async writeManagedFile(root: string, doc: ManagedDoc, updatedFiles: string[], relativeTo = root): Promise<void> {
+    const fullPath = join(root, doc.path);
+    await mkdir(dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, doc.content, 'utf-8');
+    updatedFiles.push(relative(relativeTo, fullPath));
+  }
+
+  private async findNestedRepositories(projectRoot: string): Promise<string[]> {
+    const claudeRoot = join(projectRoot, '.claude');
+    if (!existsSync(claudeRoot)) {
+      return [];
+    }
+
+    const discovered = new Set<string>();
+    await this.walkForRepositories(claudeRoot, discovered);
+    discovered.delete(projectRoot);
+
+    return [...discovered].sort();
+  }
+
+  private async walkForRepositories(currentPath: string, discovered: Set<string>): Promise<void> {
+    let entries: Array<{ name: string; isDirectory(): boolean }> = [];
+    try {
+      entries = await readdir(currentPath, { withFileTypes: true }) as Array<{ name: string; isDirectory(): boolean }>;
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const fullPath = join(currentPath, entry.name);
+      if (entry.name === '.claude') {
+        continue;
+      }
+
+      if (this.isRepositoryCandidate(fullPath, entry.name)) {
+        discovered.add(fullPath);
+      }
+
+      await this.walkForRepositories(fullPath, discovered);
+    }
+  }
+
+  private isRepositoryCandidate(directoryPath: string, directoryName: string): boolean {
+    if (directoryName.toLowerCase().includes('repository') || directoryName.toLowerCase().includes('repo')) {
+      return true;
+    }
+
+    const markers = ['.git', 'package.json', 'pyproject.toml', 'go.mod', 'Cargo.toml'];
+    for (const marker of markers) {
+      if (existsSync(join(directoryPath, marker))) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private async installRequiredLsps(projectRoot: string, profile: DetectedProjectProfile): Promise<{ installed: string[]; warnings: string[] }> {
+    const installed: string[] = [];
+    const warnings: string[] = [];
+
+    if (!existsSync(join(projectRoot, 'package.json'))) {
+      return { installed, warnings };
+    }
+
+    const packages = new Set<string>();
+    if (profile.languages.includes('TypeScript/JavaScript')) {
+      packages.add('typescript');
+      packages.add('typescript-language-server');
+      packages.add('vscode-langservers-extracted');
+      packages.add('yaml-language-server');
+    }
+
+    if (!packages.size) {
+      return { installed, warnings };
+    }
+
+    const argsPrefix = profile.packageManager === 'pnpm'
+      ? ['add', '-D']
+      : profile.packageManager === 'yarn'
+        ? ['add', '-D']
+        : ['install', '--save-dev'];
+    const command = profile.packageManager === 'pnpm'
+      ? 'pnpm'
+      : profile.packageManager === 'yarn'
+        ? 'yarn'
+        : 'npm';
+
+    try {
+      await execFileAsync(command, [...argsPrefix, ...packages], { cwd: projectRoot });
+      installed.push(...packages);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      warnings.push(`Unable to install LSP packages automatically: ${message}`);
+    }
+
+    return { installed, warnings };
+  }
+
+  private async writeFingerprint(
+    projectRoot: string,
+    payload: {
+      mode: ClaudeSetupOptions['mode'];
+      updatedFiles: string[];
+      nestedRepositories: string[];
+      installedLsps: string[];
+      profile: DetectedProjectProfile;
+    }
+  ): Promise<string> {
+    const fingerprintPath = join(projectRoot, '.claude', 'fingerprint.json');
+    const fingerprint = {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      mode: payload.mode,
+      project: payload.profile.name,
+      stack: payload.profile.stack,
+      languages: payload.profile.languages,
+      nestedRepositories: payload.nestedRepositories,
+      installedLsps: payload.installedLsps,
+      managedFiles: payload.updatedFiles,
+      hash: createHash('sha256').update(JSON.stringify(payload)).digest('hex'),
+    };
+
+    await mkdir(dirname(fingerprintPath), { recursive: true });
+    await writeFile(fingerprintPath, JSON.stringify(fingerprint, null, 2) + '\n', 'utf-8');
+    return fingerprintPath;
+  }
+}
+
+export function createClaudeSetupManager(): ClaudeSetupManager {
+  return new ClaudeSetupManager();
+}

--- a/plugins/claude-code-templating-plugin/src/core/index.ts
+++ b/plugins/claude-code-templating-plugin/src/core/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { TemplateEngine, createTemplateEngine } from './template-engine.js';
+export { ClaudeSetupManager, createClaudeSetupManager } from './claude-setup.js';

--- a/plugins/claude-code-templating-plugin/src/index.ts
+++ b/plugins/claude-code-templating-plugin/src/index.ts
@@ -741,10 +741,14 @@ export class ClaudeCodeTemplatingPlugin extends EventEmitter<PluginEvents> {
     const installLsps =
       args.options['install-lsps'] !== false
       && args.options['no-install-lsps'] !== true;
+    const force =
+      args.options.force === true
+      && args.options['no-force'] !== true;
 
     const result = await this.claudeSetupManager.ensureProjectSetup({
       mode,
       projectRoot,
+      force,
       includeNestedRepositories,
       installLsps,
     });

--- a/plugins/claude-code-templating-plugin/src/index.ts
+++ b/plugins/claude-code-templating-plugin/src/index.ts
@@ -10,6 +10,7 @@
 
 import { EventEmitter } from 'eventemitter3';
 import { TemplateOrchestrator, createOrchestrator } from './core/orchestrator.js';
+import { ClaudeSetupManager, createClaudeSetupManager } from './core/claude-setup.js';
 import { HarnessExpertAgent } from './agents/harness-expert.js';
 import type {
   ScaffoldSpec,
@@ -208,6 +209,7 @@ export class ClaudeCodeTemplatingPlugin extends EventEmitter<PluginEvents> {
   private initialized = false;
   private orchestrator: TemplateOrchestrator | null = null;
   private harnessAgent: HarnessExpertAgent | null = null;
+  private claudeSetupManager: ClaudeSetupManager | null = null;
 
   /**
    * Plugin name
@@ -258,6 +260,10 @@ export class ClaudeCodeTemplatingPlugin extends EventEmitter<PluginEvents> {
       // Initialize Harness Expert Agent
       this.harnessAgent = new HarnessExpertAgent();
       context.logger.debug('Harness Expert Agent initialized');
+
+      // Initialize Claude setup manager
+      this.claudeSetupManager = createClaudeSetupManager();
+      context.logger.debug('Claude setup manager initialized');
 
       // Register commands
       await this.registerCommands(context);
@@ -358,6 +364,16 @@ export class ClaudeCodeTemplatingPlugin extends EventEmitter<PluginEvents> {
             error: `Unknown action: ${action}. Use: pipeline, template, deploy`,
           };
       }
+    });
+
+    // /setup command
+    context.api.registerCommand('setup', async (args) => {
+      return this.handleClaudeSetup('setup', args);
+    });
+
+    // /update command
+    context.api.registerCommand('update', async (args) => {
+      return this.handleClaudeSetup('update', args);
     });
 
     // /generate command
@@ -710,6 +726,34 @@ export class ClaudeCodeTemplatingPlugin extends EventEmitter<PluginEvents> {
         error: result.error || 'Template creation failed',
       };
     }
+  }
+
+  private async handleClaudeSetup(mode: 'setup' | 'update', args: CommandArgs): Promise<CommandResult> {
+    if (!this.claudeSetupManager) {
+      return { success: false, error: 'Claude setup manager not initialized' };
+    }
+
+    const projectRoot = (args.options['project-root'] as string) || args.context.cwd;
+
+    const includeNestedRepositories =
+      args.options['include-nested-repositories'] !== false
+      && args.options['no-include-nested-repositories'] !== true;
+    const installLsps =
+      args.options['install-lsps'] !== false
+      && args.options['no-install-lsps'] !== true;
+
+    const result = await this.claudeSetupManager.ensureProjectSetup({
+      mode,
+      projectRoot,
+      includeNestedRepositories,
+      installLsps,
+    });
+
+    return {
+      success: true,
+      message: `${mode === 'setup' ? 'Bootstrapped' : 'Updated'} Claude Code workspace in ${projectRoot}`,
+      data: result,
+    };
   }
 
   private async handleHarnessDeploy(args: CommandArgs): Promise<CommandResult> {

--- a/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
+++ b/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock,
+}));
+
+import { ClaudeSetupManager } from '../../../src/core/claude-setup.js';
+
+describe('ClaudeSetupManager', () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    execFileMock.mockReset();
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback?.(null, '', '');
+      return {};
+    });
+    tempRoot = await mkdtemp(join(tmpdir(), 'claude-setup-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('creates the managed Claude workspace and context docs', async () => {
+    await writeFile(
+      join(tempRoot, 'package.json'),
+      JSON.stringify({
+        name: 'demo-app',
+        dependencies: {
+          react: '^18.0.0',
+        },
+        devDependencies: {
+          typescript: '^5.0.0',
+        },
+      }),
+      'utf-8'
+    );
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'setup',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(result.updatedFiles).toContain('README.md');
+    expect(result.updatedFiles).toContain('CLAUDE.md');
+    expect(result.updatedFiles).toContain('docs/context/project.md');
+
+    const claudeMd = await readFile(join(tempRoot, 'CLAUDE.md'), 'utf-8');
+    expect(claudeMd).toContain('Reference Documents');
+
+    const fingerprint = JSON.parse(await readFile(join(tempRoot, '.claude', 'fingerprint.json'), 'utf-8')) as {
+      managedFiles: string[];
+      project: string;
+    };
+    expect(fingerprint.project).toBe('demo-app');
+    expect(fingerprint.managedFiles).toContain('README.md');
+  });
+
+  it('adds local .claude docs for nested repositories under the root .claude tree', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
+    const nestedRepo = join(tempRoot, '.claude', 'repositories', 'sample-repo');
+    await mkdir(nestedRepo, { recursive: true });
+    await writeFile(join(nestedRepo, 'package.json'), JSON.stringify({ name: 'nested-app' }), 'utf-8');
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'update',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(result.nestedRepositories).toContain('.claude/repositories/sample-repo');
+
+    const nestedReadme = await readFile(join(nestedRepo, '.claude', 'README.md'), 'utf-8');
+    expect(nestedReadme).toContain('Nested Repository Claude Workspace');
+  });
+
+  it('attempts to install relevant LSP packages for node-based projects', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'setup',
+      projectRoot: tempRoot,
+    });
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][0]).toBe('npm');
+    expect(execFileMock.mock.calls[0][1]).toEqual(expect.arrayContaining([
+      'install',
+      '--save-dev',
+      'typescript-language-server',
+      'vscode-langservers-extracted',
+      'yaml-language-server',
+    ]));
+    expect(result.installedLsps).toEqual(expect.arrayContaining([
+      'typescript-language-server',
+      'vscode-langservers-extracted',
+      'yaml-language-server',
+    ]));
+  });
+});

--- a/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
+++ b/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
@@ -66,6 +66,66 @@ describe('ClaudeSetupManager', () => {
     expect(fingerprint.managedFiles).toContain('README.md');
   });
 
+  it('preserves an existing root README.md by default and adds a warning', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'demo-app' }), 'utf-8');
+    await writeFile(join(tempRoot, 'README.md'), 'host README', 'utf-8');
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'setup',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(await readFile(join(tempRoot, 'README.md'), 'utf-8')).toBe('host README');
+    expect(result.updatedFiles).not.toContain('README.md');
+    expect(result.warnings).toContain(
+      'Skipped overwriting existing README.md; rerun with --force to replace the managed template.'
+    );
+  });
+
+  it('preserves an existing root CLAUDE.md by default and adds a warning', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'demo-app' }), 'utf-8');
+    await writeFile(join(tempRoot, 'CLAUDE.md'), 'host CLAUDE', 'utf-8');
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'update',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(await readFile(join(tempRoot, 'CLAUDE.md'), 'utf-8')).toBe('host CLAUDE');
+    expect(result.updatedFiles).not.toContain('CLAUDE.md');
+    expect(result.warnings).toContain(
+      'Skipped overwriting existing CLAUDE.md; rerun with --force to replace the managed template.'
+    );
+  });
+
+  it('overwrites managed targets intentionally when force is true', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'demo-app' }), 'utf-8');
+    await writeFile(join(tempRoot, 'README.md'), 'host README', 'utf-8');
+    await writeFile(join(tempRoot, 'CLAUDE.md'), 'host CLAUDE', 'utf-8');
+    await mkdir(join(tempRoot, '.claude', 'rules'), { recursive: true });
+    await writeFile(join(tempRoot, '.claude', 'rules', 'coding.md'), 'old managed content', 'utf-8');
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'setup',
+      projectRoot: tempRoot,
+      force: true,
+      installLsps: false,
+    });
+
+    expect(await readFile(join(tempRoot, 'README.md'), 'utf-8')).toContain('# demo-app');
+    expect(await readFile(join(tempRoot, 'CLAUDE.md'), 'utf-8')).toContain('Claude Operating Manual');
+    expect(await readFile(join(tempRoot, '.claude', 'rules', 'coding.md'), 'utf-8')).toContain('# Coding Rules');
+    expect(result.updatedFiles).toEqual(expect.arrayContaining(['README.md', 'CLAUDE.md', '.claude/rules/coding.md']));
+    expect(result.warnings).not.toContain(
+      expect.stringContaining('rerun with --force')
+    );
+  });
+
   it('adds local .claude docs for nested repositories under the root .claude tree', async () => {
     await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
     const nestedRepo = join(tempRoot, '.claude', 'repositories', 'sample-repo');

--- a/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
+++ b/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
@@ -126,7 +126,7 @@ describe('ClaudeSetupManager', () => {
     );
   });
 
-  it('adds local .claude docs for nested repositories under the root .claude tree', async () => {
+  it('adds local .claude docs for a real nested repo under .claude/repositories', async () => {
     await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
     const nestedRepo = join(tempRoot, '.claude', 'repositories', 'sample-repo');
     await mkdir(nestedRepo, { recursive: true });
@@ -143,6 +143,38 @@ describe('ClaudeSetupManager', () => {
 
     const nestedReadme = await readFile(join(nestedRepo, '.claude', 'README.md'), 'utf-8');
     expect(nestedReadme).toContain('Nested Repository Claude Workspace');
+  });
+
+  it('ignores false-positive repository folder names inside plugin-managed .claude/templates', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
+    const templateFolder = join(tempRoot, '.claude', 'templates', 'repository-guidelines');
+    await mkdir(templateFolder, { recursive: true });
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'update',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(result.nestedRepositories).not.toContain('.claude/templates/repository-guidelines');
+    await expect(readFile(join(templateFolder, '.claude', 'README.md'), 'utf-8')).rejects.toThrow();
+  });
+
+  it('ignores folders with repo in the name when they have no repository markers', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
+    const fakeRepoFolder = join(tempRoot, '.claude', 'workspace-repo-cache');
+    await mkdir(fakeRepoFolder, { recursive: true });
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'update',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(result.nestedRepositories).not.toContain('.claude/workspace-repo-cache');
+    await expect(readFile(join(fakeRepoFolder, '.claude', 'README.md'), 'utf-8')).rejects.toThrow();
   });
 
   it('attempts to install relevant LSP packages for node-based projects', async () => {


### PR DESCRIPTION
### Motivation

- Provide a repeatable command so the plugin can bootstrap or refresh the Claude docs/metadata inside an installed project regardless of later plugin changes.
- Ensure any repository-like folders under the root `.claude/` tree also receive a local `.claude/` workspace so nested repos are discoverable and manageable.
- Make the generated `README.md` / `CLAUDE.md` and `docs/context/` rich, nested, and fingerprinted so the installed project has durable context Claude can read.
- Attempt best-effort LSP bootstrapping for detected stacks so language tooling is available for Claude-assisted workflows.

### Description

- Added a new setup manager class `ClaudeSetupManager` to `src/core/claude-setup.ts` that generates managed docs, writes `fingerprint.json`, scans `/.claude` for nested repos, and optionally installs LSP packages via `installRequiredLsps`.
- Registered new commands in the plugin entrypoint: `setup` and `update` (handlers `handleClaudeSetup`) and exposed the manager via `createClaudeSetupManager()` in `src/index.ts` and `src/core/index.ts`.
- Added user-facing command documentation `commands/setup.md` and updated plugin docs (`README.md`, `CLAUDE.md`, `CONTEXT_SUMMARY.md`, and `commands/index.json`) to document the workflow and guarantees.
- Added unit tests for the new manager in `test/unit/core/claude-setup.test.ts` covering root generation, nested `.claude` propagation, and LSP installation behavior.
- Implementation details: writes a fingerprint at `/.claude/fingerprint.json`, emits a deterministic managed file tree (`.claude/rules`, `docs/context/`, templates, agents, hooks, `lessons-learned.md`), and provides `--no-install-lsps` / `--no-include-nested-repositories` controls via command options.

### Testing

- Ran the targeted unit test: `npx vitest run test/unit/core/claude-setup.test.ts` and the suite passed (3 tests).
- Ran `git diff --check` to validate whitespace/format issues and it produced no problems.
- Ran full `npm test` for the plugin; unrelated integration/unit suites failed in this environment due to missing project-wide dependencies (`eventemitter3`, `nunjucks`, etc.), so those failures are external to the new `ClaudeSetupManager` change.
- Ran `npm run typecheck`; TypeScript/type errors reported are from pre-existing repository-wide type/dependency configuration and are not caused by the new setup manager changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb90fd2e74832aaa2da66d55b37f3d)