### PR TITLE
Normalize source IDs using shared helper (toSourceId/toSourceKey)

### DIFF
--- a/plugins/scrapin-aint-easy/src/core/ids.ts
+++ b/plugins/scrapin-aint-easy/src/core/ids.ts
@@ -1,0 +1,14 @@
+const SOURCE_ID_PREFIX = 'source::';
+
+export function toSourceId(keyOrId: string): string {
+  if (keyOrId.startsWith(SOURCE_ID_PREFIX)) {
+    return keyOrId;
+  }
+  return `${SOURCE_ID_PREFIX}${keyOrId}`;
+}
+
+export function toSourceKey(keyOrId: string): string {
+  return keyOrId.startsWith(SOURCE_ID_PREFIX)
+    ? keyOrId.slice(SOURCE_ID_PREFIX.length)
+    : keyOrId;
+}

--- a/plugins/scrapin-aint-easy/src/crawler/crawler.ts
+++ b/plugins/scrapin-aint-easy/src/crawler/crawler.ts
@@ -12,6 +12,7 @@ import { parseSitemap } from './sitemap-parser.js';
 import { parseOpenApiSpec } from './openapi-parser.js';
 import { extractSymbols } from './symbol-extractor.js';
 import { saveSnapshot, loadSnapshot, diffSnapshots } from './snapshot.js';
+import { toSourceId } from '../core/ids.js';
 
 const logger = pino({ name: 'crawler' });
 
