### PR TITLE
feat(claude-code-expert): add channels, agent-teams, scheduled-tasks, checkpointing skills

### DIFF
--- a/.claude/registry/skills.index.json
+++ b/.claude/registry/skills.index.json
@@ -76,6 +76,9 @@
     "lobbi-platform-manager:agentic-patterns": "../plugins/lobbi-platform-manager/skills/agentic-patterns/SKILL.md",
     "tvs-microsoft-deploy:agentic-patterns": "../plugins/tvs-microsoft-deploy/skills/agentic-patterns/SKILL.md",
     "claude-code-expert:channels": "../plugins/claude-code-expert/skills/channels/SKILL.md",
-    "claude-code-expert:channels-user-guide": "../plugins/claude-code-expert/skills/channels-user-guide/SKILL.md"
+    "claude-code-expert:channels-user-guide": "../plugins/claude-code-expert/skills/channels-user-guide/SKILL.md",
+    "claude-code-expert:agent-teams": "../plugins/claude-code-expert/skills/agent-teams/SKILL.md",
+    "claude-code-expert:scheduled-tasks": "../plugins/claude-code-expert/skills/scheduled-tasks/SKILL.md",
+    "claude-code-expert:checkpointing": "../plugins/claude-code-expert/skills/checkpointing/SKILL.md"
   }
 }

--- a/.claude/registry/skills.index.json
+++ b/.claude/registry/skills.index.json
@@ -74,6 +74,8 @@
     "frontend-design-system:agentic-patterns": "../plugins/frontend-design-system/skills/agentic-patterns/SKILL.md",
     "claude-code-templating:agentic-patterns": "../plugins/claude-code-templating-plugin/skills/agentic-patterns/SKILL.md",
     "lobbi-platform-manager:agentic-patterns": "../plugins/lobbi-platform-manager/skills/agentic-patterns/SKILL.md",
-    "tvs-microsoft-deploy:agentic-patterns": "../plugins/tvs-microsoft-deploy/skills/agentic-patterns/SKILL.md"
+    "tvs-microsoft-deploy:agentic-patterns": "../plugins/tvs-microsoft-deploy/skills/agentic-patterns/SKILL.md",
+    "claude-code-expert:channels": "../plugins/claude-code-expert/skills/channels/SKILL.md",
+    "claude-code-expert:channels-user-guide": "../plugins/claude-code-expert/skills/channels-user-guide/SKILL.md"
   }
 }

--- a/.claude/rules/lessons-learned.md
+++ b/.claude/rules/lessons-learned.md
@@ -1425,3 +1425,32 @@ First entry keys: not a dict
 - **Input:** `N/A`
 - **Error:** Request failed with status code 404
 - **Status:** NEEDS_FIX - Claude should document the fix here after resolving
+
+### Error: Bash failure (2026-03-27T06:09:58Z)
+- **Tool:** Bash
+- **Input:** `node scripts/check-plugin-context.mjs 2>&1`
+- **Error:** Exit code 1
+❌ aws-eks-helm-keycloak: plugin manifest is missing required "contextEntry" field
+❌ claude-code-templating-plugin: plugin manifest is missing required "contextEntry" field
+❌ cowork-marketplace: plugin manifest is missing required "contextEntry" field
+❌ deployment-pipeline: plugin manifest is missing required "contextEntry" field
+❌ drawio-diagramming: plugin manifest is missing required "contextEntry" field
+❌ exec-automator: plugin manifest is missing required "contextEntry" field
+❌ fastapi-backend: plugin manifest is missing required "contextEntry" field
+❌ frontend-design-system: plugin manifest is missing required "contextEntry" field
+❌ fullstack-iac: plugin manifest is missing required "contextEntry" field
+❌ home-assistant-architect: plugin manifest is missing required "contextEntry" field
+❌ jira-orchestrator: plugin manifest is missing required "contextEntry" field
+❌ lobbi-platform-manager: plugin manifest is missing required "contextEntry" field
+❌ marketplace-pro: plugin manifest is missing required "contextEntry" field
+❌ react-animation-studio: plugin manifest is missing required "contextEntry" field
+❌ team-accelerator: plugin manifest is missing required "contextEntry" field
+❌ tvs-microsoft-deploy: plugin manifest is missing required "contextEntry" field
+❌ upgrade-suggestion: plugin manifest is missing required "contextEntry" field
+- **Status:** NEEDS_FIX - Claude should document the fix here after resolving
+
+### Error: mcp__github__resolve_review_thread failure (2026-03-27T06:10:34Z)
+- **Tool:** mcp__github__resolve_review_thread
+- **Input:** `N/A`
+- **Error:** GitHub GraphQL error: GraphQL error: Could not resolve to a node with the global id of 'PRT_kwDOOYmw3s6XJG7l'.
+- **Status:** NEEDS_FIX - Claude should document the fix here after resolving

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -200,7 +200,7 @@
     ]
   },
   "attribution": {
-    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
-    "pr": "Generated with Claude Code"
+    "commit": "⚡ Engineered by Markus AI\n\nCo-Authored-By: Markus AI Platform <ai@markus41.dev>",
+    "pr": "⚡ Engineered by Markus AI Platform"
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -201,6 +201,6 @@
   },
   "attribution": {
     "commit": "",
-    "pr": "[![Built by Markus](https://img.shields.io/badge/built%20by-Markus%20Ahling-ff6b35?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0xMiAyTDEgMjFoMjJMMTIgMnptMCw0bDcuNTMgMTNINi40N0wxMiA2eiIvPjwvc3ZnPg==&logoColor=white)](https://github.com/markus41)"
+    "pr": "---\n\n<div align=\"center\">\n\n[![Markus Ahling](https://img.shields.io/badge/%E2%9A%A1-markus41-000000?style=for-the-badge&labelColor=FF4500&color=1a1a2e)](https://github.com/markus41) [![Marketplace](https://img.shields.io/badge/plugin-marketplace-blueviolet?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/markus41/claude) [![Status](https://img.shields.io/badge/status-shipped%20%F0%9F%9A%80-brightgreen?style=for-the-badge)](https://github.com/markus41/claude)\n\n*architecture by humans, velocity by machines*\n\n</div>"
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -200,7 +200,7 @@
     ]
   },
   "attribution": {
-    "commit": "⚡ Engineered by Markus AI\n\nCo-Authored-By: Markus AI Platform <ai@markus41.dev>",
-    "pr": "⚡ Engineered by Markus AI Platform"
+    "commit": "",
+    "pr": "[![Built by Markus](https://img.shields.io/badge/built%20by-Markus%20Ahling-ff6b35?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0xMiAyTDEgMjFoMjJMMTIgMnptMCw0bDcuNTMgMTNINi40N0wxMiA2eiIvPjwvc3ZnPg==&logoColor=white)](https://github.com/markus41)"
   }
 }

