### PR TITLE
fix(marketplace): align claude-code-expert entry to v7.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -300,8 +300,8 @@
     },
     {
       "name": "claude-code-expert",
-      "description": "High-intelligence Claude Code copilot with deep code reasoning, evidence-driven planning, orchestration-first execution, model routing, context budgeting, CI/CD integration, enterprise security, plugin development, prompt engineering, performance profiling, agent teams, interactive tutorials, and a queryable 10-tool MCP documentation server. 16 commands, 33 skills, 16 agents.",
-      "version": "6.0.0",
+      "description": "High-intelligence Claude Code copilot with deep code reasoning, evidence-driven planning, orchestration-first execution, model routing, context budgeting, CI/CD integration, enterprise security, plugin development, prompt engineering, performance profiling, agent teams, interactive tutorials, orchestration blackboard (shared multi-round state), prompt-budget preflight, specialist-first routing, verify-between-waves cadence, agent telemetry, and a queryable 19-tool MCP documentation server with 2 MCP resources. 22 commands, 56 skills, 26 agents, 9 hooks.",
+      "version": "7.9.0",
       "author": {
         "name": "Markus Ahling"
       },
@@ -316,6 +316,11 @@
         "debugging",
         "configuration",
         "orchestration",
+        "orchestration-blackboard",
+        "prompt-budget",
+        "agent-telemetry",
+        "specialist-routing",
+        "verify-between-waves",
         "council",
         "best-practices"
       ]

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/plugins.schema.json",
   "version": "3.0.0",
-  "lastUpdated": "2026-03-31T09:37:45Z",
+  "lastUpdated": "2026-04-17T00:00:00Z",
   "description": "Plugin registry for Claude Code orchestration plugins - upgraded with Agentic Design Patterns (Gulli & Sauco, 2025)",
   "installed": {
     "aws-eks-helm-keycloak": {
@@ -116,10 +116,10 @@
       "dependencies": {}
     },
     "claude-code-expert": {
-      "version": "7.6.0",
+      "version": "7.9.0",
       "path": "../plugins/claude-code-expert",
       "source": "local",
-      "installedAt": "2026-03-08T00:00:00.000Z",
+      "installedAt": "2026-04-17T00:00:00.000Z",
       "dependencies": {}
     },
     "cowork-marketplace": {
@@ -362,8 +362,8 @@
     },
     "claude-code-expert": {
       "name": "claude-code-expert",
-      "version": "7.6.0",
-      "description": "High-intelligence Claude Code copilot with deep code reasoning, evidence-driven planning, orchestration-first execution, model routing, context budgeting, CI/CD integration, enterprise security, plugin development, prompt engineering, performance profiling, agent teams, channels, hook policy engine (8 packs), layered memory deployment, role-based subagent packs, 5 agent-team topology kits, autonomy operating mode (4 profiles + 3 gate agents), and a queryable 15-tool MCP documentation server with autonomy advisor.",
+      "version": "7.9.0",
+      "description": "High-intelligence Claude Code copilot with deep code reasoning, evidence-driven planning, orchestration-first execution, model routing, context budgeting, CI/CD integration, enterprise security, plugin development, prompt engineering, performance profiling, agent teams, channels, hook policy engine, layered memory deployment, role-based subagent packs, agent-team topology kits, autonomy operating mode, orchestration blackboard (shared multi-round state across parallel agents), prompt-budget preflight, specialist-first routing, verify-between-waves cadence, agent telemetry, and a queryable 19-tool MCP documentation server with 2 MCP resources. 22 commands, 56 skills, 26 agents, 9 hooks.",
       "author": {
         "name": "Markus Ahling"
       },
@@ -746,7 +746,7 @@
     "totalInstalled": 21,
     "totalPlugins": 27,
     "totalAvailable": 6,
-    "lastUpdated": "2026-04-07T00:00:00.000Z",
+    "lastUpdated": "2026-04-17T00:00:00.000Z",
     "byTier": {
       "enterprise": 1,
       "standard": 24


### PR DESCRIPTION
## Summary

PR #132 merged the plugin's own `plugin.json` bump to v7.9.0 but left the marketplace entry in `.claude-plugin/marketplace.json` and the registry entry in `.claude/registry/plugins.index.json` stale at **v6.0.0** with the old counts (16 commands / 33 skills / 16 agents / 10-tool MCP). The install dialog still shows those old numbers because it reads from `marketplace.json`, not from `plugin.json`.

This PR is the single missing commit: align the marketplace and registry metadata to v7.9.0 so the install dialog matches the actual plugin contents.

## Changes

- `.claude-plugin/marketplace.json` — `claude-code-expert` entry bumped to v7.9.0; description refreshed with correct counts (22 commands / 56 skills / 26 agents / 9 hooks / 19-tool MCP server + 2 resources); added tags for the new capabilities (orchestration-blackboard, prompt-budget, agent-telemetry, specialist-routing, verify-between-waves)
- `.claude/registry/plugins.index.json` — `installed` record + `plugins` record both bumped to 7.9.0; description refreshed; `installedAt` and top-level `lastUpdated` and `stats.lastUpdated` refreshed to 2026-04-17

## Verification

After merge, all four version-of-record sources agree at 7.9.0:
- `plugins/claude-code-expert/.claude-plugin/plugin.json` (already on main via #132)
- `plugins/claude-code-expert/CHANGELOG.md` (already on main via #132)
- `.claude-plugin/marketplace.json` (this PR)
- `.claude/registry/plugins.index.json` (this PR)

The install dialog should refresh to show "v7.9.0 · 22 commands, 56 skills, 26 agents · 19-tool MCP server" on next local index rebuild.

---

<div align="center">

[![Markus Ahling](https://img.shields.io/badge/%E2%9A%A1-markus41-000000?style=for-the-badge&labelColor=FF4500&color=1a1a2e)](https://github.com/markus41) [![Marketplace](https://img.shields.io/badge/plugin-marketplace-blueviolet?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/markus41/claude) [![Status](https://img.shields.io/badge/status-shipped%20%F0%9F%9A%80-brightgreen?style=for-the-badge)](https://github.com/markus41/claude)

*architecture by humans, velocity by machines*

</div>