### PR TITLE
Refine nested repository discovery

### DIFF
--- a/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
+++ b/plugins/claude-code-templating-plugin/src/core/claude-setup.ts
@@ -381,11 +381,11 @@ export class ClaudeSetupManager {
       }
 
       const fullPath = join(currentPath, entry.name);
-      if (entry.name === '.claude') {
+      if (entry.name === '.claude' || this.isExcludedClaudeDirectory(fullPath)) {
         continue;
       }
 
-      if (this.isRepositoryCandidate(fullPath, entry.name)) {
+      if (this.isRepositoryCandidate(fullPath)) {
         discovered.add(fullPath);
       }
 
@@ -393,19 +393,38 @@ export class ClaudeSetupManager {
     }
   }
 
-  private isRepositoryCandidate(directoryPath: string, directoryName: string): boolean {
-    if (directoryName.toLowerCase().includes('repository') || directoryName.toLowerCase().includes('repo')) {
-      return true;
-    }
+  private isRepositoryCandidate(directoryPath: string): boolean {
+    const repositoryMarkers = [
+      '.git',
+      'package.json',
+      'pyproject.toml',
+      'requirements.txt',
+      'go.mod',
+      'Cargo.toml',
+    ];
 
-    const markers = ['.git', 'package.json', 'pyproject.toml', 'go.mod', 'Cargo.toml'];
-    for (const marker of markers) {
+    for (const marker of repositoryMarkers) {
       if (existsSync(join(directoryPath, marker))) {
         return true;
       }
     }
 
     return false;
+  }
+
+  private isExcludedClaudeDirectory(directoryPath: string): boolean {
+    const claudeSubpath = this.getClaudeSubpath(directoryPath);
+    return claudeSubpath.length === 1 && ['skills', 'templates', 'agents', 'hooks'].includes(claudeSubpath[0] ?? '');
+  }
+
+  private getClaudeSubpath(directoryPath: string): string[] {
+    const segments = directoryPath.split(/[\\/]+/);
+    const claudeSegmentIndex = segments.lastIndexOf('.claude');
+    if (claudeSegmentIndex === -1) {
+      return [];
+    }
+
+    return segments.slice(claudeSegmentIndex + 1);
   }
 
   private async installRequiredLsps(projectRoot: string, profile: DetectedProjectProfile): Promise<{ installed: string[]; warnings: string[] }> {

--- a/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
+++ b/plugins/claude-code-templating-plugin/test/unit/core/claude-setup.test.ts
@@ -126,7 +126,7 @@ describe('ClaudeSetupManager', () => {
     );
   });
 
-  it('adds local .claude docs for nested repositories under the root .claude tree', async () => {
+  it('adds local .claude docs for a real nested repo under .claude/repositories', async () => {
     await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
     const nestedRepo = join(tempRoot, '.claude', 'repositories', 'sample-repo');
     await mkdir(nestedRepo, { recursive: true });
@@ -143,6 +143,38 @@ describe('ClaudeSetupManager', () => {
 
     const nestedReadme = await readFile(join(nestedRepo, '.claude', 'README.md'), 'utf-8');
     expect(nestedReadme).toContain('Nested Repository Claude Workspace');
+  });
+
+  it('ignores false-positive repository folder names inside plugin-managed .claude/templates', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
+    const templateFolder = join(tempRoot, '.claude', 'templates', 'repository-guidelines');
+    await mkdir(templateFolder, { recursive: true });
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'update',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(result.nestedRepositories).not.toContain('.claude/templates/repository-guidelines');
+    await expect(readFile(join(templateFolder, '.claude', 'README.md'), 'utf-8')).rejects.toThrow();
+  });
+
+  it('ignores folders with repo in the name when they have no repository markers', async () => {
+    await writeFile(join(tempRoot, 'package.json'), JSON.stringify({ name: 'root-app' }), 'utf-8');
+    const fakeRepoFolder = join(tempRoot, '.claude', 'workspace-repo-cache');
+    await mkdir(fakeRepoFolder, { recursive: true });
+
+    const manager = new ClaudeSetupManager();
+    const result = await manager.ensureProjectSetup({
+      mode: 'update',
+      projectRoot: tempRoot,
+      installLsps: false,
+    });
+
+    expect(result.nestedRepositories).not.toContain('.claude/workspace-repo-cache');
+    await expect(readFile(join(fakeRepoFolder, '.claude', 'README.md'), 'utf-8')).rejects.toThrow();
   });
 
   it('attempts to install relevant LSP packages for node-based projects', async () => {


### PR DESCRIPTION
### Motivation
- Prevent creation of local `.claude` files in folders that only look like repos by name and avoid polluting plugin-managed `.claude` trees with generated content.
- Use stronger evidence (repository manifests) to identify real nested repositories and narrow any name-based heuristics to avoid false positives.

### Description
- Replace the previous name-based shortcut in `isRepositoryCandidate` with an explicit marker check for repository manifests (`.git`, `package.json`, `pyproject.toml`, `requirements.txt`, `go.mod`, `Cargo.toml`).
- Skip traversal of known plugin-managed `.claude` subfolders by adding `isExcludedClaudeDirectory` which ignores `skills`, `templates`, `agents`, and `hooks` when walking `.claude`.
- Add `getClaudeSubpath` helper to parse the `.claude`-relative path segments used by exclusion logic.
- Add unit tests in `test/unit/core/claude-setup.test.ts` to cover a real nested repo under `.claude/repositories/sample-repo`, a false-positive folder under `.claude/templates/repository-guidelines`, and a folder with `repo` in the name but no repo markers.

### Testing
- Ran the targeted unit suite with `npx vitest run test/unit/core/claude-setup.test.ts` and the tests passed (1 file, 8 tests, all passed).
- Ran the package typecheck with `npm run typecheck`, which failed due to pre-existing repository-wide TypeScript/dependency configuration issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba35abccc832aa4a0f76ac533739c)