--- a/plugins/claude-code-expert/.claude-plugin/plugin.json
+++ b/plugins/claude-code-expert/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.local/schemas/plugin.schema.json",
   "name": "claude-code-expert",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "High-intelligence Claude Code copilot with deep code reasoning, evidence-driven planning, orchestration-first execution, model routing, context budgeting, CI/CD integration, enterprise security, plugin development, prompt engineering, performance profiling, agent teams, channels (MCP event streaming), interactive tutorials, and a queryable 10-tool MCP documentation server.",
   "author": {
     "name": "Markus Ahling"
@@ -68,7 +68,11 @@
     "channels",
     "mcp-channels",
     "webhooks",
-    "permission-relay"
+    "permission-relay",
+    "scheduled-tasks",
+    "cron",
+    "checkpointing",
+    "rewind"
   ],
   "permissions": {
     "requires": [
@@ -95,7 +99,10 @@
       "enterprise-security",
       "plugin-development-guide",
       "session-analytics",
-      "channels-event-streaming"
+      "channels-event-streaming",
+      "agent-teams-orchestration",
+      "scheduled-tasks",
+      "checkpointing"
     ],
     "requires": []
   },
@@ -142,7 +149,10 @@
       "commands/cc-budget.md",
       "commands/cc-cicd.md",
       "skills/channels/SKILL.md",
-      "skills/channels-user-guide/SKILL.md"
+      "skills/channels-user-guide/SKILL.md",
+      "skills/agent-teams/SKILL.md",
+      "skills/scheduled-tasks/SKILL.md",
+      "skills/checkpointing/SKILL.md"
     ]
   }
 }

--- a/plugins/claude-code-expert/.claude-plugin/plugin.json
+++ b/plugins/claude-code-expert/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.local/schemas/plugin.schema.json",
   "name": "claude-code-expert",
   "version": "7.0.0",
-  "description": "High-intelligence Claude Code copilot with deep code reasoning, evidence-driven planning, orchestration-first execution, model routing, context budgeting, CI/CD integration, enterprise security, plugin development, prompt engineering, performance profiling, agent teams, interactive tutorials, and a queryable 10-tool MCP documentation server.",
+  "description": "High-intelligence Claude Code copilot with deep code reasoning, evidence-driven planning, orchestration-first execution, model routing, context budgeting, CI/CD integration, enterprise security, plugin development, prompt engineering, performance profiling, agent teams, channels (MCP event streaming), interactive tutorials, and a queryable 10-tool MCP documentation server.",
   "author": {
     "name": "Markus Ahling"
   },
@@ -64,7 +64,11 @@
     "evaluation-monitoring",
     "a2a-communication",
     "resource-optimization",
-    "reasoning-techniques"
+    "reasoning-techniques",
+    "channels",
+    "mcp-channels",
+    "webhooks",
+    "permission-relay"
   ],
   "permissions": {
     "requires": [
@@ -90,7 +94,8 @@
       "model-routing",
       "enterprise-security",
       "plugin-development-guide",
-      "session-analytics"
+      "session-analytics",
+      "channels-event-streaming"
     ],
     "requires": []
   },
@@ -135,7 +140,9 @@
       "skills/prompt-engineering/SKILL.md",
       "skills/enterprise-security/SKILL.md",
       "commands/cc-budget.md",
-      "commands/cc-cicd.md"
+      "commands/cc-cicd.md",
+      "skills/channels/SKILL.md",
+      "skills/channels-user-guide/SKILL.md"
     ]
   }
 }

