### PR TITLE
fix(scrapin-aint-easy): use symlinks for plugin component auto-discovery

### DIFF
--- a/plugins/scrapin-aint-easy/.claude-plugin/plugin.json
+++ b/plugins/scrapin-aint-easy/.claude-plugin/plugin.json
@@ -18,12 +18,6 @@
     "interview-setup",
     "code-intelligence"
   ],
-  "commands": "./.claude/commands/",
-  "agents": "./.claude/agents/",
-  "skills": [
-    "./skills/",
-    "./.claude/skills/"
-  ],
   "mcpServers": {
     "scrapin-aint-easy": {
       "command": "node",

--- a/plugins/scrapin-aint-easy/agents
+++ b/plugins/scrapin-aint-easy/agents
@@ -1,0 +1,1 @@
+.claude/agents

--- a/plugins/scrapin-aint-easy/commands
+++ b/plugins/scrapin-aint-easy/commands
@@ -1,0 +1,1 @@
+.claude/commands

--- a/plugins/scrapin-aint-easy/skills
+++ b/plugins/scrapin-aint-easy/skills
@@ -1,0 +1,1 @@
+.claude/skills


### PR DESCRIPTION
## Summary

- **Remove `commands`/`agents`/`skills` path overrides from plugin.json** — custom path arrays caused "agents: Invalid input" validation error on install
- **Add symlinks** at standard locations so Claude Code auto-discovers components:
  - `commands/` -> `.claude/commands/` (7 commands)
  - `agents/` -> `.claude/agents/` (12 agents)
  - `skills/` -> `.claude/skills/` (5 skills)
- Symlinks are followed during plugin cache copy per [official docs](https://code.claude.com/docs/en/plugins-reference#working-with-external-dependencies)

## Verified

- Manifest has no non-standard fields
- `author` is object, `repository` is string
- All 7 commands, 12 agents, 5 skills resolve through symlinks
- `mcpServers` uses `${CLAUDE_PLUGIN_ROOT}` correctly

## Test plan

- [ ] `/plugin install scrapin-aint-easy@claude-orchestration` completes without validation errors
- [ ] `/scrapin-search`, `/scrapin-setup` etc. appear as available commands
- [ ] Agents visible in `/agents` interface
- [ ] MCP server starts when plugin is enabled

https://claude.ai/code/session_01RjNDPySF1fTtQA3ok8uNLN