### PR TITLE
Generate JSON Schema for MCP tools and add coercion for numeric/boolean inputs

### DIFF
--- a/plugins/scrapin-aint-easy/src/index.ts
+++ b/plugins/scrapin-aint-easy/src/index.ts
@@ -15,6 +15,7 @@ import { EventBus } from './core/event-bus.js';
 import { createTools, type ToolDefinition } from './mcp/tools.js';
 import { createResources, type ResourceDefinition } from './mcp/resources.js';
 import { createPrompts, type PromptDefinition } from './mcp/prompts.js';
+import { zodToJsonSchema } from './mcp/zod-json-schema.js';
 import { CronScheduler } from './scheduler/cron.js';
 import { createFullSweepJob } from './scheduler/jobs/full-sweep.js';
 import { createStalenessCheckJob } from './scheduler/jobs/staleness-check.js';
@@ -82,15 +83,7 @@ export async function createScrapinServer(options: ScrapinServerOptions = {}): P
     tools: tools.map((t) => ({
       name: t.name,
       description: t.description,
-      inputSchema: {
-        type: 'object' as const,
-        properties: Object.fromEntries(
-          Object.entries((t.inputSchema as { shape?: Record<string, unknown> }).shape ?? {}).map(([key]) => [
-            key,
-            { type: 'string' },
-          ]),
-        ),
-      },
+      inputSchema: zodToJsonSchema(t.inputSchema),
     })),
   }));
 

