### PR TITLE
Protect setup-managed root docs by default (add --force)

### DIFF
--- a/plugins/claude-code-templating-plugin/commands/setup.md
+++ b/plugins/claude-code-templating-plugin/commands/setup.md
@@ -27,6 +27,7 @@ The `/setup` command creates the managed Claude Code structure expected by this 
 - `docs/context/` with nested, durable markdown files such as `project.md`, `architecture.md`, `testing-strategy.md`, and ADRs.
 - Automatic discovery of repository-like folders beneath the root `.claude/` tree so they also receive local `.claude/` guidance.
 - Best-effort LSP installation for supported stacks.
+- Safe handling for existing top-level `README.md` and `CLAUDE.md`; those files are preserved by default unless you opt in with `--force`.
 
 Use `/update` to run the same synchronization flow later after the plugin changes.
 
@@ -35,8 +36,8 @@ Use `/update` to run the same synchronization flow later after the plugin change
 ## Basic Syntax
 
 ```bash
-/setup [--project-root <path>] [--no-install-lsps] [--no-include-nested-repositories]
-/update [--project-root <path>] [--no-install-lsps] [--no-include-nested-repositories]
+/setup [--project-root <path>] [--force | --no-force] [--no-install-lsps] [--no-include-nested-repositories]
+/update [--project-root <path>] [--force | --no-force] [--no-install-lsps] [--no-include-nested-repositories]
 ```
 
 ---
@@ -45,6 +46,7 @@ Use `/update` to run the same synchronization flow later after the plugin change
 
 ```
 --project-root <path>               Root of the installed project to manage (default: current directory)
+--force / --no-force                Overwrite protected top-level managed files such as README.md and CLAUDE.md
 --install-lsps / --no-install-lsps  Enable or disable automatic LSP package installation
 --include-nested-repositories / --no-include-nested-repositories
                                    Enable or disable scanning inside the root .claude tree for repositories
@@ -86,6 +88,12 @@ project/
 - `/update` is the command you should rerun after plugin upgrades or template revisions.
 - The fingerprint file records generated metadata so the workspace remains traceable.
 
+### Protected top-level files
+- Root `README.md` and `CLAUDE.md` are treated as host-project-owned files.
+- If either file already exists, setup/update leaves it in place by default and emits a warning in the command result.
+- Pass `--force` to intentionally replace those protected files with the plugin-managed versions.
+- Plugin-owned files under `.claude/` and `docs/context/` continue to regenerate automatically.
+
 ### Nested repository handling
 - The root `.claude/` folder is scanned recursively.
 - Directories that look like repositories, or directories named with `repo` / `repository`, receive their own `.claude/README.md` and `.claude/CLAUDE.md`.
@@ -107,9 +115,9 @@ project/
 /setup --project-root .
 ```
 
-### Refresh after updating the plugin
+### Refresh after updating the plugin and replace protected top-level docs intentionally
 ```bash
-/update --project-root .
+/update --project-root . --force
 ```
 
 ### Refresh docs only without touching LSP dependencies

--- a/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
+++ b/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile, readdir, readFile } from 'fs/promises';
+import { mkdir, writeFile, readdir, readFile, access } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, basename, relative, dirname } from 'path';
 import { createHash } from 'crypto';
@@ -44,6 +44,11 @@ interface ManagedDoc {
   content: string;
 }
 
