### PR TITLE
VectorStore: explicit embedding providers, persistent quantized embeddings, HNSW ANN path, and tests

### DIFF
--- a/plugins/scrapin-aint-easy/src/core/vector.ts
+++ b/plugins/scrapin-aint-easy/src/core/vector.ts
@@ -5,17 +5,49 @@ import pino from 'pino';
 
 const logger = pino({ name: 'vector' });
 
-/**
- * Vector embedding store using @xenova/transformers for embedding generation
- * and hnswlib-node for approximate nearest neighbor search.
- * Falls back to brute-force cosine similarity when native modules unavailable.
- */
+const EMBEDDING_DIMENSION = 384;
+const EMBEDDINGS_DIR = 'embeddings';
+const ENTRIES_FILE = 'entries.json';
 
 interface VectorEntry {
   id: string;
   label: string;
   text: string;
   embedding: number[];
+}
+
+interface PersistedEntry {
+  id: string;
+  label: string;
+  text: string;
+  embedding?: number[];
+  embedding_q?: number[];
+  embedding_scale?: number;
+}
+
+interface EmbeddingProvider {
+  readonly name: string;
+  embed(text: string): Promise<number[]>;
+}
+
+interface HnswIndex {
+  initIndex(maxElements: number): void;
+  addPoint(point: number[] | Float32Array, id: number): void;
+  writeIndexSync(path: string): void;
+  readIndexSync(path: string): void;
+  searchKnn(query: number[] | Float32Array, k: number): { neighbors: number[]; distances: number[] };
+  markDelete?(id: number): void;
+  resizeIndex?(size: number): void;
+}
+
+interface VectorStoreOptions {
+  embeddingProvider?: 'local' | 'remote' | 'test';
+  remoteEmbeddingUrl?: string;
+  remoteEmbeddingApiKey?: string;
+  modelName?: string;
+  allowTestProvider?: boolean;
+  hnswFactory?: () => Promise<HnswIndex | null>;
+  disableHnsw?: boolean;
 }
 
 export interface VectorSearchResult {
@@ -25,140 +57,467 @@ export interface VectorSearchResult {
   score: number;
 }
 
-export class VectorStore {
-  private entries: VectorEntry[] = [];
-  private pipeline: unknown = null;
-  private hnswIndex: unknown = null;
-  private indexDirty = false;
-  private readonly modelName = 'Xenova/all-MiniLM-L6-v2';
+class LocalTransformersProvider implements EmbeddingProvider {
+  readonly name = 'local-transformers';
+  private pipelinePromise:
+    | Promise<(text: string, opts: Record<string, unknown>) => Promise<{ data: Float32Array }>>
+    | null = null;
 
-  constructor(private readonly dataDir: string) {}
-
-  async initialize(): Promise<void> {
-    const embeddingsDir = join(this.dataDir, 'embeddings');
-    if (!existsSync(embeddingsDir)) {
-      await mkdir(embeddingsDir, { recursive: true });
-    }
-
-    // Try loading transformer pipeline
-    try {
-      const transformers = await import('@xenova/transformers');
-      this.pipeline = await transformers.pipeline('feature-extraction', this.modelName);
-      logger.info('Xenova transformer pipeline loaded');
-    } catch {
-      logger.warn('Xenova transformers not available, using random embeddings for testing');
-    }
-
-    // Try loading HNSW index
-    try {
-      const hnswlib = await import('hnswlib-node');
-      const index = new hnswlib.default.HierarchicalNSW('cosine', 384);
-      const indexPath = join(embeddingsDir, 'hnsw.index');
-      if (existsSync(indexPath)) {
-        index.readIndexSync(indexPath);
-      } else {
-        index.initIndex(100000);
-      }
-      this.hnswIndex = index;
-      logger.info('HNSW index loaded');
-    } catch {
-      logger.info('hnswlib-node not available, using brute-force search');
-    }
-
-    // Load persisted entries
-    await this.loadEntries();
-  }
+  constructor(private readonly modelName: string) {}
 
   async embed(text: string): Promise<number[]> {
-    if (this.pipeline) {
-      const pipe = this.pipeline as (text: string, opts: Record<string, unknown>) => Promise<{ data: Float32Array }>;
-      const result = await pipe(text, { pooling: 'mean', normalize: true });
-      return Array.from(result.data);
+    if (!this.pipelinePromise) {
+      this.pipelinePromise = import('@xenova/transformers').then((transformers) =>
+        transformers.pipeline('feature-extraction', this.modelName),
+      );
+    }
+    const pipe = await this.pipelinePromise;
+    const result = await pipe(text, { pooling: 'mean', normalize: true });
+    return Array.from(result.data);
+  }
+}
+
+class RemoteEmbeddingProvider implements EmbeddingProvider {
+  readonly name = 'remote';
+
+  constructor(
+    private readonly endpoint: string,
+    private readonly apiKey?: string,
+  ) {}
+
+  async embed(text: string): Promise<number[]> {
+    const res = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(this.apiKey ? { authorization: `Bearer ${this.apiKey}` } : {}),
+      },
+      body: JSON.stringify({ input: text }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Remote embedding provider failed (${res.status} ${res.statusText})`);
     }
 
-    // Deterministic fallback: hash-based pseudo-embedding for testing
-    const dim = 384;
-    const embedding = new Array<number>(dim);
+    const body = (await res.json()) as { embedding?: number[]; data?: Array<{ embedding?: number[] }> };
+    const embedding = body.embedding ?? body.data?.[0]?.embedding;
+    if (!embedding || !Array.isArray(embedding) || embedding.length === 0) {
+      throw new Error('Remote embedding provider response missing embedding array');
+    }
+    return normalizeVector(embedding);
+  }
+}
+
+class DeterministicTestProvider implements EmbeddingProvider {
+  readonly name = 'deterministic-test';
+
+  async embed(text: string): Promise<number[]> {
+    const embedding = new Array<number>(EMBEDDING_DIMENSION);
     let hash = 0;
     for (let i = 0; i < text.length; i++) {
       hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0;
     }
-    for (let i = 0; i < dim; i++) {
+    for (let i = 0; i < EMBEDDING_DIMENSION; i++) {
       hash = ((hash << 5) - hash + i) | 0;
       embedding[i] = (hash & 0xffff) / 0xffff;
     }
-    // Normalize
-    const norm = Math.sqrt(embedding.reduce((s, v) => s + v * v, 0));
-    return embedding.map((v) => v / (norm || 1));
+    return normalizeVector(embedding);
+  }
+}
+
+export class VectorStore {
+  private entries: VectorEntry[] = [];
+  private readonly modelName: string;
+  private embeddingProvider: EmbeddingProvider | null = null;
+  private hnswIndex: HnswIndex | null = null;
+  private readonly idToLabel = new Map<string, number>();
+  private readonly labelToId = new Map<number, string>();
+  private nextLabel = 1;
+
+  constructor(
+    private readonly dataDir: string,
+    private readonly options: VectorStoreOptions = {},
+  ) {
+    this.modelName = options.modelName ?? 'Xenova/all-MiniLM-L6-v2';
+  }
+
+  async initialize(): Promise<void> {
+    const embeddingsDir = this.getEmbeddingsDir();
+    if (!existsSync(embeddingsDir)) {
+      await mkdir(embeddingsDir, { recursive: true });
+    }
+
+    await this.loadEntries();
+    this.embeddingProvider = await this.resolveEmbeddingProvider();
+    this.hnswIndex = await this.loadHnswIndex();
+
+    if (this.hnswIndex) {
+      this.rebuildHnswFromEntries();
+    }
+
+    logger.info(
+      {
+        entries: this.entries.length,
+        embeddingProvider: this.embeddingProvider.name,
+        annAvailable: Boolean(this.hnswIndex),
+      },
+      'Vector store initialized',
+    );
+  }
+
+  async embed(text: string): Promise<number[]> {
+    if (!this.embeddingProvider) {
+      throw new Error('Vector store not initialized: embedding provider unavailable');
+    }
+    return this.embeddingProvider.embed(text);
   }
 
   async add(id: string, label: string, text: string): Promise<void> {
     const embedding = await this.embed(text);
 
-    // Remove existing entry with same id
-    this.entries = this.entries.filter((e) => e.id !== id);
-    this.entries.push({ id, label, text, embedding });
-    this.indexDirty = true;
+    const existing = this.entries.find((e) => e.id === id);
+    if (existing) {
+      await this.remove(id);
+    }
+
+    const entry: VectorEntry = { id, label, text, embedding };
+    this.entries.push(entry);
+    this.addToHnsw(entry);
+    await this.saveEntries();
   }
 
   async search(query: string, limit = 10, labelFilter?: string): Promise<VectorSearchResult[]> {
+    const startedAt = Date.now();
     const queryEmbedding = await this.embed(query);
+
+    const annSearch = this.tryAnnSearch(queryEmbedding, limit, labelFilter);
+    if (annSearch) {
+      logger.info(
+        {
+          embeddingProvider: this.embeddingProvider?.name,
+          searchPath: 'ann',
+          queryLatencyMs: Date.now() - startedAt,
+          candidates: annSearch.candidateCount,
+          limit,
+          labelFilter,
+        },
+        'Vector search completed',
+      );
+      return annSearch.results;
+    }
 
     let candidates = this.entries;
     if (labelFilter) {
-      candidates = candidates.filter((e) => e.label === labelFilter);
+      candidates = candidates.filter((entry) => entry.label === labelFilter);
     }
 
-    // Cosine similarity search
     const scored = candidates.map((entry) => ({
       ...entry,
       score: cosineSimilarity(queryEmbedding, entry.embedding),
     }));
 
-    return scored
+    const results = scored
       .sort((a, b) => b.score - a.score)
       .slice(0, limit)
       .map(({ id, label, text, score }) => ({ id, label, text, score }));
+
+    logger.info(
+      {
+        embeddingProvider: this.embeddingProvider?.name,
+        searchPath: 'brute-force',
+        queryLatencyMs: Date.now() - startedAt,
+        candidates: candidates.length,
+        limit,
+        labelFilter,
+      },
+      'Vector search completed',
+    );
+
+    return results;
   }
 
   async remove(id: string): Promise<void> {
-    this.entries = this.entries.filter((e) => e.id !== id);
-    this.indexDirty = true;
+    const existing = this.entries.find((entry) => entry.id === id);
+    if (!existing) {
+      return;
+    }
+
+    this.entries = this.entries.filter((entry) => entry.id !== id);
+    this.deleteFromHnsw(id);
+    await this.saveEntries();
   }
 
   async rebuild(): Promise<void> {
-    if (!this.indexDirty) return;
-    // In a full implementation, rebuild HNSW index here
+    if (this.hnswIndex) {
+      this.rebuildHnswFromEntries();
+      await this.persistHnswIndex();
+    }
     await this.saveEntries();
-    this.indexDirty = false;
-    logger.info(`Vector index rebuilt with ${this.entries.length} entries`);
+    logger.info({ entries: this.entries.length }, 'Vector index rebuilt');
   }
 
   get size(): number {
     return this.entries.length;
   }
 
+  private async resolveEmbeddingProvider(): Promise<EmbeddingProvider> {
+    const isTestLikeMode =
+      this.options.allowTestProvider ?? (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development');
+
+    const configured = this.options.embeddingProvider ?? (process.env.SCRAPIN_VECTOR_EMBEDDING_PROVIDER as
+      | 'local'
+      | 'remote'
+      | 'test'
+      | undefined);
+
+    if (configured && configured !== 'local' && configured !== 'remote' && configured !== 'test') {
+      throw new Error(
+        `Invalid SCRAPIN_VECTOR_EMBEDDING_PROVIDER value "${configured}". Supported values: local, remote, test.`,
+      );
+    }
+
+    if (configured === 'test') {
+      if (!isTestLikeMode) {
+        throw new Error(
+          'Deterministic test embedding provider is only allowed in NODE_ENV=test or NODE_ENV=development.',
+        );
+      }
+      return new DeterministicTestProvider();
+    }
+
+    if (configured === 'remote') {
+      const remoteUrl = this.options.remoteEmbeddingUrl ?? process.env.SCRAPIN_VECTOR_REMOTE_URL;
+      if (!remoteUrl) {
+        throw new Error('SCRAPIN_VECTOR_REMOTE_URL is required when SCRAPIN_VECTOR_EMBEDDING_PROVIDER=remote.');
+      }
+      return new RemoteEmbeddingProvider(remoteUrl, this.options.remoteEmbeddingApiKey ?? process.env.SCRAPIN_VECTOR_REMOTE_API_KEY);
+    }
+
+    if (configured === 'local') {
+      await this.assertLocalProviderAvailable();
+      return this.createLocalProvider();
+    }
+
+    try {
+      await this.assertLocalProviderAvailable();
+      return this.createLocalProvider();
+    } catch (error) {
+      const remoteUrl = this.options.remoteEmbeddingUrl ?? process.env.SCRAPIN_VECTOR_REMOTE_URL;
+      if (remoteUrl) {
+        return new RemoteEmbeddingProvider(remoteUrl, this.options.remoteEmbeddingApiKey ?? process.env.SCRAPIN_VECTOR_REMOTE_API_KEY);
+      }
+      if (isTestLikeMode) {
+        logger.warn({ err: error }, 'Falling back to deterministic test embedding provider in test/dev mode');
+        return new DeterministicTestProvider();
+      }
+      throw new Error(
+        'No valid embedding provider configured. Install @xenova/transformers for local embeddings or configure SCRAPIN_VECTOR_EMBEDDING_PROVIDER=remote with SCRAPIN_VECTOR_REMOTE_URL.',
+      );
+    }
+  }
+
+  private createLocalProvider(): EmbeddingProvider {
+    return new LocalTransformersProvider(this.modelName);
+  }
+
+  private async assertLocalProviderAvailable(): Promise<void> {
+    try {
+      await import('@xenova/transformers');
+    } catch (error) {
+      throw new Error(
+        `Local embedding provider unavailable: ${(error as Error).message}. Install @xenova/transformers or configure SCRAPIN_VECTOR_EMBEDDING_PROVIDER=remote.`,
+      );
+    }
+  }
+
+  private async loadHnswIndex(): Promise<HnswIndex | null> {
+    if (this.options.disableHnsw) {
+      return null;
+    }
+
+    if (this.options.hnswFactory) {
+      return this.options.hnswFactory();
+    }
+
+    try {
+      const hnswlib = await import('hnswlib-node');
+      const index = new hnswlib.default.HierarchicalNSW('cosine', EMBEDDING_DIMENSION) as HnswIndex;
+      index.initIndex(Math.max(1024, this.entries.length * 2 + 1));
+      return index;
+    } catch {
+      logger.info('hnswlib-node not available; using brute-force vector search');
+      return null;
+    }
+  }
+
+  private getEmbeddingsDir(): string {
+    return join(this.dataDir, EMBEDDINGS_DIR);
+  }
+
+  private getEntriesPath(): string {
+    return join(this.getEmbeddingsDir(), ENTRIES_FILE);
+  }
+
+  private getHnswPath(): string {
+    return join(this.getEmbeddingsDir(), 'hnsw.index');
+  }
+
   private async saveEntries(): Promise<void> {
-    const filePath = join(this.dataDir, 'embeddings', 'entries.json');
-    const data = this.entries.map(({ id, label, text }) => ({ id, label, text }));
+    const filePath = this.getEntriesPath();
+    const data: PersistedEntry[] = this.entries.map((entry) => {
+      const quantized = quantizeEmbedding(entry.embedding);
+      return {
+        id: entry.id,
+        label: entry.label,
+        text: entry.text,
+        embedding_q: quantized.values,
+        embedding_scale: quantized.scale,
+      };
+    });
+
     await writeFile(filePath, JSON.stringify(data), 'utf-8');
+    await this.persistHnswIndex();
   }
 
   private async loadEntries(): Promise<void> {
-    const filePath = join(this.dataDir, 'embeddings', 'entries.json');
+    const filePath = this.getEntriesPath();
     try {
       const raw = await readFile(filePath, 'utf-8');
-      const data = JSON.parse(raw) as Array<{ id: string; label: string; text: string }>;
-      // Re-embed on load (embeddings are not persisted to save space)
-      for (const entry of data) {
-        const embedding = await this.embed(entry.text);
-        this.entries.push({ ...entry, embedding });
-      }
-      logger.info(`Loaded ${this.entries.length} vector entries from disk`);
+      const data = JSON.parse(raw) as PersistedEntry[];
+      this.entries = data
+        .map((entry) => {
+          const embedding = restoreEmbedding(entry);
+          if (!embedding) {
+            return null;
+          }
+          return {
+            id: entry.id,
+            label: entry.label,
+            text: entry.text,
+            embedding,
+          } satisfies VectorEntry;
+        })
+        .filter((entry): entry is VectorEntry => entry !== null);
+      logger.info({ loaded: this.entries.length }, 'Loaded vector entries from disk');
     } catch {
-      // No persisted entries
+      // No persisted entries yet.
     }
   }
+
+  private rebuildHnswFromEntries(): void {
+    if (!this.hnswIndex) {
+      return;
+    }
+
+    this.idToLabel.clear();
+    this.labelToId.clear();
+    this.nextLabel = 1;
+
+    this.hnswIndex.initIndex(Math.max(1024, this.entries.length * 2 + 1));
+    for (const entry of this.entries) {
+      this.addToHnsw(entry);
+    }
+  }
+
+  private addToHnsw(entry: VectorEntry): void {
+    if (!this.hnswIndex) {
+      return;
+    }
+
+    const label = this.nextLabel++;
+    this.idToLabel.set(entry.id, label);
+    this.labelToId.set(label, entry.id);
+    this.hnswIndex.addPoint(entry.embedding, label);
+  }
+
+  private deleteFromHnsw(id: string): void {
+    if (!this.hnswIndex) {
+      return;
+    }
+
+    const label = this.idToLabel.get(id);
+    if (label === undefined) {
+      return;
+    }
+
+    this.idToLabel.delete(id);
+    this.labelToId.delete(label);
+    this.hnswIndex.markDelete?.(label);
+  }
+
+  private tryAnnSearch(
+    queryEmbedding: number[],
+    limit: number,
+    labelFilter?: string,
+  ): { results: VectorSearchResult[]; candidateCount: number } | null {
+    if (!this.hnswIndex || this.entries.length === 0) {
+      return null;
+    }
+
+    const requestedCandidates = Math.max(limit * 5, limit);
+    const k = Math.min(this.entries.length, requestedCandidates);
+    const nearest = this.hnswIndex.searchKnn(queryEmbedding, k);
+    const neighbors = nearest.neighbors ?? [];
+
+    const mapped = neighbors
+      .map((labelId) => this.labelToId.get(labelId))
+      .filter((id): id is string => Boolean(id))
+      .map((id) => this.entries.find((entry) => entry.id === id))
+      .filter((entry): entry is VectorEntry => entry !== undefined)
+      .filter((entry) => !labelFilter || entry.label === labelFilter)
+      .map((entry) => ({
+        id: entry.id,
+        label: entry.label,
+        text: entry.text,
+        score: cosineSimilarity(queryEmbedding, entry.embedding),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+
+    return {
+      results: mapped,
+      candidateCount: neighbors.length,
+    };
+  }
+
+  private async persistHnswIndex(): Promise<void> {
+    if (!this.hnswIndex) {
+      return;
+    }
+
+    this.hnswIndex.writeIndexSync(this.getHnswPath());
+  }
+}
+
+function restoreEmbedding(entry: PersistedEntry): number[] | null {
+  if (entry.embedding && Array.isArray(entry.embedding)) {
+    return normalizeVector(entry.embedding);
+  }
+
+  if (entry.embedding_q && entry.embedding_scale) {
+    const restored = entry.embedding_q.map((value) => value * entry.embedding_scale!);
+    return normalizeVector(restored);
+  }
+
+  return null;
+}
+
+function quantizeEmbedding(values: number[]): { values: number[]; scale: number } {
+  const maxAbs = values.reduce((acc, v) => Math.max(acc, Math.abs(v)), 0);
+  const scale = maxAbs > 0 ? maxAbs / 32767 : 1;
+  const quantized = values.map((value) => Math.round(value / scale));
+  return {
+    values: quantized,
+    scale,
+  };
+}
+
+function normalizeVector(values: number[]): number[] {
+  const norm = Math.sqrt(values.reduce((sum, value) => sum + value * value, 0));
+  if (!norm) {
+    return values;
+  }
+  return values.map((value) => value / norm);
 }
 
 function cosineSimilarity(a: number[], b: number[]): number {

--- a/plugins/scrapin-aint-easy/tests/core/vector.test.ts
+++ b/plugins/scrapin-aint-easy/tests/core/vector.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+vi.mock('pino', () => ({
+  default: () => ({
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  }),
+}));
+
+class FakeHnswIndex {
+  private readonly points = new Map<number, number[]>();
+
+  initIndex(): void {
+    this.points.clear();
+  }
+
+  addPoint(point: number[] | Float32Array, id: number): void {
+    this.points.set(id, Array.from(point));
+  }
+
+  writeIndexSync(): void {
+    // no-op for test
+  }
+
+  readIndexSync(): void {
+    // no-op for test
+  }
+
+  searchKnn(query: number[] | Float32Array, k: number): { neighbors: number[]; distances: number[] } {
+    const queryVector = Array.from(query);
+    const scored = [...this.points.entries()]
+      .map(([id, point]) => ({ id, score: cosineSimilarity(queryVector, point) }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, k);
+
+    return {
+      neighbors: scored.map((row) => row.id),
+      distances: scored.map((row) => 1 - row.score),
+    };
+  }
+
+  markDelete(id: number): void {
+    this.points.delete(id);
+  }
+}
+
+describe('VectorStore', () => {
+  let VectorStore: typeof import('../../src/core/vector.js').VectorStore;
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalProvider = process.env.SCRAPIN_VECTOR_EMBEDDING_PROVIDER;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.SCRAPIN_VECTOR_EMBEDDING_PROVIDER = 'test';
+    ({ VectorStore } = await import('../../src/core/vector.js'));
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalProvider === undefined) {
+      delete process.env.SCRAPIN_VECTOR_EMBEDDING_PROVIDER;
+    } else {
+      process.env.SCRAPIN_VECTOR_EMBEDDING_PROVIDER = originalProvider;
+    }
+  });
+
+  it('maintains stable ranking behavior across restarts', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'vector-store-restart-'));
+
+    const first = new VectorStore(dataDir);
+    await first.initialize();
+    await first.add('a', 'Symbol', 'react query useQuery fetching data');
+    await first.add('b', 'Symbol', 'react mutation update and invalidate cache');
+    await first.add('c', 'Symbol', 'pagination and infinite query patterns');
+
+    const beforeRestart = await first.search('query cache invalidation', 3);
+
+    const second = new VectorStore(dataDir);
+    await second.initialize();
+    const afterRestart = await second.search('query cache invalidation', 3);
+
+    expect(afterRestart.map((row) => row.id)).toEqual(beforeRestart.map((row) => row.id));
+    expect(afterRestart[0]?.score).toBeCloseTo(beforeRestart[0]?.score ?? 0, 5);
+  });
+
+  it('returns ANN and brute-force parity on small corpora', async () => {
+    const annDataDir = await mkdtemp(join(tmpdir(), 'vector-store-ann-'));
+    const bruteDataDir = await mkdtemp(join(tmpdir(), 'vector-store-brute-'));
+
+    const annStore = new VectorStore(annDataDir, {
+      hnswFactory: async () => new FakeHnswIndex(),
+    });
+    const bruteStore = new VectorStore(bruteDataDir, {
+      disableHnsw: true,
+    });
+
+    await annStore.initialize();
+    await bruteStore.initialize();
+
+    const docs = [
+      ['doc-1', 'AlgoNode', 'binary search over sorted arrays'],
+      ['doc-2', 'AlgoNode', 'depth first search on graph with stack'],
+      ['doc-3', 'AlgoNode', 'breadth first search with queue'],
+      ['doc-4', 'AlgoNode', 'dynamic programming edit distance'],
+    ] as const;
+
+    for (const [id, label, text] of docs) {
+      await annStore.add(id, label, text);
+      await bruteStore.add(id, label, text);
+    }
+
+    const ann = await annStore.search('graph traversal queue', 3);
+    const brute = await bruteStore.search('graph traversal queue', 3);
+
+    expect(ann.map((row) => row.id)).toEqual(brute.map((row) => row.id));
+  });
+
+  it('rejects invalid embedding backend in production mode', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.SCRAPIN_VECTOR_EMBEDDING_PROVIDER = 'test';
+
+    const dataDir = await mkdtemp(join(tmpdir(), 'vector-store-prod-'));
+    const store = new VectorStore(dataDir);
+
+    await expect(store.initialize()).rejects.toThrow(/only allowed in NODE_ENV=test or NODE_ENV=development/i);
+  });
+});
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    const va = a[i] ?? 0;
+    const vb = b[i] ?? 0;
+    dot += va * vb;
+    normA += va * va;
+    normB += vb * vb;
+  }
+
+  if (!normA || !normB) {
+    return 0;
+  }
+
+  return dot / Math.sqrt(normA * normB);
+}


### PR DESCRIPTION
### Motivation
- Replace ad-hoc pseudo-random fallback and TODO index behaviour with explicit, production-safe embedding provider selection and deterministic test-only provider.
- Avoid re-embedding every entry on startup by persisting actual (quantized) embeddings so restarts preserve ranking stability.
- Use native HNSW ANN index when available for efficient queries while keeping a clear brute-force fallback and telemetry.
- Provide regression tests to lock behavior (restart stability, ANN vs brute-force parity, and production-mode provider validation).

### Description
- Added explicit embedding provider implementations: `LocalTransformersProvider` (loads `@xenova/transformers`), `RemoteEmbeddingProvider` (HTTP endpoint), and `DeterministicTestProvider` (allowed only in test/dev); provider selection is config-gated and validated with actionable errors.
- Persisted quantized embeddings (`embedding_q` + `embedding_scale`) alongside metadata in `embeddings/entries.json` and load restored vectors on startup to avoid re-embedding.
- Implemented HNSW integration with an ANN-first `search()` path that maps HNSW labels back to entries, and a deterministic brute-force cosine fallback; added telemetry logs including provider, search path (`ann` vs `brute-force`), query latency, and candidate counts.
- Replaced deferred index TODOs with incremental index maintenance: adds/removes update the HNSW index immediately and writes the index snapshot (`hnsw.index`) on save/rebuild; included helper plumbing for custom `hnswFactory` or disabling HNSW.
- Added tests under `plugins/scrapin-aint-easy/tests/core/vector.test.ts` that mock logging and a fake HNSW index to verify restart-stable rankings, ANN vs brute-force parity on small corpora, and that production rejects the test provider.

### Testing
- Ran vector-specific tests with `npm test -- tests/core/vector.test.ts` and observed the new vector suite pass (3 tests passed).
- Ran core tests with `npm test -- tests/core/*.test.ts` where the vector tests and several core tests passed, but the `graph` suite failed in this container due to `pino` resolution in that environment; vector regressions under `tests/core/vector.test.ts` passed.
- All new vector tests exercise provider selection, persistence/restoration, ANN and brute-force search paths, and production-mode provider validation and passed locally in the test environment used for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46c0e3318832ab6969653edd50dc9)