### PR TITLE
Add marketplace item update command with registry drift detection

### DIFF
--- a/.claude/commands/plugin-update.md
+++ b/.claude/commands/plugin-update.md
@@ -77,18 +77,28 @@ Updates respect these constraints and check compatibility.
 
 ## Update Process
 
-1. **Check Current Version**: Read installed plugin version
-2. **Query Registry**: Find latest available version
-3. **Check Compatibility**: Verify semver constraints
-4. **Check Dependencies**: Ensure dependency compatibility
-5. **Run Pre-Update Hooks**: Execute plugin's pre-update script
-6. **Backup Current Version**: Create backup (optional)
-7. **Download/Clone New Version**: Fetch updated plugin
-8. **Validate New Version**: Check plugin structure
-9. **Update Registry**: Update plugin metadata
-10. **Run Post-Update Hooks**: Execute plugin's post-update script
-11. **Run Tests**: Validate plugin works (if configured)
-12. **Generate Report**: Show update summary
+1. **Detect Unregistered Plugins**: Scan `plugins/` for directories with `.claude-plugin/plugin.json` that are missing from `plugins.index.json`. Register them before proceeding.
+2. **Check Current Version**: Read installed plugin version from registry AND from on-disk `plugin.json` manifest. If they differ, the registry is stale.
+3. **Query Registry**: Find latest available version
+4. **Check Compatibility**: Verify semver constraints
+5. **Check Dependencies**: Ensure dependency compatibility
+6. **Run Pre-Update Hooks**: Execute plugin's pre-update script
+7. **Backup Current Version**: Create backup (optional)
+8. **Download/Clone New Version**: Fetch updated plugin
+9. **Validate New Version**: Check plugin structure
+10. **Update Registry**: Update plugin metadata in all sections (`installed`, `registry`, `plugins`, `callsignRegistry`, `stats`)
+11. **Run Post-Update Hooks**: Execute plugin's post-update script
+12. **Run Tests**: Validate plugin works (if configured)
+13. **Generate Report**: Show update summary
+
+### Registry Drift Detection (Step 1-2)
+
+Plugins can become unregistered when:
+- Manually copied into `plugins/` without running `/plugin-install`
+- Installed via marketplace but the registry entry was not persisted
+- Plugin was updated on disk but the registry version was not bumped
+
+The update command now scans for these drift cases and fixes them automatically before proceeding with the version update.
 
 ## Examples
 

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -114,6 +114,20 @@
       "source": "local",
       "installedAt": "2026-03-16T00:00:00.000Z",
       "dependencies": {}
+    },
+    "claude-code-expert": {
+      "version": "6.0.0",
+      "path": "../plugins/claude-code-expert",
+      "source": "local",
+      "installedAt": "2026-03-08T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "cowork-marketplace": {
+      "version": "1.0.0",
+      "path": "../plugins/cowork-marketplace",
+      "source": "local",
+      "installedAt": "2026-02-23T00:00:00.000Z",
+      "dependencies": {}
     }
   },
   "registry": {
@@ -310,6 +324,26 @@
         "orchestration"
       ]
     },
+    "claude-code-expert": {
+      "name": "claude-code-expert",
+      "version": "6.0.0",
+      "description": "High-intelligence Claude Code copilot with deep code reasoning, orchestration, CI/CD, enterprise security, and MCP documentation server",
+      "author": {
+        "name": "Markus Ahling"
+      },
+      "keywords": [
+        "claude-code",
+        "expert",
+        "orchestration",
+        "mcp",
+        "debugging",
+        "enterprise"
+      ],
+      "categories": [
+        "developer-tools",
+        "orchestration"
+      ]
+    },
     "drawio-diagramming": {
       "name": "drawio-diagramming",
       "version": "1.0.0",
@@ -443,7 +477,22 @@
         "tier": "standard"
       }
     },