--- a/plugins/claude-code-expert/skills/agent-teams/SKILL.md
+++ b/plugins/claude-code-expert/skills/agent-teams/SKILL.md
@@ -1,0 +1,196 @@
+# Agent Teams
+
+> Orchestrate teams of Claude Code sessions working together with shared tasks, inter-agent messaging, and centralized management.
+> Experimental feature — requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable.
+> Requires Claude Code v2.1.32+.
+
+## Overview
+
+Agent teams let you coordinate multiple Claude Code instances working together. One session acts as the **team lead**, coordinating work, assigning tasks, and synthesizing results. Teammates work independently, each in its own context window, and communicate directly with each other.
+
+Unlike subagents (which run within a single session and only report back), you can interact with individual teammates directly without going through the lead.
+
+## When to Use Agent Teams
+
+Best use cases:
+- **Research and review**: multiple teammates investigate different aspects simultaneously, share and challenge findings
+- **New modules or features**: teammates each own a separate piece without stepping on each other
+- **Debugging with competing hypotheses**: test different theories in parallel, converge faster
+- **Cross-layer coordination**: changes spanning frontend, backend, and tests, each owned by different teammate
+
+**When NOT to use**: Sequential tasks, same-file edits, or work with many dependencies → use single session or subagents.
+
+### Subagents vs Agent Teams
+
+|                   | Subagents | Agent Teams |
+|:-----------------|:----------|:------------|
+| **Context** | Own window; results return to caller | Own window; fully independent |
+| **Communication** | Report back to main agent only | Message each other directly |
+| **Coordination** | Main agent manages all work | Shared task list with self-coordination |
+| **Best for** | Focused tasks where only result matters | Complex work requiring discussion |
+| **Token cost** | Lower: results summarized back | Higher: each is a separate Claude instance |
+
+## Enable Agent Teams
+
+```json
+// settings.json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+## Starting a Team
+
+Describe the task and team structure in natural language:
+
+```
+I'm designing a CLI tool that helps developers track TODO comments.
+Create an agent team: one on UX, one on technical architecture, one as devil's advocate.
+```
+
+Claude creates the team, spawns teammates, coordinates work, and cleans up when finished.
+
+## Display Modes
+
+| Mode | Description | Setup |
+|------|-------------|-------|
+| **In-process** | All teammates in main terminal. `Shift+Down` to cycle. | Works anywhere |
+| **Split panes** | Each teammate gets own pane. Click to interact. | Requires tmux or iTerm2 |
+| **Auto** (default) | Split panes if in tmux, in-process otherwise | — |
+
+Configure in settings.json:
+```json
+{ "teammateMode": "in-process" }
+```
+
+Or per-session:
+```bash
+claude --teammate-mode in-process
+```
+
+## Controlling Teams
+
+### Specify Teammates and Models
+```
+Create a team with 4 teammates to refactor these modules in parallel.
+Use Sonnet for each teammate.
+```
+
+### Require Plan Approval
+```
+Spawn an architect teammate to refactor the auth module.
+Require plan approval before they make any changes.
+```
+Teammate works in read-only plan mode until lead approves. Lead reviews and approves/rejects autonomously — influence with criteria like "only approve plans that include test coverage."
+
+### Talk to Teammates Directly
+- **In-process**: `Shift+Down` to cycle, type to message. `Enter` to view session, `Esc` to interrupt. `Ctrl+T` for task list.
+- **Split panes**: Click into pane to interact.
+
+### Task Management
+Shared task list coordinates work. Tasks have states: pending → in progress → completed. Tasks support dependencies.
+
+- **Lead assigns**: Tell lead which task for which teammate
+- **Self-claim**: Teammate picks up next unassigned, unblocked task automatically
+
+Task claiming uses file locking to prevent race conditions.
+
+### Shutdown
+```
+Ask the researcher teammate to shut down
+```
+Then clean up:
+```
+Clean up the team
+```
+Always use the lead to clean up (not teammates).
+
+## Quality Gates with Hooks
+
+| Hook | When it runs | Exit code 2 behavior |
+|------|-------------|---------------------|
+| `TeammateIdle` | Teammate about to go idle | Send feedback, keep working |
+| `TaskCreated` | Task being created | Prevent creation with feedback |
+| `TaskCompleted` | Task being marked complete | Prevent completion with feedback |
+
+## Architecture
+
+| Component | Role |
+|:----------|:-----|
+| **Team lead** | Main session that creates team, spawns teammates, coordinates |
+| **Teammates** | Separate Claude Code instances working on assigned tasks |
+| **Task list** | Shared work items that teammates claim and complete |
+| **Mailbox** | Messaging system for inter-agent communication |
+
+Storage:
+- Team config: `~/.claude/teams/{team-name}/config.json`
+- Task list: `~/.claude/tasks/{team-name}/`
+
+### Permissions
+Teammates inherit lead's permission settings. Can change individual modes after spawning.
+
+### Context and Communication
+- Each teammate has own context window, loads same project context (CLAUDE.md, MCP, skills)
+- Lead's conversation history does NOT carry over
+- Messages delivered automatically between teammates
+- Idle notifications sent automatically to lead
+- Shared task list visible to all agents
+
+### Git Integration
+Each teammate gets its own git worktree (isolated branch). On completion, changes merge back. If conflicts occur:
+- Fast-forward merges when possible
+- Lead resolves conflicts when they arise
+- Teammates can also resolve conflicts themselves
+
+## Best Practices
+
+1. **Define clear boundaries**: Give each teammate a distinct area (frontend, backend, tests)
+2. **Start small**: 2-3 teammates before scaling up
+3. **Use plan approval for risky tasks**: Require review before implementation
+4. **Set quality criteria**: Tell the lead what "done" means
+5. **Monitor token usage**: Each teammate is a full Claude instance
+
+## Use Case Examples
+
+### Feature Development
+```
+Create a team to implement user authentication:
+- Backend teammate: API routes, middleware, JWT handling
+- Frontend teammate: login form, token storage, protected routes
+- Test teammate: integration tests for the full auth flow
+```
+
+### Code Review
+```
+Create a review team for PR #456:
+- Security reviewer: check for vulnerabilities
+- Performance reviewer: identify bottlenecks
+- Architecture reviewer: evaluate design decisions
+Have them discuss findings and produce a unified review.
+```
+
+### Debugging
+```
+The /api/orders endpoint is returning 500 errors intermittently.
+Create a debugging team:
+- One teammate investigates the database layer
+- One teammate traces the request handling pipeline
+- One teammate analyzes recent deployments and config changes
+```
+
+## Limitations
+
+- **Session resumption**: Resumed sessions may not fully restore team state
+- **Task coordination**: Complex task dependency graphs can cause deadlocks
+- **Shutdown**: Teammates may not always shut down cleanly; always clean up via lead
+- **Token cost**: Significantly more expensive than single sessions or subagents
+- **No cross-machine**: All teammates run on the same machine
+
+## See Also
+
+- [Subagents](https://code.claude.com/docs/en/sub-agents) — Lighter-weight parallel workers
+- [Interactive Mode](https://code.claude.com/docs/en/interactive-mode) — Keyboard shortcuts and task list
+- [Hooks](https://code.claude.com/docs/en/hooks) — Quality gates for team workflows
+- [Settings](https://code.claude.com/docs/en/settings) — Configuration options

--- a/plugins/claude-code-expert/skills/channels-user-guide/SKILL.md
+++ b/plugins/claude-code-expert/skills/channels-user-guide/SKILL.md
@@ -1,0 +1,167 @@
+# Channels User Guide
+
+> Push events into a running Claude Code session with channels.
+> Forward CI results, chat messages, monitoring alerts, and webhook events so Claude can react while you're away.
+> Requires Claude Code v2.1.80+. Research preview — requires claude.ai login.
+
+## Overview
+
+A channel is an MCP server that pushes events into your running Claude Code session, so Claude can react to things that happen while you're not at the terminal. Channels can be two-way: Claude reads the event and replies back through the same channel, like a chat bridge.
+
+Events only arrive while the session is open. For always-on setups, run Claude in a background process or persistent terminal.
+
+### Key Differences from Other Features
+
+| Feature | What it does | Good for |
+|---------|-------------|----------|
+| Claude Code on the web | Runs tasks in a fresh cloud sandbox, cloned from GitHub | Delegating self-contained async work |
+| Claude in Slack | Spawns a web session from an `@Claude` mention | Starting tasks from team conversation |
+| Standard MCP server | Claude queries it during a task; nothing is pushed | On-demand access to read or query |
+| Remote Control | Drive your local session from claude.ai or mobile | Steering an in-progress session remotely |
+| **Channels** | **Push events from external sources into running session** | **CI alerts, chat bridges, webhooks, monitoring** |
+
+Channels fill the gap by pushing events from non-Claude sources into your already-running local session.
+
+## Supported Channels
+
+### Telegram
+
+1. **Create bot**: Open [BotFather](https://t.me/BotFather), send `/newbot`, copy the token
+2. **Install**: `/plugin install telegram@claude-plugins-official`
+3. **Configure**: `/telegram:configure <token>` (saves to `~/.claude/channels/telegram/.env`)
+4. **Start**: `claude --channels plugin:telegram@claude-plugins-official`
+5. **Pair**: Message your bot on Telegram, get pairing code, run `/telegram:access pair <code>`
+6. **Lock down**: `/telegram:access policy allowlist`
+
+### Discord
+
+1. **Create bot**: [Discord Developer Portal](https://discord.com/developers/applications) → New Application → Bot → Reset Token
+2. **Enable Message Content Intent**: Bot settings → Privileged Gateway Intents → Message Content Intent
+3. **Invite**: OAuth2 → URL Generator → `bot` scope → View Channels, Send Messages, Send Messages in Threads, Read Message History, Attach Files, Add Reactions
+4. **Install**: `/plugin install discord@claude-plugins-official`
+5. **Configure**: `/discord:configure <token>`
+6. **Start**: `claude --channels plugin:discord@claude-plugins-official`
+7. **Pair**: DM your bot, get code, run `/discord:access pair <code>`
+8. **Lock down**: `/discord:access policy allowlist`
+
+### iMessage (macOS only)
+
+Reads Messages database directly, sends replies through AppleScript. No bot token needed.
+
+1. **Grant Full Disk Access**: System Settings → Privacy & Security → Full Disk Access → add your terminal
+2. **Install**: `/plugin install imessage@claude-plugins-official`
+3. **Start**: `claude --channels plugin:imessage@claude-plugins-official`
+4. **Self-chat**: Text yourself — bypasses access control automatically
+5. **Allow others**: `/imessage:access allow +15551234567` (phone or Apple ID email)
+
+### Fakechat (Demo)
+
+Localhost demo channel — no authentication, no external services.
+
+1. **Install**: `/plugin install fakechat@claude-plugins-official`
+2. **Start**: `claude --channels plugin:fakechat@claude-plugins-official`
+3. **Open UI**: [http://localhost:8787](http://localhost:8787) and type a message
+4. Events arrive as `<channel source="fakechat">` tags
+
+## Build & Pipeline Use Cases
+
+Channels are especially powerful for CI/CD and infrastructure workflows:
+
+### CI/CD Webhook Channel
+Push build failures, test results, and deployment status directly into your session:
+- **Build failure alerts**: Claude receives the failure, reads the build log, and starts investigating
+- **Test result streaming**: Failed test details arrive where Claude has your code open
+- **Deploy status**: Post-deploy health checks forwarded for Claude to monitor
+
+### Monitoring & Alerting Channel
+Forward monitoring events so Claude can react:
+- **Error tracker webhooks**: Sentry/Datadog alerts arrive for immediate root-cause analysis
+- **Infrastructure alerts**: CPU spikes, OOM events, pod restarts
+- **Log anomalies**: Stream unusual log patterns for Claude to investigate
+
+### Pipeline Approval Channel
+Use the permission relay for remote deployment approvals:
+- Claude proposes a deployment action
+- Approval prompt forwarded to your phone via Telegram/Discord
+- You approve remotely, deployment proceeds
+
+### Example: GitHub Actions Webhook → Channel
+```
+GitHub Actions → webhook POST to localhost:8788 → Channel Server → Claude Code Session
+                                                                    ↓
+                                                              Claude reads build log,
+                                                              identifies failure,
+                                                              proposes fix
+```
+
+## Security
+
+### Sender Allowlists
+Every channel maintains a sender allowlist. Only approved IDs can push messages — everyone else is silently dropped.
+
+**Telegram/Discord pairing flow**:
+1. Send any message to your bot
+2. Bot replies with pairing code
+3. Approve in Claude Code: `/telegram:access pair <code>` or `/discord:access pair <code>`
+4. Lock to allowlist: `/telegram:access policy allowlist`
+
+**iMessage**: Self-chat bypasses automatically. Add others with `/imessage:access allow`.
+
+### Important Security Notes
+- Being in `.mcp.json` isn't enough — server must also be named in `--channels`
+- Allowlist also gates permission relay — only allowlist senders you trust with tool approval authority
+- Gate on `message.from.id`, not `message.chat.id` (prevents group chat injection)
+
+## Enterprise Controls
+
+On Team and Enterprise plans, channels are **off by default**.
+
+| Setting | Purpose | When not configured |
+|---------|---------|-------------------|
+| `channelsEnabled` | Master switch. Must be `true` for any channel to deliver messages. | Channels blocked |
+| `allowedChannelPlugins` | Which plugins can register. Replaces Anthropic-maintained list when set. | Anthropic default list applies |
+
+### Enable for organization
+Admin console: **claude.ai → Admin settings → Claude Code → Channels** or set `channelsEnabled: true` in managed settings.
+
+### Restrict plugins
+```json
+{
+  "channelsEnabled": true,
+  "allowedChannelPlugins": [
+    { "marketplace": "claude-plugins-official", "plugin": "telegram" },
+    { "marketplace": "claude-plugins-official", "plugin": "discord" },
+    { "marketplace": "acme-corp-plugins", "plugin": "internal-alerts" }
+  ]
+}
+```
+
+When set, replaces the Anthropic allowlist entirely. Leave unset for default. Empty array blocks all plugins from allowlist (but `--dangerously-load-development-channels` still works).
+
+## Running Channels
+
+```bash
+# Single channel
+claude --channels plugin:telegram@claude-plugins-official
+
+# Multiple channels (space-separated)
+claude --channels plugin:telegram@claude-plugins-official plugin:fakechat@claude-plugins-official
+
+# Development channel (custom/local)
+claude --dangerously-load-development-channels server:my-webhook
+```
+
+## Research Preview Notes
+
+- Rolling out gradually — `--channels` flag syntax may change
+- Only plugins from Anthropic allowlist (or org allowlist) accepted
+- Default approved set: [claude-plugins-official](https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins)
+- Test custom channels with `--dangerously-load-development-channels`
+
+## See Also
+
+- [Channels Reference](../channels/SKILL.md) — Build your own channel (MCP server implementation)
+- [MCP Documentation](https://code.claude.com/docs/en/mcp) — Underlying protocol
+- [Plugins](https://code.claude.com/docs/en/plugins) — Package channels for distribution
+- [Remote Control](https://code.claude.com/docs/en/remote-control) — Drive sessions remotely
+- [Scheduled Tasks](https://code.claude.com/docs/en/scheduled-tasks) — Poll on a timer instead of reacting to pushed events

--- a/plugins/claude-code-expert/skills/channels/SKILL.md
+++ b/plugins/claude-code-expert/skills/channels/SKILL.md
@@ -1,0 +1,289 @@
+# Channels Reference
+
+> Build MCP servers that push webhooks, alerts, and chat messages into a Claude Code session.
+> Requires Claude Code v2.1.80+ (permission relay requires v2.1.81+).
+> Research preview — requires claude.ai login; Console/API key auth not supported.
+
+## What Is a Channel
+
+A channel is an MCP server that pushes events into a Claude Code session so Claude can react to things happening outside the terminal. Claude Code spawns it as a subprocess and communicates over stdio.
+
+**One-way channels**: Forward alerts, webhooks, monitoring events for Claude to act on.
+**Two-way channels**: Also expose a reply tool so Claude can send messages back.
+**Permission relay**: Trusted two-way channels can forward tool approval prompts to remote devices.
+
+### Architecture
+
+```
+External System → Your Channel Server (local) ←stdio→ Claude Code Session
+```
+
+- **Chat platforms** (Telegram, Discord): Plugin polls platform API, forwards messages to Claude
+- **Webhooks** (CI, monitoring): Server listens on local HTTP port, pushes POSTs to Claude
+
+### Built-in Channels (Research Preview)
+
+Telegram, Discord, iMessage, and fakechat are included. Custom channels require `--dangerously-load-development-channels` flag.
+
+## Building a Channel
+
+### Requirements
+
+- `@modelcontextprotocol/sdk` package
+- Node.js-compatible runtime (Bun, Node, Deno)
+- stdio transport (Claude Code spawns as subprocess)
+
+### Minimal One-Way Channel (Webhook Receiver)
+
+```ts
+#!/usr/bin/env bun
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+
+const mcp = new Server(
+  { name: 'webhook', version: '0.0.1' },
+  {
+    // This key makes it a channel — Claude Code registers a listener
+    capabilities: { experimental: { 'claude/channel': {} } },
+    // Added to Claude's system prompt
+    instructions: 'Events from the webhook channel arrive as <channel source="webhook" ...>. Read them and act, no reply expected.',
+  },
+)
+
+await mcp.connect(new StdioServerTransport())
+
+// HTTP server forwards every POST to Claude
+Bun.serve({
+  port: 8788,
+  hostname: '127.0.0.1',
+  async fetch(req) {
+    const body = await req.text()
+    await mcp.notification({
+      method: 'notifications/claude/channel',
+      params: {
+        content: body,
+        meta: { path: new URL(req.url).pathname, method: req.method },
+      },
+    })
+    return new Response('ok')
+  },
+})
+```
+
+### Registration (.mcp.json)
+
+```json
+{
+  "mcpServers": {
+    "webhook": { "command": "bun", "args": ["./webhook.ts"] }
+  }
+}
+```
+
+### Testing
+
+```bash
+# Start with development flag
+claude --dangerously-load-development-channels server:webhook
+
+# In another terminal, send a test event
+curl -X POST localhost:8788 -d "build failed on main: https://ci.example.com/run/1234"
+```
+
+Events arrive as `<channel>` tags:
+```
+<channel source="webhook" path="/" method="POST">build failed on main: https://ci.example.com/run/1234</channel>
+```
+
+## Server Options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `capabilities.experimental['claude/channel']` | `object` | **Required**. Always `{}`. Registers the notification listener. |
+| `capabilities.experimental['claude/channel/permission']` | `object` | Optional. Enables permission relay for remote tool approval. |
+| `capabilities.tools` | `object` | Two-way only. Always `{}`. Enables MCP tool discovery. |
+| `instructions` | `string` | Recommended. Added to Claude's system prompt. Describe events, reply behavior, and routing. |
+
+## Notification Format
+
+Push events via `mcp.notification()` with method `notifications/claude/channel`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `content` | `string` | Event body — becomes body of `<channel>` tag |
+| `meta` | `Record<string, string>` | Optional. Each entry becomes a tag attribute (e.g., `chat_id`, `severity`). Keys: letters, digits, underscores only. |
+
+```ts
+await mcp.notification({
+  method: 'notifications/claude/channel',
+  params: {
+    content: 'build failed on main',
+    meta: { severity: 'high', run_id: '1234' },
+  },
+})
+// Arrives as: <channel source="your-channel" severity="high" run_id="1234">build failed on main</channel>
+```
+
+## Two-Way Channels: Reply Tool
+
+Add a reply tool so Claude can send messages back:
+
+1. Add `tools: {}` to capabilities
+2. Register `ListToolsRequestSchema` and `CallToolRequestSchema` handlers
+3. Update `instructions` to tell Claude when/how to reply
+
+```ts
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [{
+    name: 'reply',
+    description: 'Send a message back over this channel',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chat_id: { type: 'string', description: 'The conversation to reply in' },
+        text: { type: 'string', description: 'The message to send' },
+      },
+      required: ['chat_id', 'text'],
+    },
+  }],
+}))
+
+mcp.setRequestHandler(CallToolRequestSchema, async req => {
+  if (req.params.name === 'reply') {
+    const { chat_id, text } = req.params.arguments as { chat_id: string; text: string }
+    send(`Reply to ${chat_id}: ${text}`)
+    return { content: [{ type: 'text', text: 'sent' }] }
+  }
+  throw new Error(`unknown tool: ${req.params.name}`)
+})
+```
+
+## Sender Gating (Security)
+
+**An ungated channel is a prompt injection vector.** Always check sender identity before emitting notifications:
+
+```ts
+const allowed = new Set(loadAllowlist())
+
+// Gate on sender identity, NOT room/chat identity
+if (!allowed.has(message.from.id)) {
+  return  // drop silently
+}
+await mcp.notification({ ... })
+```
+
+Gate on `message.from.id`, not `message.chat.id` — in group chats these differ, and gating on room would let anyone in an allowlisted group inject messages.
+
+### Pairing Flows
+- **Telegram/Discord**: User DMs bot → bot sends pairing code → user approves in Claude Code → platform ID added to allowlist
+- **iMessage**: Detects user's own addresses from Messages DB at startup, auto-allows
+
+## Permission Relay
+
+Requires Claude Code v2.1.81+. Lets remote users approve/deny tool use from another device.
+
+### How It Works
+
+1. Claude Code generates 5-letter request ID, notifies your server
+2. Server forwards prompt + ID to chat app
+3. User replies `yes <id>` or `no <id>`
+4. Server parses reply into verdict notification back to Claude Code
+
+Local terminal dialog stays open — first answer (local or remote) wins.
+
+### Request ID Format
+Five lowercase letters from `a-z` excluding `l` (avoids confusion with `1`/`I`).
+
+### Permission Request Fields
+
+| Field | Description |
+|-------|-------------|
+| `request_id` | Five-letter ID to echo in verdict |
+| `tool_name` | Tool name (e.g., `Bash`, `Write`) |
+| `description` | Human-readable summary of tool call |
+| `input_preview` | Tool args as JSON, truncated to 200 chars |
+
+### Implementation
+
+```ts
+import { z } from 'zod'
+
+// 1. Declare capability
+capabilities: {
+  experimental: {
+    'claude/channel': {},
+    'claude/channel/permission': {},  // opt in
+  },
+  tools: {},
+},
+
+// 2. Handle incoming permission requests
+const PermissionRequestSchema = z.object({
+  method: z.literal('notifications/claude/channel/permission_request'),
+  params: z.object({
+    request_id: z.string(),
+    tool_name: z.string(),
+    description: z.string(),
+    input_preview: z.string(),
+  }),
+})
+
+mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }) => {
+  send(
+    `Claude wants to run ${params.tool_name}: ${params.description}\n\n` +
+    `Reply "yes ${params.request_id}" or "no ${params.request_id}"`,
+  )
+})
+
+// 3. Parse verdict from inbound messages
+const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
+
+const m = PERMISSION_REPLY_RE.exec(body)
+if (m) {
+  await mcp.notification({
+    method: 'notifications/claude/channel/permission',
+    params: {
+      request_id: m[2].toLowerCase(),
+      behavior: m[1].toLowerCase().startsWith('y') ? 'allow' : 'deny',
+    },
+  })
+  return  // don't also forward as chat
+}
+```
+
+## Publishing as a Plugin
+
+Wrap your channel in a plugin and publish to a marketplace:
+- Users install with `/plugin install`
+- Enable per session with `--channels plugin:<name>@<marketplace>`
+- Custom marketplace channels still need `--dangerously-load-development-channels`
+- Submit to official marketplace for security review and allowlisting
+- Team/Enterprise admins can add to `allowedChannelPlugins` list instead
+
+## Troubleshooting
+
+| Symptom | Diagnosis |
+|---------|-----------|
+| `curl` succeeds but event doesn't reach Claude | Run `/mcp` to check server status. Check `~/.claude/debug/<session-id>.txt` for stderr |
+| `curl` fails with "connection refused" | Port not bound or stale process. `lsof -i :<port>` to check, kill stale process |
+| "blocked by org policy" | Team/Enterprise admin must enable channels first |
+| Permission relay verdict ignored | ID doesn't match open request — check format (5 lowercase letters, no `l`) |
+
+## Key Points
+
+- Channels are MCP servers with `claude/channel` experimental capability
+- Events arrive as `<channel source="name" ...>content</channel>` tags
+- Two-way channels add `tools: {}` capability and reply tool handlers
+- **Always gate inbound messages** on sender identity to prevent prompt injection
+- Permission relay requires `claude/channel/permission` capability and v2.1.81+
+- Local terminal dialog and remote relay both stay live — first answer wins
+- Package as plugin for distribution via marketplace
+
+## See Also
+
+- [Channels user guide](https://code.claude.com/docs/en/channels) — install and use built-in channels
+- [Official channel implementations](https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins) — Telegram, Discord, iMessage, fakechat
+- [MCP documentation](https://code.claude.com/docs/en/mcp) — underlying protocol
+- [Plugins](https://code.claude.com/docs/en/plugins) — package channels for distribution

--- a/plugins/claude-code-expert/skills/checkpointing/SKILL.md
+++ b/plugins/claude-code-expert/skills/checkpointing/SKILL.md
@@ -1,0 +1,85 @@
+# Checkpointing
+
+> Track, rewind, and summarize Claude's edits and conversation to manage session state.
+> Built-in feature — no configuration required.
+
+## Overview
+
+Claude Code automatically tracks file edits as you work, allowing you to quickly undo changes and rewind to previous states. This safety net lets you pursue ambitious, wide-scale tasks knowing you can always return to a prior code state.
+
+## How Checkpoints Work
+
+### Automatic Tracking
+- Every user prompt creates a new checkpoint
+- Checkpoints persist across sessions (available in resumed conversations)
+- Auto-cleaned after 30 days (configurable)
+- Tracks all changes made by Claude's file editing tools
+
+### Rewind Menu
+
+Open with `Esc` + `Esc` (double-press) or `/rewind` command.
+
+Scrollable list shows each prompt from the session. Select a point and choose an action:
+
+| Action | Effect |
+|:-------|:-------|
+| **Restore code and conversation** | Revert both code and conversation to that point |
+| **Restore conversation** | Rewind to that message, keep current code |
+| **Restore code** | Revert file changes, keep conversation |
+| **Summarize from here** | Compress conversation from this point forward |
+| **Never mind** | Cancel, return to message list |
+
+After restoring conversation or summarizing, the original prompt is restored into the input field for re-sending or editing.
+
+### Restore vs Summarize
+
+**Restore** (3 options) — reverts state: undoes code changes, conversation history, or both.
+
+**Summarize from here** — different behavior:
+- Messages before selected point stay intact
+- Selected message and all subsequent → replaced with compact AI summary
+- No files on disk changed
+- Original messages preserved in transcript (Claude can reference details)
+- Like targeted `/compact` — keep early context in full, compress what's using space
+- Optional instructions to guide summary focus
+
+Use summarize to free context space. Use fork (`claude --continue --fork-session`) to branch and try a different approach while keeping original session.
+
+## Common Use Cases
+
+- **Exploring alternatives**: Try different implementations without losing starting point
+- **Recovering from mistakes**: Quickly undo changes that broke functionality
+- **Iterating on features**: Experiment with variations, revert to working states
+- **Freeing context space**: Summarize verbose debugging sessions from midpoint forward
+
+## Pipeline and Build Integration
+
+Checkpointing is valuable during CI/CD workflows:
+
+### Failed Build Recovery
+When a build fix attempt makes things worse, rewind to the pre-fix state and try a different approach.
+
+### Iterative Debugging
+Checkpoint before each debugging hypothesis. If approach A fails, rewind and try approach B without residual changes.
+
+### Safe Refactoring
+Make sweeping changes with confidence — rewind instantly if tests fail.
+
+## Limitations
+
+### Bash Commands Not Tracked
+Files modified by bash commands (`rm`, `mv`, `cp`) are NOT tracked. Only direct file edits through Claude's editing tools.
+
+### External Changes Not Tracked
+Manual changes outside Claude Code and edits from other concurrent sessions are normally not captured (unless they modify same files as current session).
+
+### Not a Version Control Replacement
+- Use Git for commits, branches, long-term history
+- Think of checkpoints as "local undo" and Git as "permanent history"
+- Checkpoints complement but don't replace Git
+
+## See Also
+
+- [Interactive Mode](https://code.claude.com/docs/en/interactive-mode) — Keyboard shortcuts and session controls
+- [Built-in Commands](https://code.claude.com/docs/en/commands) — `/rewind` command reference
+- [CLI Reference](https://code.claude.com/docs/en/cli-reference) — Command-line options

--- a/plugins/claude-code-expert/skills/scheduled-tasks/SKILL.md
+++ b/plugins/claude-code-expert/skills/scheduled-tasks/SKILL.md
@@ -1,0 +1,151 @@
+# Scheduled Tasks
+
+> Use `/loop` and cron scheduling tools to run prompts repeatedly, poll for status, or set one-time reminders within a Claude Code session.
+> Requires Claude Code v2.1.72+.
+
+## Overview
+
+Scheduled tasks let Claude re-run a prompt automatically on an interval. Use them to:
+- Poll a deployment status
+- Babysit a PR review cycle
+- Check on a long-running build
+- Set reminders during a session
+
+Tasks are **session-scoped**: they live in the current process and are gone when you exit. For durable scheduling, use Cloud, Desktop, or GitHub Actions.
+
+## Scheduling Options Comparison
+
+| | Cloud | Desktop | `/loop` |
+|:--|:------|:--------|:--------|
+| **Runs on** | Anthropic cloud | Your machine | Your machine |
+| **Requires machine on** | No | Yes | Yes |
+| **Requires open session** | No | No | Yes |
+| **Persistent across restarts** | Yes | Yes | No |
+| **Access to local files** | No (fresh clone) | Yes | Yes |
+| **MCP servers** | Connectors per task | Config files + connectors | Inherits from session |
+| **Permission prompts** | No (autonomous) | Configurable | Inherits from session |
+| **Minimum interval** | 1 hour | 1 minute | 1 minute |
+
+## Schedule with /loop
+
+The quickest way to schedule a recurring prompt:
+
+```
+/loop 5m check if the deployment finished and tell me what happened
+```
+
+### Interval Syntax
+
+| Form | Example | Parsed |
+|:-----|:--------|:-------|
+| Leading token | `/loop 30m check the build` | Every 30 minutes |
+| Trailing `every` clause | `/loop check the build every 2 hours` | Every 2 hours |
+| No interval | `/loop check the build` | Default: every 10 minutes |
+
+Units: `s` (seconds, rounded to nearest minute), `m` (minutes), `h` (hours), `d` (days).
+
+### Loop Over Commands
+
+Schedule any command or skill:
+```
+/loop 20m /review-pr 1234
+```
+
+## One-Time Reminders
+
+Use natural language for single-fire tasks:
+```
+remind me at 3pm to push the release branch
+```
+```
+in 45 minutes, check whether the integration tests passed
+```
+
+## Manage Tasks
+
+```
+what scheduled tasks do I have?
+cancel the deploy check job
+```
+
+### Underlying Tools
+
+| Tool | Purpose |
+|:-----|:--------|
+| `CronCreate` | Schedule new task (5-field cron, prompt, recurrence flag) |
+| `CronList` | List all tasks with IDs, schedules, prompts |
+| `CronDelete` | Cancel task by ID |
+
+Max 50 tasks per session. Each has an 8-character ID.
+
+## How Tasks Run
+
+- Scheduler checks every second for due tasks
+- Tasks fire **between your turns** (low priority), not mid-response
+- If Claude is busy, task waits until current turn ends
+- All times in **local timezone** (not UTC)
+
+### Jitter
+- Recurring: fire up to 10% of period late, capped at 15 min
+- One-shot at :00 or :30: fire up to 90 seconds early
+- Offset derived from task ID (deterministic)
+
+### Three-Day Expiry
+Recurring tasks auto-expire after 3 days. Fires one final time, then deletes itself. Recreate before expiry for longer runs, or use Cloud/Desktop for durable scheduling.
+
+## Cron Expression Reference
+
+5-field format: `minute hour day-of-month month day-of-week`
+
+| Expression | Meaning |
+|:-----------|:--------|
+| `*/5 * * * *` | Every 5 minutes |
+| `0 * * * *` | Every hour on the hour |
+| `7 * * * *` | Every hour at :07 |
+| `0 9 * * *` | Daily at 9am local |
+| `0 9 * * 1-5` | Weekdays at 9am local |
+| `30 14 15 3 *` | March 15 at 2:30pm local |
+
+Day-of-week: `0`/`7` = Sunday through `6` = Saturday. No extended syntax (`L`, `W`, `?`, name aliases).
+
+## CI/CD and Pipeline Integration
+
+Scheduled tasks are powerful for build and deployment monitoring:
+
+### Deploy Watch
+```
+/loop 2m check the deployment status of staging and report any failures
+```
+
+### Build Monitor
+```
+/loop 5m check if CI pipeline #1234 has completed. If it failed, analyze the logs and suggest fixes
+```
+
+### PR Babysitter
+```
+/loop 10m check PR #456 for new review comments and CI status changes
+```
+
+### Health Check Polling
+```
+/loop 1m curl the /health endpoint and alert me if it returns non-200
+```
+
+## Disable
+
+Set `CLAUDE_CODE_DISABLE_CRON=1` to disable the scheduler entirely. Tools and `/loop` become unavailable.
+
+## Limitations
+
+- Tasks only fire while Claude Code is running and idle
+- No catch-up for missed fires (fires once when idle, not once per missed interval)
+- No persistence across restarts
+- Session-scoped only (max 50 tasks)
+
+## See Also
+
+- [Cloud Scheduled Tasks](https://code.claude.com/docs/en/web-scheduled-tasks) — Durable cloud-based scheduling
+- [Desktop Scheduled Tasks](https://code.claude.com/docs/en/desktop) — Local persistent scheduling
+- [GitHub Actions](https://code.claude.com/docs/en/github-actions) — CI/CD schedule triggers
+- [Channels](../channels-user-guide/SKILL.md) — Push events instead of polling

--- a/plugins/claude-code-expert/skills/settings-deep-dive/SKILL.md
+++ b/plugins/claude-code-expert/skills/settings-deep-dive/SKILL.md
@@ -122,7 +122,54 @@ Complete reference for every settings option, configuration key, and customizati
 
   // === ATTRIBUTION ===
   "attribution": {
-    "commit": "Generated with Claude Code"
+    "commit": "Generated with AI\n\nCo-Authored-By: AI <ai@example.com>",
+    "pr": ""
+  },
+  "includeCoAuthoredBy": true, // DEPRECATED: use attribution instead
+
+  // === CHANNELS (v2.1.80+) ===
+  "channelsEnabled": true,       // Managed only - master switch for Team/Enterprise
+  "allowedChannelPlugins": [     // Managed only - restrict which channel plugins
+    { "marketplace": "claude-plugins-official", "plugin": "telegram" }
+  ],
+
+  // === AGENT TEAMS (experimental) ===
+  "teammateMode": "auto",       // "auto" | "in-process" | "tmux"
+
+  // === WORKTREE ===
+  "worktree": {
+    "symlinkDirectories": ["node_modules", ".cache"],
+    "sparsePaths": ["packages/my-app", "shared/utils"]
+  },
+
+  // === AUTO MODE ===
+  "autoMode": {
+    "environment": ["Trusted repo: github.example.com/acme"],
+    "allow": ["Read any file in the project"],
+    "soft_deny": ["Never delete production databases"]
+  },
+  "disableAutoMode": false,      // "disable" to block auto mode
+  "useAutoModeDuringPlan": true,
+
+  // === EFFORT & VOICE ===
+  "effortLevel": "high",        // "low" | "medium" | "high" (Opus 4.6, Sonnet 4.6)
+  "voiceEnabled": false,
+  "alwaysThinkingEnabled": false,
+
+  // === UI CUSTOMIZATION ===
+  "spinnerTipsOverride": {
+    "excludeDefault": true,
+    "tips": ["Use our internal tool X"]
+  },
+  "prefersReducedMotion": false,
+  "terminalProgressBarEnabled": true,
+  "showClearContextOnPlanAccept": false,
+  "plansDirectory": "~/.claude/plans",
+
+  // === MODELS ===
+  "availableModels": ["sonnet", "haiku", "opus"],
+  "modelOverrides": {
+    "claude-opus-4-6": "arn:aws:bedrock:us-east-1:..."
   }
 }
 ```