@@ -105,6 +106,7 @@ export class DocCrawler {
    */
   async crawlSource(sourceKey: string, sourceConfig: SourceConfig): Promise<CrawlStats> {
     const startTime = Date.now();
+    const sourceId = toSourceId(sourceKey);
     const stats: CrawlStats = {
       pagesProcessed: 0,
       pagesSkipped: 0,
@@ -121,7 +123,7 @@ export class DocCrawler {
 
     // Upsert Source node in graph
     await this.graph.upsertNode('Source', {
-      id: `source::${sourceKey}`,
+      id: sourceId,
       name: sourceConfig.name,
       base_url: sourceConfig.base_url,
       last_crawled: new Date().toISOString(),
@@ -210,14 +212,14 @@ export class DocCrawler {
       id: `page::${sourceKey}::${pageId}`,
       name: String(metadata['title'] ?? pageId),
       url,
-      source_id: `source::${sourceKey}`,
+      source_id: toSourceId(sourceKey),
       last_crawled: new Date().toISOString(),
     });
 
     await this.graph.upsertEdge(
       'PART_OF',
       `page::${sourceKey}::${pageId}`,
-      `source::${sourceKey}`,
+      toSourceId(sourceKey),
     );
 
     // Extract symbols
@@ -233,7 +235,7 @@ export class DocCrawler {
         description: symbol.description,
         deprecated: symbol.deprecated,
         deleted: false,
-        source_id: sourceKey,
+        source_id: toSourceId(sourceKey),
         page_id: `page::${sourceKey}::${pageId}`,
         last_crawled: new Date().toISOString(),
       });
@@ -376,7 +378,7 @@ export class DocCrawler {
           id: `page::${sourceKey}::${pageId}`,
           name: `${page.method} ${page.path}`,
           url: specUrlOrPath,
-          source_id: `source::${sourceKey}`,
+          source_id: toSourceId(sourceKey),
           kind: 'openapi-endpoint',
           last_crawled: new Date().toISOString(),
         });
@@ -384,7 +386,7 @@ export class DocCrawler {
         await this.graph.upsertEdge(
           'PART_OF',
           `page::${sourceKey}::${pageId}`,
-          `source::${sourceKey}`,
+          toSourceId(sourceKey),
         );
 
         await this.vectorStore.add(

--- a/plugins/scrapin-aint-easy/src/lsp/resolver.ts
+++ b/plugins/scrapin-aint-easy/src/lsp/resolver.ts
@@ -1,6 +1,7 @@
 import pino from 'pino';
 import { type GraphAdapter, type SymbolNode, type SearchResult } from '../core/graph.js';
 import { type VectorStore, type VectorSearchResult } from '../core/vector.js';
+import { toSourceKey } from '../core/ids.js';
 
 const logger = pino({ name: 'lsp-resolver' });
 
@@ -217,7 +218,7 @@ export class SymbolResolver {
   }
 
   private buildCanonicalUrl(sourceId: string, pageId: string): string {
-    const sourceConfig = this.sources[sourceId];
+    const sourceConfig = this.sources[toSourceKey(sourceId)];
     if (!sourceConfig) return '';
 
     const baseUrl = sourceConfig['base_url'] as string | undefined;

--- a/plugins/scrapin-aint-easy/src/mcp/tools.ts
+++ b/plugins/scrapin-aint-easy/src/mcp/tools.ts
@@ -3,6 +3,7 @@ import pino from 'pino';
 import { type GraphAdapter } from '../core/graph.js';
 import { type VectorStore } from '../core/vector.js';
 import { type EventBus } from '../core/event-bus.js';
+import { toSourceId } from '../core/ids.js';
 
 const logger = pino({ name: 'mcp:tools' });
 
@@ -297,7 +298,8 @@ export function createTools(
         logger.info({ sourceKey: input.source_key }, 'scrapin_diff');
 
         const pages = await graph.getNodesByLabel('Page');
-        const sourcePages = pages.filter((p) => p.props['source_id'] === input.source_key);
+        const sourceId = toSourceId(input.source_key);
+        const sourcePages = pages.filter((p) => toSourceId(String(p.props['source_id'] ?? '')) === sourceId);
         const stale = sourcePages.filter((p) => p.props['stale'] === true);
 
         const meta = makeMetadata('scrapin_diff', false);
@@ -359,7 +361,7 @@ export function createTools(
         logger.info({ key: input.key, baseUrl: input.base_url }, 'scrapin_add_source');
 
         await graph.upsertNode('Source', {
-          id: input.key,
+          id: toSourceId(input.key),
           name: input.name,
           base_url: input.base_url,
           last_crawled: '',

--- a/plugins/scrapin-aint-easy/src/scheduler/jobs/openapi-sync.ts
+++ b/plugins/scrapin-aint-easy/src/scheduler/jobs/openapi-sync.ts
@@ -2,6 +2,7 @@ import pino from 'pino';
 import { type GraphAdapter } from '../../core/graph.js';
 import { type VectorStore } from '../../core/vector.js';
 import { loadSources } from '../../config/loader.js';
+import { toSourceId } from '../../core/ids.js';
 
 const logger = pino({ name: 'job:openapi-sync' });
 
@@ -30,7 +31,7 @@ export function createOpenApiSyncJob(
             url: `${config.base_url}${page.path}`,
             title: `${page.method.toUpperCase()} ${page.path}`,
             content_md: page.markdown,
-            source_id: key,
+            source_id: toSourceId(key),
             last_crawled: new Date().toISOString(),
             stale: false,
           });

--- a/plugins/scrapin-aint-easy/tests/source-id-normalization.test.ts
+++ b/plugins/scrapin-aint-easy/tests/source-id-normalization.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { GraphAdapter } from '../src/core/graph.js';
+import { createTools } from '../src/mcp/tools.js';
+import { toSourceId } from '../src/core/ids.js';
+import { createOpenApiSyncJob } from '../src/scheduler/jobs/openapi-sync.js';
+
+async function makeGraph(): Promise<GraphAdapter> {
+  const dataDir = await mkdtemp(join(tmpdir(), 'scrapin-test-data-'));
+  const configDir = await mkdtemp(join(tmpdir(), 'scrapin-test-config-'));
+  const graph = new GraphAdapter(dataDir, configDir);
+  await graph.initialize();
+  return graph;
+}
+
+describe('source id normalization', () => {
+  let graph: GraphAdapter;
+
+  beforeEach(async () => {
+    graph = await makeGraph();
+  });
+
+  it('supports add source + page creation and diff by raw source key', async () => {
+    const tools = createTools(
+      graph,
+      {
+        search: async () => [],
+        add: async () => {},
+        size: 0,
+      } as never,
+      {
+        emit: async () => {},
+      } as never,
+      { configDir: '', dataDir: '', projectRoot: '' },
+    );
+
+    const addSource = tools.find((tool) => tool.name === 'scrapin_add_source');
+    const diff = tools.find((tool) => tool.name === 'scrapin_diff');
+
+    expect(addSource).toBeDefined();
+    expect(diff).toBeDefined();
+
+    await addSource!.handler({
+      key: 'docs',
+      name: 'Docs',
+      base_url: 'https://example.com',
+      package_aliases: [],
+      concurrency: 2,
+      rps: 1,
+    });
+
+    await graph.upsertNode('Page', {
+      id: 'page::docs::intro',
+      title: 'Intro',
+      url: 'https://example.com/intro',
+      source_id: toSourceId('docs'),
+      stale: true,
+    });
+
+    await graph.upsertEdge('PART_OF', 'page::docs::intro', toSourceId('docs'));
+
+    const source = await graph.getNode(toSourceId('docs'));
+    expect(source).toBeDefined();
+
+    const response = await diff!.handler({ source_key: 'docs' });
+    const text = response.content[0]?.text ?? '';
+
+    expect(text).toContain('Total pages:** 1');
+    expect(text).toContain('Stale pages:** 1');
+  });
+
+  it('openapi sync writes normalized source_id and diff finds pages by source key', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'scrapin-openapi-config-'));
+    const dataDir = await mkdtemp(join(tmpdir(), 'scrapin-openapi-data-'));
+    const specPath = join(configDir, 'openapi.json');
+
+    await writeFile(specPath, JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'Demo', version: '1.0.0' },
+      paths: {
+        '/status': {
+          get: {
+            summary: 'Status',
+            responses: {
+              '200': { description: 'ok' },
+            },
+          },
+        },
+      },
+    }), 'utf-8');
+
+    await writeFile(join(configDir, 'sources.yaml'), `sources:\n  demo:\n    name: Demo\n    base_url: https://example.com\n    openapi_spec: ${specPath}\n`, 'utf-8');
+
+    const localGraph = new GraphAdapter(dataDir, configDir);
+    await localGraph.initialize();
+
+    const job = createOpenApiSyncJob(
+      localGraph,
+      {
+        add: async () => {},
+      } as never,
+      configDir,
+    );
+
+    await job();
+
+    const pages = await localGraph.getNodesByLabel('Page');
+    expect(pages.length).toBeGreaterThan(0);
+    expect(pages[0]?.props['source_id']).toBe(toSourceId('demo'));
+
+    const tools = createTools(
+      localGraph,
+      {
+        search: async () => [],
+        add: async () => {},
+        size: 0,
+      } as never,
+      {
+        emit: async () => {},
+      } as never,
+      { configDir: '', dataDir: '', projectRoot: '' },
+    );
+
+    const diff = tools.find((tool) => tool.name === 'scrapin_diff');
+    const response = await diff!.handler({ source_key: 'demo' });
+    const text = response.content[0]?.text ?? '';
+
+    expect(text).toContain('Total pages:** 1');
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent inconsistent handling of source identifiers by normalizing source keys to a canonical form (`source::<key>`) when reading or writing graph nodes and edges.
- Ensure filters, joins, and LSP URL lookups compare normalized IDs rather than raw keys to avoid missing pages or symbols.

### Description

- Added a shared helper module `src/core/ids.ts` exposing `toSourceId(keyOrId)` and `toSourceKey(keyOrId)` to normalize and reverse-normalize source identifiers.
- Updated the crawler to use `toSourceId` when creating/upserting `Source` nodes, `Page.source_id`, `Symbol.source_id`, and `PART_OF` edges so persisted IDs are normalized (file: `src/crawler/crawler.ts`).
- Updated MCP tools so `scrapin_add_source` writes normalized `Source.id` and `scrapin_diff` compares normalized IDs when filtering `Page` nodes (file: `src/mcp/tools.ts`).
- Updated the OpenAPI sync job to write normalized `source_id` for generated pages and updated the LSP resolver to call `toSourceKey` when mapping `source_id` back to configured source entries (files: `src/scheduler/jobs/openapi-sync.ts`, `src/lsp/resolver.ts`).
- Added regression tests `tests/source-id-normalization.test.ts` that register a source, create pages, run OpenAPI sync, call the diff tool, and assert pages are returned when queried by the raw source key.

### Testing

- Ran the new test file with `npm test -- tests/source-id-normalization.test.ts` in the `plugins/scrapin-aint-easy` package and all tests passed (2 tests).
- The test run validated that `Page.source_id` values are written as `toSourceId(<key>)` and that `scrapin_diff` returns pages when queried with the raw key.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46a0741a4832a9f057734a0b77352)