+    "developer-tools": {
+      "claude-code-expert": {
+        "path": "../plugins/claude-code-expert/.claude-plugin/plugin.json",
+        "callsign": "Expert",
+        "version": "6.0.0",
+        "status": "active",
+        "tier": "standard"
+      }
+    },
     "marketplace-ecosystem": {
+      "cowork-marketplace": {
+        "path": "../plugins/cowork-marketplace/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
       "marketplace-pro": {
         "path": "../plugins/marketplace-pro/.claude-plugin/plugin.json",
         "version": "1.0.0",
@@ -510,19 +559,20 @@
     "Migrator": "migration-wizard",
     "TestForge": "testforge",
     "Consul": "tvs-microsoft-deploy",
-    "Cartographer": "drawio-diagramming"
+    "Cartographer": "drawio-diagramming",
+    "Expert": "claude-code-expert"
   },
   "stats": {
-    "totalInstalled": 16,
-    "totalPlugins": 22,
+    "totalInstalled": 18,
+    "totalPlugins": 24,
     "totalAvailable": 6,
-    "lastUpdated": "2026-03-16T00:00:00.000Z",
+    "lastUpdated": "2026-03-19T00:00:00.000Z",
     "byTier": {
       "enterprise": 1,
-      "standard": 20
+      "standard": 22
     },
     "byLocation": {
-      "plugins/": 16,
+      "plugins/": 18,
       ".claude/plugins/": 6
     }
   }

--- a/plugins/cowork-marketplace/CLAUDE.md
+++ b/plugins/cowork-marketplace/CLAUDE.md
@@ -1,6 +1,6 @@
 # Cowork Marketplace Plugin
 
-Browse, install, launch, and export cowork marketplace items backed by real plugin agents, skills, and commands.
+Browse, install, update, launch, and export cowork marketplace items backed by real plugin agents, skills, and commands.
 
 ## Available Commands
 
@@ -8,6 +8,7 @@ Browse, install, launch, and export cowork marketplace items backed by real plug
 |---------|------------|
 | `/cowork-marketplace:browse` | Search and discover marketplace items |
 | `/cowork-marketplace:install` | Install an item and activate its plugin bindings |
+| `/cowork-marketplace:update` | Update an item by re-syncing plugin bindings and registry |
 | `/cowork-marketplace:launch` | Start a cowork session with an installed item |
 | `/cowork-marketplace:details` | View full item details, trust score, and plugin bindings |
 | `/cowork-marketplace:collections` | Browse 10 curated collections by domain |
@@ -24,13 +25,13 @@ Browse, install, launch, and export cowork marketplace items backed by real plug
 
 ## Skills
 
-- **plugin-catalog** - Catalog knowledge (17 items, 16 plugins, 136+ agents)
+- **plugin-catalog** - Catalog knowledge (18 items, 18 plugins, 136+ agents)
 - **cowork-sessions** - Session lifecycle and agent coordination
 - **plugin-packaging** - Cowork plugin format and distribution
 
 ## Catalog
 
-17 items across 5 types, backed by 16 installed plugins:
+18 items across 5 types, backed by 18 installed plugins:
 - 3 Templates (FastAPI, Fullstack, Home Assistant)
 - 4 Workflows (Jira-to-PR, EKS Deploy, Microsoft Platform, Sprint Planning)
 - 3 Agent Configs (Code Reviewer, Nonprofit Director, Design Architect)

--- a/plugins/cowork-marketplace/commands/index.json
+++ b/plugins/cowork-marketplace/commands/index.json
@@ -119,6 +119,19 @@
       "risk": "low",
       "cost": "medium",
       "path": "commands/bundle-export.md"
+    },
+    {
+      "name": "cowork-marketplace:update",
+      "intent": "Update an installed marketplace item by re-syncing plugin bindings and registry",
+      "tags": [
+        "cowork-marketplace",
+        "command",
+        "update"
+      ],
+      "inputs": [],
+      "risk": "low",
+      "cost": "low",
+      "path": "commands/update.md"
     }
   ]
 }

