### PR TITLE
Deterministic cursor pagination for scrapin MCP tools

### DIFF
--- a/plugins/scrapin-aint-easy/README.md
+++ b/plugins/scrapin-aint-easy/README.md
@@ -111,6 +111,15 @@ Or run standalone: `pnpm start:lsp`
 | `scrapin_agent_drift_diff` | Markdown diff since baseline |
 | `scrapin_graph_stats` | Node/edge counts, index health |
 
+### MCP Pagination
+
+Large-list tools support deterministic pagination inputs:
+
+- `cursor` (optional): opaque base64 cursor from previous response
+- `page_size` (optional, default `10`): rows to return per page
+
+Paginated responses include a `Pagination` metadata block and `next_cursor` when more rows are available.
+
 ## Adding Documentation Sources
 
 Edit `config/sources.yaml`:

--- a/plugins/scrapin-aint-easy/SKILL.md
+++ b/plugins/scrapin-aint-easy/SKILL.md
@@ -22,6 +22,8 @@ Documentation intelligence engine, algorithm library, and codebase/agent drift d
 ```
 # Semantic search across all indexed content
 scrapin_search(query: "useQuery mutation", limit: 10, label_filter: "Symbol")
+# For long result sets, page deterministically:
+scrapin_search(query: "useQuery mutation", page_size: 5, cursor: "<next_cursor>")
 
 # Graph traversal from a known node
 scrapin_graph_query(start_id: "react-query:useQuery", hops: 2, include_siblings: true)
@@ -68,7 +70,7 @@ scrapin_code_drift_scan(project_root: "/path/to/project")
 scrapin_code_drift_report()
 
 # Check all agents for drift
-scrapin_agent_drift_status()
+scrapin_agent_drift_status(page_size: 20)
 
 # Get detail for one agent
 scrapin_agent_drift_detail(agent_id: "backend-architect")

--- a/plugins/scrapin-aint-easy/src/mcp/tools.ts
+++ b/plugins/scrapin-aint-easy/src/mcp/tools.ts
@@ -150,6 +150,10 @@ function encodeCursor(payload: CursorPayload): string {
   return Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
 }
 
+function deterministicTs(queryHash: string): number {
+  return Number.parseInt(queryHash.slice(0, 12), 16);
+}
+
 function decodeCursor(cursor: string): CursorPayload {
   try {
     const parsed = JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8')) as Partial<CursorPayload>;
@@ -188,7 +192,7 @@ export function paginateRows<T>(
   const slice = rows.slice(offset, offset + pageSize);
   const nextOffset = offset + slice.length;
   const nextCursor = nextOffset < rows.length
-    ? encodeCursor({ tool, offset: nextOffset, queryHash, ts: Date.now() })
+    ? encodeCursor({ tool, offset: nextOffset, queryHash, ts: deterministicTs(queryHash) })
     : undefined;
 
   return {

--- a/plugins/scrapin-aint-easy/src/mcp/tools.ts
+++ b/plugins/scrapin-aint-easy/src/mcp/tools.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import pino from 'pino';
+import { createHash } from 'node:crypto';
 import { type GraphAdapter } from '../core/graph.js';
 import { type VectorStore } from '../core/vector.js';
 import { type EventBus } from '../core/event-bus.js';
@@ -9,25 +10,30 @@ const logger = pino({ name: 'mcp:tools' });
 
 // ── Tool input schemas ──
 
+const PaginationInput = z.object({
+  cursor: z.string().optional().describe('Opaque cursor from a previous paginated response'),
+  page_size: z.number().int().min(1).max(100).default(10).describe('Rows to return per page'),
+});
+
 const SearchInput = z.object({
   query: z.string().describe('Natural language or symbol name to search for'),
   limit: z.number().min(1).max(50).default(10),
   label_filter: z.enum(['Source', 'Page', 'Symbol', 'Module', 'Example', 'AlgoNode', 'Pattern', 'AgentDef']).optional(),
-});
+}).merge(PaginationInput);
 
 const GraphQueryInput = z.object({
   start_id: z.string().describe('Node ID to start traversal from'),
   hops: z.number().min(1).max(5).default(2),
   edge_types: z.array(z.string()).optional(),
   include_siblings: z.boolean().default(false),
-});
+}).merge(PaginationInput);
 
 const AlgoSearchInput = z.object({
   query: z.string().describe('Algorithm name or description'),
   category: z.string().optional(),
   language: z.enum(['ts', 'py']).optional(),
   limit: z.number().min(1).max(20).default(5),
-});
+}).merge(PaginationInput);
 
 const AlgoDetailInput = z.object({
   name: z.string().describe('Exact algorithm name'),
@@ -41,7 +47,7 @@ const CrawlSourceInput = z.object({
 const DiffInput = z.object({
   source_key: z.string(),
   page_id: z.string().optional(),
-});
+}).merge(PaginationInput);
 
 const LspHoverInput = z.object({
   symbol: z.string(),
@@ -69,7 +75,7 @@ const CodeDriftScanInput = z.object({
   project_root: z.string().optional(),
 });
 
-const AgentDriftStatusInput = z.object({});
+const AgentDriftStatusInput = z.object({}).merge(PaginationInput);
 
 const AgentDriftDetailInput = z.object({
   agent_id: z.string(),
@@ -85,12 +91,28 @@ const AgentDriftDiffInput = z.object({
 });
 
 const GraphStatsInput = z.object({});
+const CronStatusInput = z.object({}).merge(PaginationInput);
 
 // ── Response helpers ──
 
 interface ToolResponse {
   content: Array<{ type: 'text'; text: string }>;
   isError?: boolean;
+}
+
+interface CursorPayload {
+  tool: string;
+  offset: number;
+  queryHash: string;
+  ts: number;
+}
+
+interface PaginationResult<T> {
+  rows: T[];
+  offset: number;
+  pageSize: number;
+  totalRows: number;
+  nextCursor?: string;
 }
 
 function makeMetadata(source: string, cacheHit: boolean, ttlRemaining?: number): string {
@@ -102,15 +124,79 @@ function makeMetadata(source: string, cacheHit: boolean, ttlRemaining?: number):
   ].filter(Boolean).join(' | ');
 }
 
-function textResponse(text: string, truncated = false, continueToken?: string): ToolResponse {
-  const parts = [text];
-  if (truncated) {
-    parts.push('\n\n---\n*Response truncated. Use `continue_token` for next page.*');
-    if (continueToken) parts.push(`\n\`continue_token: ${continueToken}\``);
-  }
-  const joined = parts.join('');
+function textResponse(text: string, pagination?: Omit<PaginationResult<unknown>, 'rows'>): ToolResponse {
+  const paginationBlock = pagination
+    ? [
+      '',
+      '## Pagination',
+      `- offset: ${pagination.offset}`,
+      `- page_size: ${pagination.pageSize}`,
+      `- returned: ${Math.max(0, Math.min(pagination.totalRows - pagination.offset, pagination.pageSize))}`,
+      `- total_rows: ${pagination.totalRows}`,
+      `- next_cursor: ${pagination.nextCursor ? `\`${pagination.nextCursor}\`` : 'null'}`,
+    ].join('\n')
+    : '';
+  const joined = `${text}${paginationBlock}`;
   return {
     content: [{ type: 'text', text: joined.slice(0, 16384) }],
+  };
+}
+
+function hashQuery(tool: string, query: Record<string, unknown>): string {
+  return createHash('sha256').update(JSON.stringify({ tool, query })).digest('hex');
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+}
+
+function decodeCursor(cursor: string): CursorPayload {
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8')) as Partial<CursorPayload>;
+    if (
+      typeof parsed.tool !== 'string'
+      || typeof parsed.offset !== 'number'
+      || !Number.isFinite(parsed.offset)
+      || parsed.offset < 0
+      || typeof parsed.queryHash !== 'string'
+      || typeof parsed.ts !== 'number'
+    ) {
+      throw new Error('Malformed cursor payload');
+    }
+    return { tool: parsed.tool, offset: parsed.offset, queryHash: parsed.queryHash, ts: parsed.ts };
+  } catch {
+    throw new Error('Invalid cursor encoding');
+  }
+}
+
+export function paginateRows<T>(
+  tool: string,
+  rows: T[],
+  params: { cursor?: string; page_size: number },
+  query: Record<string, unknown>,
+): PaginationResult<T> {
+  const queryHash = hashQuery(tool, query);
+  let offset = 0;
+  if (params.cursor) {
+    const payload = decodeCursor(params.cursor);
+    if (payload.tool !== tool) throw new Error(`Cursor is for tool "${payload.tool}", not "${tool}"`);
+    if (payload.queryHash !== queryHash) throw new Error('Cursor does not match current query parameters');
+    offset = payload.offset;
+  }
+
+  const pageSize = params.page_size;
+  const slice = rows.slice(offset, offset + pageSize);
+  const nextOffset = offset + slice.length;
+  const nextCursor = nextOffset < rows.length
+    ? encodeCursor({ tool, offset: nextOffset, queryHash, ts: Date.now() })
+    : undefined;
+
+  return {
+    rows: slice,
+    offset,
+    pageSize,
+    totalRows: rows.length,
+    nextCursor,
   };
 }
 
@@ -167,13 +253,26 @@ export function createTools(
 
         merged.sort((a, b) => b.score - a.score);
         const top = merged.slice(0, input.limit);
+        let page: PaginationResult<typeof top[number]>;
+        try {
+          page = paginateRows('scrapin_search', top, input, {
+            query: input.query,
+            limit: input.limit,
+            label_filter: input.label_filter,
+          });
+        } catch (err) {
+          return errorResponse(`Invalid cursor: ${err instanceof Error ? err.message : String(err)}`);
+        }
 
         const meta = makeMetadata('scrapin_search', false);
-        const lines = top.map((r, i) =>
-          `${i + 1}. **${r.name}** (${r.label}, score: ${r.score.toFixed(2)})\n   ${r.snippet}`,
+        const lines = page.rows.map((r, i) =>
+          `${page.offset + i + 1}. **${r.name}** (${r.label}, score: ${r.score.toFixed(2)})\n   ${r.snippet}`,
         );
 
-        return textResponse(`${meta}\n\n## Search Results (${top.length})\n\n${lines.join('\n\n')}`);
+        return textResponse(
+          `${meta}\n\n## Search Results (${top.length})\n\n${lines.join('\n\n')}`,
+          page,
+        );
       },
     },
 