@@ -431,6 +478,125 @@ for f in glob.glob('plugins/*/. claude-plugin/plugin.json'):
   "autoMemory": false
 }
 ```
+
+## Attribution Customization
+
+Default commit attribution:
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+Default PR attribution:
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### Custom Attribution (no Claude Code branding)
+```json
+{
+  "attribution": {
+    "commit": "AI-assisted development\n\nCo-Authored-By: AI Assistant <ai@company.com>",
+    "pr": "AI-assisted development"
+  }
+}
+```
+
+### Hide All Attribution
+```json
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}
+```
+
+### Custom Branding Examples
+```json
+// Branded for your team
+{
+  "attribution": {
+    "commit": "Built with Markus AI Platform\n\nCo-Authored-By: Markus AI <ai@markusplatform.com>",
+    "pr": "Built with Markus AI Platform"
+  }
+}
+```
+
+## Channels Settings (v2.1.80+)
+
+Channels push events into running sessions. Team/Enterprise require admin enablement.
+
+### Enable for Organization (Managed Settings)
+```json
+{
+  "channelsEnabled": true,
+  "allowedChannelPlugins": [
+    { "marketplace": "claude-plugins-official", "plugin": "telegram" },
+    { "marketplace": "claude-plugins-official", "plugin": "discord" },
+    { "marketplace": "acme-corp-plugins", "plugin": "internal-ci-alerts" }
+  ]
+}
+```
+
+### CLI Flags
+```bash
+# Start with channels
+claude --channels plugin:telegram@claude-plugins-official
+
+# Multiple channels
+claude --channels plugin:telegram@claude-plugins-official plugin:discord@claude-plugins-official
+
+# Development channels (custom/local)
+claude --dangerously-load-development-channels server:my-webhook
+```
+
+## Agent Teams Settings (Experimental)
+
+### Enable
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "teammateMode": "in-process"
+}
+```
+
+### Display Modes
+| Mode | Description |
+|------|-------------|
+| `"auto"` | Split panes in tmux/iTerm2, in-process otherwise |
+| `"in-process"` | All teammates in main terminal |
+| `"tmux"` | Force split panes (requires tmux or iTerm2) |
+
+### CLI Override
+```bash
+claude --teammate-mode in-process
+```
+
+## Worktree Settings
+
+Reduce disk usage and startup time in large monorepos:
+```json
+{
+  "worktree": {
+    "symlinkDirectories": ["node_modules", ".cache"],
+    "sparsePaths": ["packages/my-app", "shared/utils"]
+  }
+}
+```
+
+## Settings Precedence
+
+1. **Managed** (highest) — server-managed > MDM/plist > file-based > HKCU registry
+2. **Command line arguments** — temporary session overrides
+3. **Local** (`.claude/settings.local.json`) — personal project overrides
+4. **Project** (`.claude/settings.json`) — team-shared settings
+5. **User** (`~/.claude/settings.json`) — personal global (lowest)
+
+Array settings (like permissions, sandbox paths) merge across scopes — they concatenate and deduplicate.
 
 ### Security-Hardened
 ```json

--- a/plugins/claude-code-expert/skills/settings-deep-dive/SKILL.md
+++ b/plugins/claude-code-expert/skills/settings-deep-dive/SKILL.md
@@ -148,7 +148,7 @@ Complete reference for every settings option, configuration key, and customizati
     "allow": ["Read any file in the project"],
     "soft_deny": ["Never delete production databases"]
   },
-  "disableAutoMode": false,      // "disable" to block auto mode
+  "disableAutoMode": "disable",  // Set to "disable" to block auto mode; omit or remove key to allow
   "useAutoModeDuringPlan": true,
 
   // === EFFORT & VOICE ===

--- a/plugins/claude-code-expert/skills/settings-deep-dive/SKILL.md
+++ b/plugins/claude-code-expert/skills/settings-deep-dive/SKILL.md
@@ -513,13 +513,12 @@ Default PR attribution:
 }
 ```
 
