### PR TITLE
fix(scrapin-aint-easy): fix plugin.json manifest schema validation

### DIFF
--- a/plugins/scrapin-aint-easy/.claude-plugin/plugin.json
+++ b/plugins/scrapin-aint-easy/.claude-plugin/plugin.json
@@ -2,16 +2,13 @@
   "name": "scrapin-aint-easy",
   "version": "1.0.0",
   "description": "Documentation intelligence engine, algorithm library, and codebase/agent drift detection system for Claude Code",
-  "author": "Markus Ahling",
+  "author": {
+    "name": "Markus Ahling"
+  },
   "license": "MIT",
   "homepage": "https://github.com/markus41/claude/tree/main/plugins/scrapin-aint-easy",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/markus41/claude.git",
-    "directory": "plugins/scrapin-aint-easy"
-  },
-  "category": "developer-tools",
-  "tags": [
+  "repository": "https://github.com/markus41/claude",
+  "keywords": [
     "documentation",
     "algorithms",
     "drift-detection",
@@ -21,101 +18,19 @@
     "interview-setup",
     "code-intelligence"
   ],
-  "marketplace": {
-    "featured": true,
-    "icon": "brain",
-    "color": "#7C3AED",
-    "shortDescription": "Graph-based doc intelligence + algorithm library + codebase & agent drift detection",
-    "longDescription": "Drop into any repo for live, graph-traversable API docs, an indexed algorithm library (TheAlgorithms, Refactoring Guru, NeetCode), automated codebase drift detection for missing/deprecated/stale docs, agent prompt drift monitoring with cross-agent contradiction detection, and an interview-driven project setup that generates tailored Claude Code configuration.",
-    "screenshots": [],
-    "minClaudeCodeVersion": "1.0.0",
-    "pricing": "free",
-    "support": "https://github.com/markus41/claude/issues"
-  },
-  "commands": [
-    {
-      "name": "scrapin-search",
-      "description": "Search documentation knowledge graph",
-      "file": ".claude/commands/scrapin-search.md"
-    },
-    {
-      "name": "scrapin-crawl",
-      "description": "Trigger documentation crawl",
-      "file": ".claude/commands/scrapin-crawl.md"
-    },
-    {
-      "name": "scrapin-diff",
-      "description": "Show doc changes since last crawl",
-      "file": ".claude/commands/scrapin-diff.md"
-    },
-    {
-      "name": "scrapin-algo",
-      "description": "Query algorithm library",
-      "file": ".claude/commands/scrapin-algo.md"
-    },
-    {
-      "name": "scrapin-drift",
-      "description": "Run drift detection",
-      "file": ".claude/commands/scrapin-drift.md"
-    },
-    {
-      "name": "scrapin-status",
-      "description": "System health dashboard",
-      "file": ".claude/commands/scrapin-status.md"
-    },
-    {
-      "name": "scrapin-setup",
-      "description": "Interactive project setup — thorough interview then generates Claude Code config",
-      "file": ".claude/commands/scrapin-setup.md"
-    }
-  ],
-  "agents": [
-    {
-      "name": "doc-crawler",
-      "file": ".claude/agents/doc-crawler.md"
-    },
-    {
-      "name": "doc-graph-builder",
-      "file": ".claude/agents/doc-graph-builder.md"
-    },
-    {
-      "name": "doc-lsp-resolver",
-      "file": ".claude/agents/doc-lsp-resolver.md"
-    },
-    {
-      "name": "doc-diff-watcher",
-      "file": ".claude/agents/doc-diff-watcher.md"
-    },
-    {
-      "name": "doc-cron-runner",
-      "file": ".claude/agents/doc-cron-runner.md"
-    },
-    {
-      "name": "algo-indexer",
-      "file": ".claude/agents/algo-indexer.md"
-    },
-    {
-      "name": "code-drift-detector",
-      "file": ".claude/agents/code-drift-detector.md"
-    },
-    {
-      "name": "agent-drift-detector",
-      "file": ".claude/agents/agent-drift-detector.md"
-    }
-  ],
+  "commands": "./.claude/commands/",
+  "agents": "./.claude/agents/",
   "skills": [
-    {
-      "name": "scrapin-aint-easy",
-      "file": "SKILL.md"
-    }
+    "./skills/",
+    "./.claude/skills/"
   ],
-  "mcpServer": {
-    "command": "node",
-    "args": [
-      "dist/cli.js",
-      "--mcp"
-    ],
-    "env": {}
-  },
-  "contextEntry": "CLAUDE.md"
+  "mcpServers": {
+    "scrapin-aint-easy": {
+      "command": "node",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/dist/cli.js",
+        "--mcp"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- **Fix `plugin.json` to match Claude Code's manifest schema** — the previous format used non-standard fields that fail validation on install
- `author`: string → object `{"name": "..."}`
- `repository`: object → string URL
- `commands`: array of objects → string path `"./.claude/commands/"`
- `agents`: array of objects → string path `"./.claude/agents/"`
- `skills`: array of objects → array of directory paths
- `mcpServers`: use correct key with `${CLAUDE_PLUGIN_ROOT}` variable
- Removed non-standard fields: `category`, `tags`, `marketplace`, `contextEntry`

## Test plan

- [ ] Run `/plugin install scrapin-aint-easy@claude-orchestration` — should install without validation errors
- [ ] Verify commands (`/scrapin-search`, `/scrapin-setup`, etc.) appear after install
- [ ] Verify agents are discoverable via `/agents`
- [ ] Run `claude plugin validate plugins/scrapin-aint-easy` to confirm schema compliance

https://claude.ai/code/session_01RjNDPySF1fTtQA3ok8uNLN