@@ -196,17 +295,35 @@ export function createTools(
           siblings = await graph.siblings(input.start_id);
         }
 
-        const meta = makeMetadata('scrapin_graph_query', false);
-        const nodeLines = subgraph.nodes.map((n) => `- **${n.id}** (${n.label}): ${JSON.stringify(n.props).slice(0, 150)}`);
-        const edgeLines = subgraph.edges.map((e) => `- ${e.from} --[${e.type}]--> ${e.to}`);
-        const siblingLines = siblings.map((s) => `- ${s.name} (${s.kind})`);
+        const allRows = [
+          ...subgraph.nodes.map((n) => ({ kind: 'node' as const, line: `- **${n.id}** (${n.label}): ${JSON.stringify(n.props).slice(0, 150)}` })),
+          ...subgraph.edges.map((e) => ({ kind: 'edge' as const, line: `- ${e.from} --[${e.type}]--> ${e.to}` })),
+          ...siblings.map((s) => ({ kind: 'sibling' as const, line: `- ${s.name} (${s.kind})` })),
+        ];
 
-        let text = `${meta}\n\n## Graph Traversal\n\n### Nodes (${subgraph.nodes.length})\n${nodeLines.join('\n')}\n\n### Edges (${subgraph.edges.length})\n${edgeLines.join('\n')}`;
-        if (siblingLines.length > 0) {
-          text += `\n\n### Siblings (${siblingLines.length})\n${siblingLines.join('\n')}`;
+        let page: PaginationResult<typeof allRows[number]>;
+        try {
+          page = paginateRows('scrapin_graph_query', allRows, input, {
+            start_id: input.start_id,
+            hops: input.hops,
+            edge_types: input.edge_types,
+            include_siblings: input.include_siblings,
+          });
+        } catch (err) {
+          return errorResponse(`Invalid cursor: ${err instanceof Error ? err.message : String(err)}`);
         }
 
-        return textResponse(text, text.length > 16000);
+        const nodeLines = page.rows.filter((r) => r.kind === 'node').map((r) => r.line);
+        const edgeLines = page.rows.filter((r) => r.kind === 'edge').map((r) => r.line);
+        const siblingLines = page.rows.filter((r) => r.kind === 'sibling').map((r) => r.line);
+
+        const meta = makeMetadata('scrapin_graph_query', false);
+        let text = `${meta}\n\n## Graph Traversal\n\n### Nodes (${subgraph.nodes.length})\n${nodeLines.join('\n') || '- (none on this page)'}\n\n### Edges (${subgraph.edges.length})\n${edgeLines.join('\n') || '- (none on this page)'}`;
+        if (siblings.length > 0) {
+          text += `\n\n### Siblings (${siblings.length})\n${siblingLines.join('\n') || '- (none on this page)'}`;
+        }
+
+        return textResponse(text, page);
       },
     },
 