-### Custom Branding Examples
+### Inline Badge (shields.io)
 ```json
-// Branded for your team
 {
   "attribution": {
-    "commit": "Built with Markus AI Platform\n\nCo-Authored-By: Markus AI <ai@markusplatform.com>",
-    "pr": "Built with Markus AI Platform"
+    "commit": "",
+    "pr": "[![Built by Markus](https://img.shields.io/badge/built%20by-Markus%20Ahling-ff6b35?style=for-the-badge&logo=github&logoColor=white)](https://github.com/markus41)"
   }
 }
 ```


### PR DESCRIPTION
## Summary

- **Channels Reference + User Guide**: Two new skills covering MCP event streaming — building channels (server options, notifications, reply tools, permission relay) and using channels (Telegram/Discord/iMessage setup, CI/CD webhook use cases, security, enterprise controls)
- **Agent Teams**: Multi-session orchestration with shared task lists, inter-agent messaging, display modes, quality gate hooks, and architecture reference
- **Scheduled Tasks**: `/loop` command, cron scheduling, CI/CD polling patterns, one-time reminders, and 3-day expiry behavior
- **Checkpointing**: Rewind, restore, summarize session state management for safe experimentation
- **Settings Deep Dive**: Updated with attribution customization (custom branding without Claude Code mention), channels settings, agent-teams config, worktree settings, and precedence docs
- **Attribution**: Customized to "⚡ Engineered by Markus AI Platform" — no Claude Code branding

### Plugin changes
- `claude-code-expert` bumped to v7.1.0
- 8 new keywords, 4 new capabilities, 5 new lazyLoadSections
- 5 new skill entries in `skills.index.json`

## Test plan
- [ ] Verify all 5 new SKILL.md files render valid markdown
- [ ] Verify plugin.json passes JSON schema validation
- [ ] Verify skills.index.json paths resolve to existing files
- [ ] Confirm attribution setting applies to new commits without Claude Code mention
- [ ] Confirm lazyLoadSections reference correct relative paths

https://claude.ai/code/session_01JUFCuBtwk88S1AGEQ8K8BH