--- a/plugins/cowork-marketplace/commands/update.md
+++ b/plugins/cowork-marketplace/commands/update.md
@@ -1,0 +1,92 @@
+---
+name: cowork-marketplace:update
+intent: Update an installed marketplace item by re-syncing its plugin bindings and registry entry
+tags:
+  - cowork-marketplace
+  - command
+  - update
+inputs: []
+risk: low
+cost: low
+description: Update a marketplace item's underlying plugin to its latest version, re-sync catalog bindings, and refresh the plugin registry
+---
+
+# Update Marketplace Item
+
+Update an installed marketplace item by refreshing its plugin bindings, re-syncing the catalog version, and updating the plugin registry entry.
+
+## Usage
+```
+/cowork-marketplace:update <item-name|item-id> [--dry-run] [--force] [--all]
+```
+
+## Options
+- `--dry-run` - Show what would change without applying updates
+- `--force` - Force update even if versions match
+- `--all` - Update all installed marketplace items
+
+## Examples
+
+### Update a specific item
+```
+/cowork-marketplace:update claude-code-mastery
+```
+
+### Preview changes
+```
+/cowork-marketplace:update claude-code-mastery --dry-run
+```
+
+### Update all marketplace items
+```
+/cowork-marketplace:update --all
+```
+
+## How It Works
+
+1. **Resolve item** - Find the item in `catalog.json` by name or ID
+2. **Read current state** - Check `plugins.index.json` for each bound plugin's registered version
+3. **Compare versions** - Compare registry version against plugin manifest (`plugin.json`) version
+4. **Detect drift** - Identify plugins that exist on disk but are missing from the registry
+5. **Sync registry** - Add missing plugins to `plugins.index.json` with correct version and path
+6. **Update version** - Bump the registry version to match the plugin manifest version
+7. **Re-sync bindings** - Verify all agents, skills, and commands in `pluginBindings` exist on disk
+8. **Report** - Display update summary with what changed
+
+## What Gets Updated
+
+### Registry Sync
+- Adds missing plugins to `plugins.index.json` `installed` section
+- Updates version numbers to match actual `plugin.json` manifests
+- Adds missing entries to `registry` metadata section
+- Updates `plugins` categorization section
+- Refreshes `callsignRegistry` entries
+- Recalculates `stats` counts
+
+### Binding Validation
+- Verifies each agent listed in `pluginBindings` has a corresponding `.md` file
+- Verifies each skill listed has a corresponding skill directory with `SKILL.md`
+- Verifies each command listed has a corresponding `.md` file
+- Reports broken bindings that reference non-existent files
+
+### Version Drift Detection
+Common scenarios this fixes:
+- Plugin was installed manually (copied to `plugins/`) but never registered
+- Plugin was updated (new version in `plugin.json`) but registry still shows old version
+- Plugin was added via marketplace install but registry entry was lost
+- Catalog references a plugin that exists on disk but isn't tracked
+
+## Troubleshooting
+
+### "Plugin not found in registry"
+The plugin exists on disk but was never registered. This command will add it.
+
+### "Version mismatch"
+The registry shows an old version but the plugin manifest has a newer version. This command will sync them.
+
+### "Broken binding"
+A catalog item references an agent/skill/command that doesn't exist in the plugin directory. Check the plugin's actual file structure.
+
+## Skills Used
+- plugin-catalog
+- plugin-packaging


### PR DESCRIPTION
## Summary

This PR adds a new `/cowork-marketplace:update` command that updates installed marketplace items by re-syncing plugin bindings and refreshing the plugin registry. It also introduces registry drift detection to handle plugins that exist on disk but are missing from or out-of-sync with the registry.

## Key Changes

- **New Command**: Added `cowork-marketplace:update` command that:
  - Updates marketplace items by re-syncing plugin bindings and registry entries
  - Supports `--dry-run`, `--force`, and `--all` options
  - Validates that all referenced agents, skills, and commands exist on disk
  - Detects and reports version mismatches between registry and plugin manifests

- **Registry Drift Detection**: Enhanced plugin update process to:
  - Scan `plugins/` directory for unregistered plugins (those with `.claude-plugin/plugin.json` but missing from `plugins.index.json`)
  - Compare registry versions against actual plugin manifest versions
  - Automatically register missing plugins before proceeding with updates
  - Handle common scenarios like manual plugin installation or lost registry entries

- **Registry Updates**: Registered two new plugins:
  - `claude-code-expert` (v6.0.0) - High-intelligence code copilot with orchestration and enterprise security
  - `cowork-marketplace` (v1.0.0) - The marketplace plugin itself

- **Documentation**: 
  - Updated `plugin-update.md` to document the new registry drift detection process
  - Updated `CLAUDE.md` to reflect the new update command and increased catalog size (18 items, 18 plugins)

## Implementation Details

The update command performs a comprehensive sync that includes:
1. Resolving items by name or ID from the catalog
2. Reading current state from `plugins.index.json`
3. Comparing versions between registry and plugin manifests
4. Detecting plugins that exist on disk but are missing from registry
5. Syncing all registry sections: `installed`, `registry`, `plugins`, `callsignRegistry`, and `stats`
6. Validating all plugin bindings reference existing files

This addresses the common issue where plugins can become unregistered when manually copied to `plugins/` or when registry entries are lost during installation.

https://claude.ai/code/session_01BT7iMxjBtyWGEMjXP46Tnb