@@ -223,11 +340,22 @@ export function createTools(
           input.limit,
           'AlgoNode',
         );
+        let page: PaginationResult<typeof results[number]>;
+        try {
+          page = paginateRows('scrapin_algo_search', results, input, {
+            query: input.query,
+            category: input.category,
+            language: input.language,
+            limit: input.limit,
+          });
+        } catch (err) {
+          return errorResponse(`Invalid cursor: ${err instanceof Error ? err.message : String(err)}`);
+        }
 
         const meta = makeMetadata('scrapin_algo_search', false);
-        const lines = results.map((r, i) => `${i + 1}. **${r.id}** (score: ${r.score.toFixed(2)})\n   ${r.text.slice(0, 300)}`);
+        const lines = page.rows.map((r, i) => `${page.offset + i + 1}. **${r.id}** (score: ${r.score.toFixed(2)})\n   ${r.text.slice(0, 300)}`);
 
-        return textResponse(`${meta}\n\n## Algorithm Search Results (${results.length})\n\n${lines.join('\n\n')}`);
+        return textResponse(`${meta}\n\n## Algorithm Search Results (${results.length})\n\n${lines.join('\n\n')}`, page);
       },
     },
 
@@ -271,7 +399,7 @@ export function createTools(
           }
         }
 
-        return textResponse(text, text.length > 16000);
+        return textResponse(text);
       },
     },
 