--- a/plugins/scrapin-aint-easy/src/mcp/tools.ts
+++ b/plugins/scrapin-aint-easy/src/mcp/tools.ts
@@ -13,22 +13,22 @@ const logger = pino({ name: 'mcp:tools' });
 
 const SearchInput = z.object({
   query: z.string().describe('Natural language or symbol name to search for'),
-  limit: z.number().min(1).max(50).default(10),
+  limit: z.coerce.number().min(1).max(50).default(10),
   label_filter: z.enum(['Source', 'Page', 'Symbol', 'Module', 'Example', 'AlgoNode', 'Pattern', 'AgentDef']).optional(),
 });
 
 const GraphQueryInput = z.object({
   start_id: z.string().describe('Node ID to start traversal from'),
-  hops: z.number().min(1).max(5).default(2),
+  hops: z.coerce.number().min(1).max(5).default(2),
   edge_types: z.array(z.string()).optional(),
-  include_siblings: z.boolean().default(false),
+  include_siblings: z.coerce.boolean().default(false),
 });
 
 const AlgoSearchInput = z.object({
   query: z.string().describe('Algorithm name or description'),
   category: z.string().optional(),
   language: z.enum(['ts', 'py']).optional(),
-  limit: z.number().min(1).max(20).default(5),
+  limit: z.coerce.number().min(1).max(20).default(5),
 });
 
 const AlgoDetailInput = z.object({
@@ -37,7 +37,7 @@ const AlgoDetailInput = z.object({
 
 const CrawlSourceInput = z.object({
   source_key: z.string().describe('Source key from sources.yaml'),
-  force: z.boolean().default(false),
+  force: z.coerce.boolean().default(false),
 });
 
 const DiffInput = z.object({
@@ -56,8 +56,8 @@ const AddSourceInput = z.object({
   base_url: z.string().url(),
   sitemap: z.string().optional(),
   package_aliases: z.array(z.string()).default([]),
-  concurrency: z.number().default(5),
-  rps: z.number().default(2),
+  concurrency: z.coerce.number().default(5),
+  rps: z.coerce.number().default(2),
 });
 
 const AddAlgoSourceInput = z.object({

--- a/plugins/scrapin-aint-easy/src/mcp/zod-json-schema.ts
+++ b/plugins/scrapin-aint-easy/src/mcp/zod-json-schema.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+
+type JsonSchema = Record<string, unknown>;
+
+function withDescription(schema: JsonSchema, zodSchema: z.ZodTypeAny): JsonSchema {
+  if (zodSchema.description) {
+    schema.description = zodSchema.description;
+  }
+  return schema;
+}
+
+function unwrapEffects(schema: z.ZodTypeAny): z.ZodTypeAny {
+  let current = schema;
+  while (current._def.typeName === z.ZodFirstPartyTypeKind.ZodEffects) {
+    current = (current as z.ZodEffects<z.ZodTypeAny>)._def.schema;
+  }
+  return current;
+}
+
+function isOptionalInput(schema: z.ZodTypeAny): boolean {
+  const unwrapped = unwrapEffects(schema);
+  if (unwrapped._def.typeName === z.ZodFirstPartyTypeKind.ZodOptional) return true;
+  if (unwrapped._def.typeName === z.ZodFirstPartyTypeKind.ZodDefault) return true;
+  return false;
+}
+
+function zodToJsonSchemaInternal(schema: z.ZodTypeAny): JsonSchema {
+  const unwrapped = unwrapEffects(schema);
+  const typeName = unwrapped._def.typeName;
+
+  if (typeName === z.ZodFirstPartyTypeKind.ZodOptional) {
+    return zodToJsonSchemaInternal((unwrapped as z.ZodOptional<z.ZodTypeAny>).unwrap());
+  }
+  if (typeName === z.ZodFirstPartyTypeKind.ZodDefault) {
+    const defaultSchema = unwrapped as z.ZodDefault<z.ZodTypeAny>;
+    const inner = zodToJsonSchemaInternal(defaultSchema._def.innerType);
+    inner.default = defaultSchema._def.defaultValue();
+    return withDescription(inner, unwrapped);
+  }
+  if (typeName === z.ZodFirstPartyTypeKind.ZodObject) {
+    const objectSchema = unwrapped as z.ZodObject<z.ZodRawShape>;
+    const shape = objectSchema.shape;
+    const properties: Record<string, JsonSchema> = {};
+    const required: string[] = [];
+
+    for (const [key, value] of Object.entries(shape)) {
+      properties[key] = zodToJsonSchemaInternal(value);
+      if (!isOptionalInput(value)) required.push(key);
+    }
+
+    const result: JsonSchema = {
+      type: 'object',
+      properties,
+      additionalProperties: false,
+    };
+    if (required.length > 0) result.required = required;
+    return withDescription(result, unwrapped);
+  }
+  if (typeName === z.ZodFirstPartyTypeKind.ZodArray) {
+    const arraySchema = unwrapped as z.ZodArray<z.ZodTypeAny>;
+    return withDescription(
+      {
+        type: 'array',
+        items: zodToJsonSchemaInternal(arraySchema.element),
+      },
+      unwrapped,
+    );
+  }
+  if (typeName === z.ZodFirstPartyTypeKind.ZodEnum) {
+    const enumSchema = unwrapped as z.ZodEnum<[string, ...string[]]>;
+    return withDescription({ type: 'string', enum: enumSchema.options }, unwrapped);
+  }
+  if (typeName === z.ZodFirstPartyTypeKind.ZodString) return withDescription({ type: 'string' }, unwrapped);
+  if (typeName === z.ZodFirstPartyTypeKind.ZodNumber) return withDescription({ type: 'number' }, unwrapped);
+  if (typeName === z.ZodFirstPartyTypeKind.ZodBoolean) return withDescription({ type: 'boolean' }, unwrapped);
+  if (typeName === z.ZodFirstPartyTypeKind.ZodLiteral) {
+    const literal = (unwrapped as z.ZodLiteral<unknown>).value;
+    return withDescription(
+      {
+        const: literal,
+        type: typeof literal,
+      },
+      unwrapped,
+    );
+  }
+  if (typeName === z.ZodFirstPartyTypeKind.ZodNullable) {
+    const nullableSchema = unwrapped as z.ZodNullable<z.ZodTypeAny>;
+    const inner = zodToJsonSchemaInternal(nullableSchema.unwrap());
+    return withDescription({ anyOf: [inner, { type: 'null' }] }, unwrapped);
+  }
+
+  return {};
+}
+
+export function zodToJsonSchema(schema: z.ZodTypeAny): JsonSchema {
+  return zodToJsonSchemaInternal(schema);
+}

--- a/plugins/scrapin-aint-easy/tests/mcp/tools-schema-coercion.test.ts
+++ b/plugins/scrapin-aint-easy/tests/mcp/tools-schema-coercion.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('pino', () => ({
+  default: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { createTools } from '../../src/mcp/tools.js';
+import { zodToJsonSchema } from '../../src/mcp/zod-json-schema.js';
+
+function makeTools() {
+  const graph = {
+    search: vi.fn().mockResolvedValue([]),
+    traverse: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    siblings: vi.fn().mockResolvedValue([]),
+  } as never;
+
+  const vector = {
+    search: vi.fn().mockResolvedValue([]),
+  } as never;
+
+  const eventBus = {
+    emit: vi.fn(),
+  } as never;
+
+  const crawlQueue = {
+    enqueue: vi.fn().mockReturnValue({ id: 'job-1' }),
+  } as never;
+
+  const tools = createTools(graph, vector, eventBus, {
+    configDir: '',
+    dataDir: '',
+    projectRoot: '',
+    sources: {
+      docs: {
+        name: 'Docs',
+        base_url: 'https://example.com',
+      },
+    },
+    crawlQueue,
+  });
+
+  return { tools, graph, vector, crawlQueue };
+}
+
+describe('MCP tool schema + coercion', () => {
+  it('ListTools advertises real JSON Schema parameter types', () => {
+    const { tools } = makeTools();
+
+    const listToolsResponse = {
+      tools: tools.map((tool) => ({
+        name: tool.name,
+        inputSchema: zodToJsonSchema(tool.inputSchema),
+      })),
+    };
+
+    const searchTool = listToolsResponse.tools.find((tool) => tool.name === 'scrapin_search');
+    const graphTool = listToolsResponse.tools.find((tool) => tool.name === 'scrapin_graph_query');
+    const crawlTool = listToolsResponse.tools.find((tool) => tool.name === 'scrapin_crawl_source');
+
+    expect(searchTool?.inputSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        limit: { type: 'number' },
+        label_filter: {
+          type: 'string',
+          enum: ['Source', 'Page', 'Symbol', 'Module', 'Example', 'AlgoNode', 'Pattern', 'AgentDef'],
+        },
+      },
+      required: ['query'],
+    });
+
+    expect(graphTool?.inputSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        hops: { type: 'number' },
+        include_siblings: { type: 'boolean' },
+        edge_types: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    });
+
+    expect(crawlTool?.inputSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        force: { type: 'boolean' },
+      },
+    });
+  });
+
+  it('accepts stringified numeric/boolean tool inputs via coercion', async () => {
+    const { tools, graph, vector, crawlQueue } = makeTools();
+    const searchTool = tools.find((tool) => tool.name === 'scrapin_search');
+    const graphTool = tools.find((tool) => tool.name === 'scrapin_graph_query');
+    const crawlTool = tools.find((tool) => tool.name === 'scrapin_crawl_source');
+
+    expect(searchTool).toBeDefined();
+    expect(graphTool).toBeDefined();
+    expect(crawlTool).toBeDefined();
+
+    await searchTool!.handler({ query: 'auth', limit: '3' });
+    await graphTool!.handler({ start_id: 'symbol::auth', hops: '2', include_siblings: 'true' });
+    await crawlTool!.handler({ source_key: 'docs', force: 'true' });
+
+    expect(vector.search).toHaveBeenCalledWith('auth', 3, undefined);
+    expect(graph.traverse).toHaveBeenCalledWith('symbol::auth', 2, undefined);
+    expect(graph.siblings).toHaveBeenCalledWith('symbol::auth');
+    expect(crawlQueue.enqueue).toHaveBeenCalledWith(
+      'docs',
+      { name: 'Docs', base_url: 'https://example.com' },
+      true,
+    );
+  });
+
+  it('rejects invalid coerced values with clear validation errors', async () => {
+    const { tools } = makeTools();
+    const searchTool = tools.find((tool) => tool.name === 'scrapin_search');
+    const graphTool = tools.find((tool) => tool.name === 'scrapin_graph_query');
+
+    await expect(searchTool!.handler({ query: 'auth', limit: '0' })).rejects.toThrow(/greater than or equal to 1/i);
+    await expect(graphTool!.handler({ start_id: 'n1', hops: 'not-a-number' })).rejects.toThrow(/number/i);
+    await expect(
+      searchTool!.handler({ query: 'auth', label_filter: 'TotallyInvalidLabel' }),
+    ).rejects.toThrow(/invalid enum value/i);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the MCP `ListTools` response advertise accurate parameter types instead of a hardcoded string mapping so clients can see true parameter shapes.  
- Accept common client input shapes (e.g. stringified numbers/booleans) for externally-facing tool parameters to improve robustness.  
- Add automated checks to ensure schema advertisement and coercion behave as expected.

### Description
- Replace the ad-hoc string-only `inputSchema` mapping in the MCP server with real JSON Schema generation using a local converter: `zodToJsonSchema(...)` and wire it into `src/index.ts`.  
- Add a lightweight Zod→JSON Schema serializer at `src/mcp/zod-json-schema.ts` that supports objects, arrays, enums, defaults, optionals, nullables, literals, and unwrapping `ZodEffects`.  
- Update externally-facing numeric/boolean Zod inputs in `src/mcp/tools.ts` to use `z.coerce.number()` / `z.coerce.boolean()` for `limit`, `hops`, `force`, `include_siblings`, `concurrency`, and `rps`.  
- Add unit tests at `tests/mcp/tools-schema-coercion.test.ts` that assert `ListTools` advertises proper parameter types, verify coerced string inputs are accepted, and verify invalid values still produce clear validation errors.

### Testing
- Ran the new test file with `npm test -- tests/mcp/tools-schema-coercion.test.ts`, which executed 3 tests and passed.  
- Attempted to build with `npm run build`, which failed in this environment due to `tsup` not being available (`tsup: not found`), unrelated to the functional changes validated by tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46de122c0832a919f686c34ce7edd)