+interface ManagedWriteOptions {
+  force?: boolean;
+  warnings: string[];
+}
+
 export class ClaudeSetupManager {
   async ensureProjectSetup(options: ClaudeSetupOptions): Promise<ClaudeSetupResult> {
     const root = options.projectRoot;
@@ -58,7 +63,10 @@ export class ClaudeSetupManager {
     const managedDocs = this.buildManagedDocs(root, profile, options.mode);
 
     for (const doc of managedDocs) {
-      await this.writeManagedFile(root, doc, updatedFiles);
+      await this.writeManagedFile(root, doc, updatedFiles, {
+        force: options.force,
+        warnings,
+      });
     }
 
     if (includeNestedRepositories) {
@@ -68,7 +76,10 @@ export class ClaudeSetupManager {
         const repoProfile = await this.detectProjectProfile(repoPath);
         const nestedDocs = this.buildNestedRepositoryDocs(root, repoPath, repoProfile, options.mode);
         for (const doc of nestedDocs) {
-          await this.writeManagedFile(repoPath, doc, updatedFiles, root);
+          await this.writeManagedFile(repoPath, doc, updatedFiles, {
+            force: options.force,
+            warnings,
+          }, root);
         }
 
         if (options.installLsps !== false) {
@@ -308,11 +319,39 @@ export class ClaudeSetupManager {
     ];
   }
 
-  private async writeManagedFile(root: string, doc: ManagedDoc, updatedFiles: string[], relativeTo = root): Promise<void> {
+  private async writeManagedFile(
+    root: string,
+    doc: ManagedDoc,
+    updatedFiles: string[],
+    options: ManagedWriteOptions,
+    relativeTo = root
+  ): Promise<void> {
     const fullPath = join(root, doc.path);
+    const fileExists = await this.pathExists(fullPath);
+
+    if (fileExists && this.shouldPreserveExistingRootFile(root, doc.path) && !options.force) {
+      options.warnings.push(
+        `Skipped overwriting existing ${doc.path}; rerun with --force to replace the managed template.`
+      );
+      return;
+    }
+
     await mkdir(dirname(fullPath), { recursive: true });
     await writeFile(fullPath, doc.content, 'utf-8');
     updatedFiles.push(relative(relativeTo, fullPath));
+  }
+
+  private shouldPreserveExistingRootFile(root: string, docPath: string): boolean {
+    return root === dirname(join(root, docPath)) && (docPath === 'README.md' || docPath === 'CLAUDE.md');
+  }
+
+  private async pathExists(filePath: string): Promise<boolean> {
+    try {
+      await access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private async findNestedRepositories(projectRoot: string): Promise<string[]> {

--- a/plugins/claude-code-templating-plugin/src/index.ts
+++ b/plugins/claude-code-templating-plugin/src/index.ts
@@ -741,10 +741,14 @@ export class ClaudeCodeTemplatingPlugin extends EventEmitter<PluginEvents> {
     const installLsps =
       args.options['install-lsps'] !== false
       && args.options['no-install-lsps'] !== true;
+    const force =
+      args.options.force === true
+      && args.options['no-force'] !== true;
 
     const result = await this.claudeSetupManager.ensureProjectSetup({
       mode,
       projectRoot,
+      force,
       includeNestedRepositories,
       installLsps,
     });

--- a/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
+++ b/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
@@ -66,6 +66,66 @@ describe('ClaudeSetupManager', () => {
     expect(fingerprint.managedFiles).toContain('README.md');
   });
 
+  it('preserves an existing root README.md by default and adds a warning', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'demo-app' }), 'utf-8');
+    await writeFile(join(tempRoot, 'README.md'), 'host README', 'utf-8');
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'setup',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(await readFile(join(tempRoot, 'README.md'), 'utf-8')).toBe('host README');
+    expect(result.updatedFiles).not.toContain('README.md');
+    expect(result.warnings).toContain(
+      'Skipped overwriting existing README.md; rerun with --force to replace the managed template.'
+    );
+  });
+
+  it('preserves an existing root CLAUDE.md by default and adds a warning', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'demo-app' }), 'utf-8');
+    await writeFile(join(tempRoot, 'CLAUDE.md'), 'host CLAUDE', 'utf-8');
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'update',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(await readFile(join(tempRoot, 'CLAUDE.md'), 'utf-8')).toBe('host CLAUDE');
+    expect(result.updatedFiles).not.toContain('CLAUDE.md');
+    expect(result.warnings).toContain(
+      'Skipped overwriting existing CLAUDE.md; rerun with --force to replace the managed template.'
+    );
+  });
+
+  it('overwrites managed targets intentionally when force is true', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'demo-app' }), 'utf-8');
+    await writeFile(join(tempRoot, 'README.md'), 'host README', 'utf-8');
+    await writeFile(join(tempRoot, 'CLAUDE.md'), 'host CLAUDE', 'utf-8');
+    await mkdir(join(tempRoot, '.claude', 'rules'), { recursive: true });
+    await writeFile(join(tempRoot, '.claude', 'rules', 'coding.md'), 'old managed content', 'utf-8');
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'setup',
+      projectRoot: tempRoot,
+      force: true,
+      installLsps: false,
+    });
+
+    expect(await readFile(join(tempRoot, 'README.md'), 'utf-8')).toContain('# demo-app');
+    expect(await readFile(join(tempRoot, 'CLAUDE.md'), 'utf-8')).toContain('Claude Operating Manual');
+    expect(await readFile(join(tempRoot, '.claude', 'rules', 'coding.md'), 'utf-8')).toContain('# Coding Rules');
+    expect(result.updatedFiles).toEqual(expect.arrayContaining(['README.md', 'CLAUDE.md', '.claude/rules/coding.md']));
+    expect(result.warnings).not.toContain(
+      expect.stringContaining('rerun with --force')
+    );
+  });
+
   it('adds local .claude docs for nested repositories under the root .claude tree', async () => {
     await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
     const nestedRepo = join(tempRoot, '.claude', 'repositories', 'sample-repo');


### PR DESCRIPTION
### Motivation
- Prevent the setup/update flow from silently replacing host-project-owned top-level files like `README.md` and `CLAUDE.md` while still allowing plugin-owned files to be regenerated automatically.
- Provide a clear opt-in overwrite flow so callers can intentionally replace protected files when desired.

### Description
- Thread `ClaudeSetupOptions.force` through `ensureProjectSetup()` and wire it from the command layer so `--force` / `--no-force` is supported in the `/setup` and `/update` handlers (`src/index.ts`).
- Change `writeManagedFile()` to check whether the target exists before writing and accept `ManagedWriteOptions` including `force` and a `warnings` accumulator (`src/core/claude-setup.ts`).
- Preserve existing root `README.md` and `CLAUDE.md` by default (skip writing) and add a warning entry to `ClaudeSetupResult.warnings` when overwrite is skipped; files under `.claude/` and `docs/context/` continue to be regenerated.
- Update the setup command documentation to describe `--force` / `--no-force` behavior and protected-file semantics (`commands/setup.md`).
- Add unit tests covering preservation of existing `README.md` and `CLAUDE.md` and intentional overwrites when `force: true` (`test/unit/core/claude-setup.test.ts`).

### Testing
- Ran the targeted unit tests with `npm test -- --run test/unit/core/claude-setup.test.ts`, and all tests passed.
- Ran `npm run typecheck`, which failed due to pre-existing, project-wide TypeScript/environment issues unrelated to this change (missing Node/module typings and other unrelated errors); these typecheck failures did not affect the implemented unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba107a970832a90d095ff73d6be85)