### PR TITLE
fix(claude-code-expert): restore schema-required context fields (v8 followup)

### DIFF
--- a/plugins/claude-code-expert/.claude-plugin/plugin.json
+++ b/plugins/claude-code-expert/.claude-plugin/plugin.json
@@ -54,9 +54,27 @@
     ],
     "requires": []
   },
+  "contextEntry": "CONTEXT_SUMMARY.md",
   "context": {
+    "entry": "CONTEXT_SUMMARY.md",
     "title": "Claude Code Expert v8",
     "summary": "Modern second brain for Claude Code: deploys the 5-layer stack (CLAUDE.md + skills + hooks + agents + memory), bridges engram (tier-1 working memory) with the user's Obsidian vault (tier-2 durable knowledge) via a memory-consolidator agent, and ships 14 behavior-triggering skills + 11 commands + 18 agents + a 22-tool MCP reference server. Route tasks via /cc-help.",
+    "tags": [
+      "claude-code",
+      "second-brain",
+      "engram",
+      "obsidian",
+      "memory",
+      "mcp",
+      "skills",
+      "agents",
+      "commands",
+      "orchestration",
+      "autonomy"
+    ],
+    "bootstrapFiles": [
+      "CONTEXT_SUMMARY.md"
+    ],
     "maxTokens": 500,
     "excludeGlobs": [
       "**/node_modules/**",

--- a/plugins/claude-code-expert/CONTEXT_SUMMARY.md
+++ b/plugins/claude-code-expert/CONTEXT_SUMMARY.md
@@ -1,0 +1,39 @@
+# Claude Code Expert v8 Context Summary
+
+Modern Claude Code second brain. Deploys the 5-layer stack (CLAUDE.md + skills + hooks + agents + memory) and bridges engram (tier-1 working memory) with the user's Obsidian vault (tier-2 durable knowledge) via a `memory-consolidator` agent. Ships 14 behavior-triggering skills, 11 single-intent commands, 18 role-scoped agents, and a 22-tool MCP reference server with 66 lazy-loaded KB artifacts (hooks, topologies, workflows, channels, LSP, patterns, autonomy) each ≤ 2 KB.
+
+## What this plugin is best at
+
+- Deploying and auditing the 5-layer Claude Code stack in any repo (`/cc-setup`, `/cc-sync`).
+- Three-tier memory: engram + Obsidian + plugin rules. Consolidator (Opus, read-only on engram) promotes reinforced patterns to Obsidian with `auto_generated: true`, respecting the user-protection invariant.
+- Deep evidence-driven analysis on hard problems (`/cc-intel`, `principal-engineer-strategist`).
+- Multi-agent orchestration by pattern (`/cc-orchestrate`, `pattern-router`), council review (`/cc-council`), autonomy profiles with gate agents (`/cc-autonomy`).
+- Progressive disclosure: MCP KB tools return single artifacts on demand — never load the full reference corpus.
+
+## Core assets
+
+- `CLAUDE.md`: routing OS (≤120 lines).
+- `commands/cc-help.md`: routing table for all `/cc-*` intents.
+- `commands/cc-memory.md`: engram wrapper — search, consolidate, export, edit-always, status.
+- `skills/cc-second-brain/SKILL.md`: three-tier routing + CC `topic_key` taxonomy.
+- `agents/memory-consolidator.md`: Opus, read-only engram; writes Obsidian + `memory/rules/cc-patterns.md`.
+- `mcp-server/src/index.js`: 22 tools (15 `cc_docs_*` + 7 `cc_kb_*`), every artifact ≤ 2 KB.
+- `memory/conventions.md`: three-tier write discipline.
+
+## When to open deeper docs
+
+| Signal | Open docs | Why |
+|---|---|---|
+| Setting up or auditing a repo | `commands/cc-setup.md` | 5-layer deploy + `--audit` scoring. |
+| Updating an existing CC setup | `commands/cc-sync.md` | Idempotent update with `--fix-drift`. |
+| Deep reasoning on hard problem | `skills/deep-code-intelligence/SKILL.md` | Evidence-driven workflow, hypothesis trees. |
+| Multi-agent review | `commands/cc-council.md` | Parallel specialists with blackboard coordinator. |
+| Memory operations | `skills/cc-second-brain/SKILL.md` | Three-tier discipline, `topic_key` taxonomy. |
+| Autonomous mode | `skills/autonomy/SKILL.md` | 4 profiles + planner/verifier/reviewer gates. |
+| Memory architecture design | `docs/MEMORY_ARCHITECTURE.md` | Engram+Obsidian+rules; consolidator flow; FAQ. |
+| v7 → v8 migration | `docs/MIGRATION.md` | Rename table, deprecations, rollback plan. |
+| MCP tool reference | `docs/MCP_TOOLS.md` | 22-tool contract + 66-artifact KB inventory. |
+
+## Non-goals
+
+Not replacing engram; not building a parallel memory MCP; not modifying user-level global CLAUDE.md. The plugin sits on top of engram and the user's Obsidian vault without duplicating either.


### PR DESCRIPTION
## Why

PR #133 (v8.0.0 redesign) merged with failing CI: `plugin-preflight` and `check-plugin-context` both reject the new `claude-code-expert` manifest. Main is currently broken per the repo's plugin schema validator. Any subsequent PR touching `plugins/**` will surface the same failures.

## What CI said

**plugin-preflight** (`scripts/validate-plugin-schema.mjs`):
```
claude-code-expert: invalid .claude-plugin/plugin.json -> / should have required property 'entry';
  / should have required property 'tags'; / should have required property 'bootstrapFiles'
claude-code-expert: missing required CONTEXT_SUMMARY.md
```

**check-plugin-context** (`scripts/check-plugin-context.mjs`):
```
claude-code-expert: plugin manifest is missing required "contextEntry" field
```

## What this PR changes

- **`.claude-plugin/plugin.json`** — restores `contextEntry` (top-level), `context.entry`, `context.tags`, `context.bootstrapFiles`. All other v8 content preserved (version 8.0.0, keywords, capabilities, lazyLoadSections for the new 5-layer stack).
- **`CONTEXT_SUMMARY.md`** — new file. v8-appropriate content focused on the three-tier memory architecture (engram + Obsidian + plugin rules) and the 22-tool MCP reference server, not a v7-style changelog dump. Passes all context validator rules:
  - ≤ 750 estimated tokens (449 words)
  - Includes "when to open deeper docs" phrase
  - Decision-table header: `| Signal | Open docs | Why |`

## Verification

- `node scripts/check-plugin-context.mjs` → `claude-code-expert: PASS`
- JSON validates: `node -e "JSON.parse(...)"` clean
- No changes to skills/commands/agents/MCP — pure manifest + context-entry fix

## Rollback

Single-commit PR. `git revert` restores the pre-fix state on main.