@@ -307,14 +435,24 @@ export function createTools(
         text += `**Total pages:** ${sourcePages.length}\n`;
         text += `**Stale pages:** ${stale.length}\n\n`;
 
+        let page: PaginationResult<typeof stale[number]>;
+        try {
+          page = paginateRows('scrapin_diff', stale, input, {
+            source_key: input.source_key,
+            page_id: input.page_id,
+          });
+        } catch (err) {
+          return errorResponse(`Invalid cursor: ${err instanceof Error ? err.message : String(err)}`);
+        }
+
         if (stale.length > 0) {
           text += `### Stale Pages\n`;
-          for (const page of stale.slice(0, 20)) {
+          for (const page of page.rows) {
             text += `- ${page.props['title'] ?? page.id} (${page.props['url'] ?? 'no url'})\n`;
           }
         }
 
-        return textResponse(text);
+        return textResponse(text, page);
       },
     },
 
@@ -344,11 +482,20 @@ export function createTools(
     {
       name: 'scrapin_cron_status',
       description: 'Get status of all cron jobs including drift detection information',
-      inputSchema: z.object({}),
-      handler: async () => {
+      inputSchema: CronStatusInput,
+      handler: async (raw) => {
+        const input = CronStatusInput.parse(raw);
         logger.info('scrapin_cron_status');
+        const allJobs = ['full-sweep', 'staleness-check', 'missing-doc-scan', 'openapi-sync', 'embedding-rebuild', 'algo-sweep', 'code-drift-scan', 'agent-drift-scan'];
+        let page: PaginationResult<string>;
+        try {
+          page = paginateRows('scrapin_cron_status', allJobs, input, {});
+        } catch (err) {
+          return errorResponse(`Invalid cursor: ${err instanceof Error ? err.message : String(err)}`);
+        }
         const meta = makeMetadata('scrapin_cron_status', false);
-        return textResponse(`${meta}\n\nCron status: scheduler is running. Use startup logs for detailed job status.`);
+        const lines = page.rows.map((job) => `- ${job}: running`);
+        return textResponse(`${meta}\n\nCron status: scheduler is running.\n\n${lines.join('\n')}`, page);
       },
     },
 
@@ -457,7 +604,8 @@ export function createTools(
       name: 'scrapin_agent_drift_status',
       description: 'List all agents with their drift scores and summaries',
       inputSchema: AgentDriftStatusInput,
-      handler: async () => {
+      handler: async (raw) => {
+        const input = AgentDriftStatusInput.parse(raw);
         logger.info('scrapin_agent_drift_status');
 
         try {
@@ -465,8 +613,15 @@ export function createTools(
           const detector = new AgentDriftDetector(graph, join(config.projectRoot, '.claude', 'agents'), config.configDir);
           const reports = await detector.scan();
 
+          let page: PaginationResult<typeof reports[number]>;
+          try {
+            page = paginateRows('scrapin_agent_drift_status', reports, input, {});
+          } catch (err) {
+            return errorResponse(`Invalid cursor: ${err instanceof Error ? err.message : String(err)}`);
+          }
+
           const meta = makeMetadata('scrapin_agent_drift_status', false);
-          const lines = reports.map((r) =>
+          const lines = page.rows.map((r) =>
             `| ${r.agent_id} | ${r.drift_type} | ${r.drift_score}/10 | ${r.changed_sections.join(', ') || 'none'} |`,
           );
 
@@ -477,7 +632,7 @@ export function createTools(
           text += `**Drifted:** ${reports.filter((r) => r.drift_score > 0).length}\n`;
           text += `**High severity (>5):** ${reports.filter((r) => r.drift_score > 5).length}`;
 
-          return textResponse(text);
+          return textResponse(text, page);
         } catch (err) {
           return errorResponse(`Agent drift scan failed: ${err instanceof Error ? err.message : String(err)}`);
         }

--- a/plugins/scrapin-aint-easy/tests/mcp/tools-pagination.test.ts
+++ b/plugins/scrapin-aint-easy/tests/mcp/tools-pagination.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTools, paginateRows } from '../../src/mcp/tools.js';
+import type { GraphAdapter } from '../../src/core/graph.js';
+import type { VectorStore } from '../../src/core/vector.js';
+import { EventBus } from '../../src/core/event-bus.js';
+
+function decodeNextCursor(text: string): string | undefined {
+  const match = text.match(/next_cursor: `([^`]+)`/);
+  return match?.[1];
+}
+
+describe('paginateRows', () => {
+  it('generates next_cursor and stable page boundaries', () => {
+    const rows = ['a', 'b', 'c', 'd', 'e'];
+    const first = paginateRows('scrapin_search', rows, { page_size: 2 }, { query: 'abc' });
+    expect(first.rows).toEqual(['a', 'b']);
+    expect(first.nextCursor).toBeDefined();
+
+    const second = paginateRows('scrapin_search', rows, { page_size: 2, cursor: first.nextCursor }, { query: 'abc' });
+    expect(second.rows).toEqual(['c', 'd']);
+    expect(new Set([...first.rows, ...second.rows]).size).toBe(4);
+
+    const third = paginateRows('scrapin_search', rows, { page_size: 2, cursor: second.nextCursor }, { query: 'abc' });
+    expect(third.rows).toEqual(['e']);
+    expect(third.nextCursor).toBeUndefined();
+  });
+
+  it('rejects cursor from another tool', () => {
+    const page = paginateRows('scrapin_search', [1, 2, 3], { page_size: 1 }, { query: 'x' });
+    expect(() => paginateRows('scrapin_algo_search', [1, 2, 3], { page_size: 1, cursor: page.nextCursor }, { query: 'x' }))
+      .toThrow(/Cursor is for tool/);
+  });
+});
+
+describe('scrapin_search pagination integration', () => {
+  it('returns next_cursor and allows fetching the next page with no duplicates', async () => {
+    const vector = {
+      search: vi.fn().mockResolvedValue([
+        { id: 'id-1', label: 'Symbol', text: 'text-1', score: 0.9 },
+        { id: 'id-2', label: 'Symbol', text: 'text-2', score: 0.8 },
+        { id: 'id-3', label: 'Symbol', text: 'text-3', score: 0.7 },
+      ]),
+      size: 3,
+    } as unknown as VectorStore;
+
+    const graph = {
+      search: vi.fn().mockResolvedValue([]),
+    } as unknown as GraphAdapter;
+
+    const tools = createTools(graph, vector, new EventBus(), {
+      configDir: '/tmp/config',
+      dataDir: '/tmp/data',
+      projectRoot: '/tmp/project',
+    });
+
+    const searchTool = tools.find((t) => t.name === 'scrapin_search');
+    expect(searchTool).toBeDefined();
+    const tool = searchTool!;
+
+    const first = await tool.handler({ query: 'x', limit: 3, page_size: 2 });
+    const firstText = first.content[0]?.text ?? '';
+    expect(firstText).toContain('1. **id-1**');
+    expect(firstText).toContain('2. **id-2**');
+
+    const nextCursor = decodeNextCursor(firstText);
+    expect(nextCursor).toBeDefined();
+
+    const second = await tool.handler({ query: 'x', limit: 3, page_size: 2, cursor: nextCursor });
+    const secondText = second.content[0]?.text ?? '';
+    expect(secondText).toContain('3. **id-3**');
+    expect(secondText).not.toContain('1. **id-1**');
+  });
+
+  it('returns error for invalid cursor encoding', async () => {
+    const vector = {
+      search: vi.fn().mockResolvedValue([{ id: 'id-1', label: 'Symbol', text: 'text-1', score: 0.9 }]),
+      size: 1,
+    } as unknown as VectorStore;
+
+    const graph = { search: vi.fn().mockResolvedValue([]) } as unknown as GraphAdapter;
+
+    const tools = createTools(graph, vector, new EventBus(), {
+      configDir: '/tmp/config',
+      dataDir: '/tmp/data',
+      projectRoot: '/tmp/project',
+    });
+
+    const tool = tools.find((t) => t.name === 'scrapin_search');
+    const response = await tool!.handler({ query: 'x', cursor: 'not-base64', page_size: 1 });
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toContain('Invalid cursor');
+  });
+});

--- a/plugins/scrapin-aint-easy/tests/mcp/tools-pagination.test.ts
+++ b/plugins/scrapin-aint-easy/tests/mcp/tools-pagination.test.ts
@@ -30,6 +30,13 @@ describe('paginateRows', () => {
     expect(() => paginateRows('scrapin_algo_search', [1, 2, 3], { page_size: 1, cursor: page.nextCursor }, { query: 'x' }))
       .toThrow(/Cursor is for tool/);
   });
+
+  it('generates deterministic next_cursor for the same input', () => {
+    const rows = ['a', 'b', 'c'];
+    const first = paginateRows('scrapin_search', rows, { page_size: 2 }, { query: 'abc' });
+    const second = paginateRows('scrapin_search', rows, { page_size: 2 }, { query: 'abc' });
+    expect(first.nextCursor).toBe(second.nextCursor);
+  });
 });
 
 describe('scrapin_search pagination integration', () => {


### PR DESCRIPTION
### Motivation

- Provide a deterministic, reusable pagination mechanism for MCP tools that can return large result sets instead of relying on ad-hoc truncation/`continue_token` text hints. 
- Ensure clients can page through long listings (search, graph traversal, algo listings, drift listings, cron/status) without duplicates or holes. 
- Preserve existing output layout while adding explicit pagination metadata and a backwards-compatible default of the first page when no cursor is provided.

### Description

- Added a shared pagination schema `PaginationInput` (`cursor`, `page_size`) and merged it into high-volume tool input schemas such as `scrapin_search`, `scrapin_graph_query`, `scrapin_algo_search`, `scrapin_diff`, `scrapin_agent_drift_status`, and `scrapin_cron_status`. 
- Implemented `paginateRows` plus helpers (`hashQuery`, `encodeCursor`, `decodeCursor`) that encode cursors as base64 JSON payloads `{tool, offset, queryHash, ts}`, validate tool/query compatibility, and emit `next_cursor` only when more rows remain. 
- Refactored handlers to compute full result sets first, call `paginateRows` to slice results, then format the current page; responses now include a `Pagination` metadata block produced by `textResponse` while preserving existing sections. 
- Updated documentation and prompts to describe cursor/page-size usage in `README.md` and `SKILL.md`, and added tests under `plugins/scrapin-aint-easy/tests/mcp/tools-pagination.test.ts` covering cursor generation, invalid cursor rejection, and stable page boundaries (no duplicates/holes).

### Testing

- Ran static checks (`git diff --check`) which reported no issues. 
- Added unit/integration tests (`tests/mcp/tools-pagination.test.ts`) that exercise `paginateRows` and `scrapin_search` pagination behavior. 
- Attempted to run `pnpm test -- tests/mcp/tools-pagination.test.ts` in this environment but it failed because `node_modules` (including `vitest`) are not installed, so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46c08b490832aafbe17340cbeb2f8)