### PR TITLE
Add guardrails layer: anchor, scope, budget, and drift detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check:plugin-indexes": "node scripts/generate-plugin-indexes.mjs --check",
     "profile:plugin-context": "node scripts/profile-plugin-context.mjs",
     "validate-archetype": "tsx scripts/validate-archetype.ts",
-    "test:pm-plugin": "node --test plugins/project-management-plugin/tests/pm-state.test.mjs plugins/project-management-plugin/tests/pm-mcp.test.mjs"
+    "test:pm-plugin": "node --test plugins/project-management-plugin/tests/pm-state.test.mjs plugins/project-management-plugin/tests/pm-mcp.test.mjs plugins/project-management-plugin/tests/pm-guardrails.test.mjs plugins/project-management-plugin/tests/pm-guardrails-mcp.test.mjs"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "generate:plugin-indexes": "node scripts/generate-plugin-indexes.mjs",
     "check:plugin-indexes": "node scripts/generate-plugin-indexes.mjs --check",
     "profile:plugin-context": "node scripts/profile-plugin-context.mjs",
-    "validate-archetype": "tsx scripts/validate-archetype.ts"
+    "validate-archetype": "tsx scripts/validate-archetype.ts",
+    "test:pm-plugin": "node --test plugins/project-management-plugin/tests/pm-state.test.mjs plugins/project-management-plugin/tests/pm-mcp.test.mjs"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check:plugin-indexes": "node scripts/generate-plugin-indexes.mjs --check",
     "profile:plugin-context": "node scripts/profile-plugin-context.mjs",
     "validate-archetype": "tsx scripts/validate-archetype.ts",
-    "test:pm-plugin": "node --test plugins/project-management-plugin/tests/pm-state.test.mjs plugins/project-management-plugin/tests/pm-mcp.test.mjs plugins/project-management-plugin/tests/pm-guardrails.test.mjs plugins/project-management-plugin/tests/pm-guardrails-mcp.test.mjs"
+    "test:pm-plugin": "node --test plugins/project-management-plugin/tests/pm-state.test.mjs plugins/project-management-plugin/tests/pm-mcp.test.mjs plugins/project-management-plugin/tests/pm-guardrails.test.mjs plugins/project-management-plugin/tests/pm-guardrails-mcp.test.mjs plugins/project-management-plugin/tests/pm-round3.test.mjs"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/plugins/project-management-plugin/.claude-plugin/marketplace.json
+++ b/plugins/project-management-plugin/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "project-management-plugin",
       "source": "../",
-      "description": "Universal project manager with interview-first init, micro-task decomposition, deep research, and 9 PM platform integrations.",
-      "version": "1.0.0",
+      "description": "Universal project manager with interview-first init, micro-task decomposition, deep research, transactional pm-mcp server, and 9 PM platform integrations.",
+      "version": "1.1.0",
       "category": "productivity",
       "keywords": [
         "project-management",

--- a/plugins/project-management-plugin/.claude-plugin/marketplace.json
+++ b/plugins/project-management-plugin/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "project-management-plugin",
       "source": "../",
-      "description": "Universal project manager with keep-Claude-on-task guardrails (focus anchor, scope lock, done-when contract, over-engineering detector, drift auditor) and a transactional pm-mcp server.",
-      "version": "1.2.0",
+      "description": "Universal project manager with keep-Claude-on-task guardrails (focus anchor, scope lock, done-when contract, over-engineering detector, drift auditor, turn budget, compaction-safe handoff) and a transactional pm-mcp server.",
+      "version": "1.3.0",
       "category": "productivity",
       "keywords": [
         "project-management",

--- a/plugins/project-management-plugin/.claude-plugin/marketplace.json
+++ b/plugins/project-management-plugin/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "project-management-plugin",
       "source": "../",
-      "description": "Universal project manager with interview-first init, micro-task decomposition, deep research, transactional pm-mcp server, and 9 PM platform integrations.",
-      "version": "1.1.0",
+      "description": "Universal project manager with keep-Claude-on-task guardrails (focus anchor, scope lock, done-when contract, over-engineering detector, drift auditor) and a transactional pm-mcp server.",
+      "version": "1.2.0",
       "category": "productivity",
       "keywords": [
         "project-management",

--- a/plugins/project-management-plugin/.claude-plugin/plugin.json
+++ b/plugins/project-management-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-management-plugin",
-  "version": "1.0.0",
-  "description": "Universal project manager: interview-first init, micro-task decomposition, deep research before execution, autonomous work loop, and 9 PM platform integrations.",
+  "version": "1.1.0",
+  "description": "Universal project manager: interview-first init, micro-task decomposition, deep research before execution, autonomous work loop, transactional state MCP server, and 9 PM platform integrations.",
   "author": {
     "name": "Markus Ahling",
     "email": "Markus@thelobbi.io"
@@ -14,12 +14,24 @@
     "research-first",
     "micro-tasks",
     "autonomous",
-    "pm-integration"
+    "pm-integration",
+    "mcp"
   ],
   "dependencies": [],
   "categories": [
     "project-management",
     "orchestration",
     "agents"
-  ]
+  ],
+  "mcpServers": {
+    "pm-mcp": {
+      "command": "node",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/mcp/pm-server.mjs"
+      ],
+      "env": {
+        "CLAUDE_PROJECT_DIR": "${CLAUDE_PROJECT_DIR}"
+      }
+    }
+  }
 }

--- a/plugins/project-management-plugin/.claude-plugin/plugin.json
+++ b/plugins/project-management-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-management-plugin",
-  "version": "1.1.0",
-  "description": "Universal project manager: interview-first init, micro-task decomposition, deep research before execution, autonomous work loop, transactional state MCP server, and 9 PM platform integrations.",
+  "version": "1.2.0",
+  "description": "Universal project manager with keep-Claude-on-task guardrails: focus anchor, scope lock, done-when contract, over-engineering detector, and drift auditor. Plus interview-first init, micro-task decomposition, deep research, transactional state MCP, and 9 PM platform integrations.",
   "author": {
     "name": "Markus Ahling",
     "email": "Markus@thelobbi.io"

--- a/plugins/project-management-plugin/.claude-plugin/plugin.json
+++ b/plugins/project-management-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-management-plugin",
-  "version": "1.2.0",
-  "description": "Universal project manager with keep-Claude-on-task guardrails: focus anchor, scope lock, done-when contract, over-engineering detector, and drift auditor. Plus interview-first init, micro-task decomposition, deep research, transactional state MCP, and 9 PM platform integrations.",
+  "version": "1.3.0",
+  "description": "Universal project manager with keep-Claude-on-task guardrails: focus anchor, scope lock, done-when contract, over-engineering detector, drift auditor, turn budget, user-prompt archive, and compaction-safe handoff. Plus interview-first init, micro-task decomposition, deep research, transactional state MCP, and 9 PM platform integrations.",
   "author": {
     "name": "Markus Ahling",
     "email": "Markus@thelobbi.io"

--- a/plugins/project-management-plugin/CLAUDE.md
+++ b/plugins/project-management-plugin/CLAUDE.md
@@ -31,19 +31,30 @@ deep research before every execution, autonomous work loop, and 9 PM platform in
 ## Core Invariants (never break these)
 1. **Interview first**: `/pm:init` always runs the full 8-phase interview — never skip
 2. **Research before execution**: tasks are never executed without a research brief
-3. **Atomic state writes**: always write tasks.json via temp-file → rename
+3. **Transactional state**: all writes to tasks.json/project.json go through the `pm-mcp` MCP server (`mcp__pm-mcp__pm_*` tools) which applies exclusive locking, schema validation, and atomic temp-file → rename. Never hand-edit tasks.json.
 4. **HITL on high-risk**: tasks with risk > 7 always pause for user
 5. **Micro-task cap**: no task over 30 min executes — must decompose first
 6. **Credentials from env**: PM platform tokens from CLAUDE_PLUGIN_OPTION_* only
 
+## pm-mcp Server (state access)
+All mutations go through the stdio MCP server registered in this plugin's manifest:
+- `pm_list_projects`, `pm_get_project`, `pm_get_tasks`, `pm_get_task` — reads
+- `pm_next_task`, `pm_unblocked_tasks` — scheduler queries
+- `pm_update_task_status`, `pm_complete_task`, `pm_block_task`, `pm_add_task` — mutations (validated + locked)
+- `pm_checkpoint`, `pm_get_research`, `pm_put_research`, `pm_validate` — ancillary
+
+The shared state library lives at `lib/pm-state.mjs` and is the only code allowed to write state files. Hook scripts and the MCP server both delegate to it.
+
 ## State Location
 All project state is in `.claude/projects/{project-id}/`:
-- `project.json` — project metadata
-- `tasks.json` — all tasks (authoritative source of truth)
+- `project.json` — project metadata (validated against `schemas/project.schema.json`)
+- `tasks.json` — all tasks (validated against `schemas/task.schema.json` per item)
 - `research/{task-id}.md` — cached research per task
 - `checkpoints/{timestamp}.json` — rolling window of last 10
 - `progress/log.md` — append-only session log
 - `artifacts/{task-id}/` — task output files
+- `.locks/{name}.lock` — exclusive O_EXCL lock files (stale > 30s are broken automatically)
+- `temp/.write-{uuid}` — temporary files used during atomic rename
 
 ## Agent Routing
 - **Opus**: project-orchestrator, project-interviewer, scope-architect, council-reviewer, adaptive replanning

--- a/plugins/project-management-plugin/CLAUDE.md
+++ b/plugins/project-management-plugin/CLAUDE.md
@@ -46,12 +46,15 @@ All mutations go through the stdio MCP server registered in this plugin's manife
 - `pm_update_task_status`, `pm_complete_task`, `pm_block_task`, `pm_add_task` — mutations (validated + locked)
 - `pm_checkpoint`, `pm_get_research`, `pm_put_research`, `pm_validate`, `pm_active_context` — ancillary
 
-**Keep-Claude-on-task guardrails (16 tools):**
+**Keep-Claude-on-task guardrails (23 tools):**
 - `pm_anchor_set` / `pm_anchor_get` / `pm_anchor_clear` — focus receipt ("DO X, DON'T Y") echoed on every turn
 - `pm_scope_set` / `pm_scope_add` / `pm_scope_remove` / `pm_scope_check` / `pm_scope_status` / `pm_scope_override` — file allowlist with drift ledger
 - `pm_done_when_set` / `pm_done_when_met` / `pm_done_when_status` — explicit completion criteria; Stop hook blocks `ok:true` while any is unmet
 - `pm_breadcrumb` / `pm_drift_report` — per-turn tool trail + classification
 - `pm_overengineering_scan` — scan a diff against the CLAUDE.md anti-pattern ruleset
+- `pm_budget_set` / `pm_budget_status` / `pm_budget_clear` — cap tool calls per task (warn 80% / over 120%)
+- `pm_user_prompt_record` / `pm_user_prompts_recent` — archive of every user prompt so Claude can be reminded what was actually asked
+- `pm_handoff_write` / `pm_handoff_read` — compaction-safe snapshot of anchor/scope/done-when/budget/prompts/breadcrumbs, restored on SessionStart
 
 The shared libraries live at `lib/pm-state.mjs` (project state) and `lib/pm-guardrails.mjs` (guardrails). Together they are the only code allowed to write state files. Hook scripts and the MCP server both delegate to them.
 

--- a/plugins/project-management-plugin/CLAUDE.md
+++ b/plugins/project-management-plugin/CLAUDE.md
@@ -36,14 +36,24 @@ deep research before every execution, autonomous work loop, and 9 PM platform in
 5. **Micro-task cap**: no task over 30 min executes — must decompose first
 6. **Credentials from env**: PM platform tokens from CLAUDE_PLUGIN_OPTION_* only
 
-## pm-mcp Server (state access)
+## pm-mcp Server (state access + guardrails)
+
 All mutations go through the stdio MCP server registered in this plugin's manifest:
+
+**Project state (14 tools):**
 - `pm_list_projects`, `pm_get_project`, `pm_get_tasks`, `pm_get_task` — reads
 - `pm_next_task`, `pm_unblocked_tasks` — scheduler queries
 - `pm_update_task_status`, `pm_complete_task`, `pm_block_task`, `pm_add_task` — mutations (validated + locked)
-- `pm_checkpoint`, `pm_get_research`, `pm_put_research`, `pm_validate` — ancillary
+- `pm_checkpoint`, `pm_get_research`, `pm_put_research`, `pm_validate`, `pm_active_context` — ancillary
 
-The shared state library lives at `lib/pm-state.mjs` and is the only code allowed to write state files. Hook scripts and the MCP server both delegate to it.
+**Keep-Claude-on-task guardrails (16 tools):**
+- `pm_anchor_set` / `pm_anchor_get` / `pm_anchor_clear` — focus receipt ("DO X, DON'T Y") echoed on every turn
+- `pm_scope_set` / `pm_scope_add` / `pm_scope_remove` / `pm_scope_check` / `pm_scope_status` / `pm_scope_override` — file allowlist with drift ledger
+- `pm_done_when_set` / `pm_done_when_met` / `pm_done_when_status` — explicit completion criteria; Stop hook blocks `ok:true` while any is unmet
+- `pm_breadcrumb` / `pm_drift_report` — per-turn tool trail + classification
+- `pm_overengineering_scan` — scan a diff against the CLAUDE.md anti-pattern ruleset
+
+The shared libraries live at `lib/pm-state.mjs` (project state) and `lib/pm-guardrails.mjs` (guardrails). Together they are the only code allowed to write state files. Hook scripts and the MCP server both delegate to them.
 
 ## State Location
 All project state is in `.claude/projects/{project-id}/`:

--- a/plugins/project-management-plugin/README.md
+++ b/plugins/project-management-plugin/README.md
@@ -34,6 +34,28 @@ repeat. Pauses automatically when it needs human input or encounters risk > 7.
 
 ---
 
+## Keep-Claude-on-Task Guardrails
+
+Beyond the PM loop, this plugin ships four commands + five hooks that keep
+Claude locked on the current task during long sessions. Works with or
+without a formal `/pm:init` project — ephemeral session state lives at
+`.claude/pm-session/` when no project is active.
+
+| Command | What it does |
+|---------|--------------|
+| `/pm:anchor` | Set/clear a two-line focus receipt; injected on every user turn |
+| `/pm:scope` | File/command allowlist; `PreToolUse` blocks out-of-scope writes |
+| `/pm:done-when` | Explicit completion criteria; `Stop` hook blocks until all have evidence |
+| `/pm:drift` | Replay the breadcrumb trail and classify each turn vs the anchor/scope/criteria |
+
+Hooks enforcing the above:
+
+- `anchor-inject.sh` (SessionStart + UserPromptSubmit) — injects the focus reminder.
+- `scope-guard.sh` (PreToolUse Write|Edit|MultiEdit) — blocks unlisted paths.
+- `overengineering-detector.sh` (PostToolUse Write|Edit|MultiEdit) — flags CLAUDE.md anti-patterns (multi-line comments, feature flags, backcompat shims, speculative validation, task-reference comments).
+- `breadcrumb-logger.sh` (PostToolUse \*) — appends every tool call to `breadcrumbs.jsonl`.
+- `done-gate.sh` (Stop) — refuses session end while any criterion lacks evidence.
+
 ## Command Reference
 
 | Command | Purpose |

--- a/plugins/project-management-plugin/README.md
+++ b/plugins/project-management-plugin/README.md
@@ -47,13 +47,19 @@ without a formal `/pm:init` project — ephemeral session state lives at
 | `/pm:scope` | File/command allowlist; `PreToolUse` blocks out-of-scope writes |
 | `/pm:done-when` | Explicit completion criteria; `Stop` hook blocks until all have evidence |
 | `/pm:drift` | Replay the breadcrumb trail and classify each turn vs the anchor/scope/criteria |
+| `/pm:budget` | Cap tool calls per task; `PostToolUse` warns at 80% and screams at 120% |
+| `/pm:handoff` | Force-write (or inspect) the compaction-safe task snapshot |
 
 Hooks enforcing the above:
 
 - `anchor-inject.sh` (SessionStart + UserPromptSubmit) — injects the focus reminder.
+- `handoff-read.sh` (SessionStart) — re-surfaces `handoff.md` after `/compact` or a new session.
+- `prompt-archive.sh` (UserPromptSubmit) — appends every user prompt verbatim.
 - `scope-guard.sh` (PreToolUse Write|Edit|MultiEdit) — blocks unlisted paths.
-- `overengineering-detector.sh` (PostToolUse Write|Edit|MultiEdit) — flags CLAUDE.md anti-patterns (multi-line comments, feature flags, backcompat shims, speculative validation, task-reference comments).
+- `overengineering-detector.sh` (PostToolUse Write|Edit|MultiEdit) — flags CLAUDE.md anti-patterns.
 - `breadcrumb-logger.sh` (PostToolUse \*) — appends every tool call to `breadcrumbs.jsonl`.
+- `budget-warn.sh` (PostToolUse \*) — surfaces turn-budget warnings at 80% / 120%.
+- `handoff-write.sh` (Stop) — snapshots anchor/scope/done-when/budget/breadcrumbs to `handoff.md`.
 - `done-gate.sh` (Stop) — refuses session end while any criterion lacks evidence.
 
 ## Command Reference

--- a/plugins/project-management-plugin/README.md
+++ b/plugins/project-management-plugin/README.md
@@ -139,12 +139,34 @@ never written to project state files or committed to the repository.
 │   └── {timestamp}.json  # Rolling window of last 10 state snapshots
 ├── progress/
 │   └── log.md            # Append-only session activity log
-└── artifacts/
-    └── {task-id}/        # Output files produced by task execution
+├── artifacts/
+│   └── {task-id}/        # Output files produced by task execution
+├── .locks/
+│   └── {name}.lock       # Exclusive O_EXCL locks (stale >30s are broken)
+└── temp/
+    └── .write-{uuid}     # Temporary files used during atomic rename
 ```
 
-State writes are always atomic: write to a temp file, then rename into place.
-This prevents corrupt state if Claude Code is interrupted mid-write.
+State writes are transactional: the shared library (`lib/pm-state.mjs`) takes
+an exclusive lock, validates against the JSON schemas, writes to a temp file,
+then atomically renames into place. The `pm-mcp` MCP server (registered in the
+plugin manifest) is the only supported way for agents to mutate tasks —
+never hand-edit `tasks.json`.
+
+## pm-mcp Server Tools
+
+The plugin ships a stdio MCP server that agents call via `mcp__pm-mcp__*`:
+
+| Tool | Purpose |
+|------|---------|
+| `pm_list_projects` | Enumerate every project with status + task counts |
+| `pm_get_project` / `pm_get_tasks` / `pm_get_task` | Read project + task state |
+| `pm_next_task` / `pm_unblocked_tasks` | Scheduler queries (priority × critical-path) |
+| `pm_update_task_status` | Validated status transitions |
+| `pm_add_task` / `pm_complete_task` / `pm_block_task` | Mutations |
+| `pm_checkpoint` | Force-write a state snapshot |
+| `pm_get_research` / `pm_put_research` | Manage research briefs |
+| `pm_validate` | Run schema validation on the project |
 
 ---
 
@@ -184,6 +206,18 @@ checkpointing, and reporting. This keeps costs proportional to task complexity.
 ## Requirements
 
 - Claude Code with the plugin system enabled
-- Node.js 18+ (used by hook scripts)
+- Node.js 20+ (used by hook scripts, shared lib, and pm-mcp server)
 - Internet access for deep research (Perplexity MCP or Context7 MCP)
 - Optional: PM platform API credentials for sync features
+
+## Development
+
+Run the plugin's unit + integration tests from the repo root:
+
+```
+pnpm test:pm-plugin
+```
+
+Tests live under `plugins/project-management-plugin/tests/` and cover the
+shared state library (atomic writes, O_EXCL locking, schema validation,
+scheduler scoring) plus the pm-mcp server (end-to-end JSON-RPC round-trips).

--- a/plugins/project-management-plugin/commands/pm-anchor.md
+++ b/plugins/project-management-plugin/commands/pm-anchor.md
@@ -1,0 +1,64 @@
+---
+description: Set or clear the focus anchor that keeps Claude on task across every turn
+---
+
+# /pm:anchor — Focus Receipt
+
+**Usage**: `/pm:anchor "{do ...}" ["{don't ...}"]`
+**Clear**: `/pm:anchor --clear`
+**Inspect**: `/pm:anchor --show`
+
+## Purpose
+
+Writes a two-line commitment ("DO X", "DON'T Y") to the active guardrail
+context. Every subsequent user turn and session start injects this
+commitment as a system reminder so Claude literally cannot forget what was
+agreed. Pairs with `/pm:scope`, `/pm:done-when`, and `/pm:drift`.
+
+Use this when you want Claude to stick to a narrow task over a long
+autonomous run. The anchor is *not* a substitute for `/pm:scope` (which
+enforces file allowlists) — it's the prose contract Claude reads on every
+turn.
+
+## Behavior
+
+1. **Set**: parse the two arguments as plain prose. Call
+   `mcp__pm-mcp__pm_anchor_set` with `{do, dont}`. Both strings are stored
+   in `anchor.json` and mirrored to `focus.md` for easy manual edits.
+2. **Clear**: call `mcp__pm-mcp__pm_anchor_clear`.
+3. **Show**: call `mcp__pm-mcp__pm_anchor_get` and print the current
+   contract.
+
+## Where it's stored
+
+- `.claude/projects/{id}/anchor.json` when an IN_PROGRESS project exists,
+  else `.claude/pm-session/anchor.json` (ephemeral, created on demand).
+- `focus.md` is written alongside `anchor.json` as the human-readable copy.
+
+## Enforcement
+
+- `SessionStart` hook (`anchor-inject.sh`) injects the anchor at the start
+  of a new session.
+- `UserPromptSubmit` hook (same script) echoes the anchor on every new user
+  message so Claude re-reads the contract before acting on a fresh prompt.
+
+## Examples
+
+```
+/pm:anchor "Implement refresh token rotation on /auth/refresh" "Don't touch the UI or add new deps"
+
+/pm:anchor --show
+  DO: Implement refresh token rotation on /auth/refresh
+  DON'T: Don't touch the UI or add new deps
+  (set 3 min ago)
+
+/pm:anchor --clear
+  Cleared focus anchor.
+```
+
+## When NOT to use
+
+- Tiny tasks that complete in one or two turns — the injection overhead
+  isn't worth the ceremony.
+- When a full `/pm:init` → `/pm:plan` project is the right container;
+  the anchor is for *sessions*, not *projects*.

--- a/plugins/project-management-plugin/commands/pm-budget.md
+++ b/plugins/project-management-plugin/commands/pm-budget.md
@@ -1,0 +1,64 @@
+---
+description: Cap the number of tool calls allowed for the current task; nudges Claude at 80% and 120%
+---
+
+# /pm:budget — Turn Budget
+
+**Usage**:
+- `/pm:budget set <N>` — cap the current task at N tool calls
+- `/pm:budget show` — print used / max / percent / status
+- `/pm:budget clear` — deactivate the cap
+
+## Purpose
+
+Keeps a long autonomous run from silently blowing through hundreds of
+tool calls. A `PostToolUse` hook (`budget-warn.sh`) reads the current
+status after every call and injects a notification when:
+
+- **80% consumed** — "turn budget approaching" soft warn.
+- **120% consumed** — "OVER turn budget" loud warn, asking Claude to stop,
+  summarize, and ask the user whether to raise the cap or close out.
+
+The hook never **blocks** tool calls — only notifies. Blocking is a
+deliberate human decision (via `/pm:budget clear` or raising the cap).
+
+## Behavior
+
+1. **Set**: call `mcp__pm-mcp__pm_budget_set` with `{max_turns}`. The
+   baseline is the current breadcrumb count — consumption is measured
+   from the moment the budget was set.
+2. **Show**: call `mcp__pm-mcp__pm_budget_status`. Returns
+   `{active, used, max_turns, pct, status}` where status is
+   `ok|warn|over`.
+3. **Clear**: call `mcp__pm-mcp__pm_budget_clear`. The budget record is
+   retained with `active:false` for audit purposes.
+
+## Storage
+
+`budget.json` in the active guardrail context (project dir or
+`.claude/pm-session/`). Consumption is derived from `breadcrumbs.jsonl`
+so the budget honors the same trail that `/pm:drift` reads.
+
+## Good default caps
+
+- Tight fix: 20
+- Feature slice: 40
+- Migration / refactor: 80
+- Green-field spike: 120
+
+Raise the cap if the task truly needs it — but only after asking "why"
+and logging an explicit reason in the anchor or an execution note.
+
+## Example
+
+```
+/pm:anchor "refresh-token rotation" "no UI"
+/pm:budget set 50
+
+# ...Claude works...
+# after ~40 tool calls the PostToolUse hook emits:
+#   "Turn budget approaching: 40/50 (80%). Consider wrapping up."
+
+/pm:budget show
+  active: yes, used: 43, max: 50, pct: 86%, status: warn
+```

--- a/plugins/project-management-plugin/commands/pm-done-when.md
+++ b/plugins/project-management-plugin/commands/pm-done-when.md
@@ -1,0 +1,79 @@
+---
+description: Declare the binary-testable criteria Claude must verify before the session may end
+---
+
+# /pm:done-when — Completion Contract
+
+**Usage**:
+- `/pm:done-when "criterion 1" "criterion 2" [...]` — declare criteria
+- `/pm:done-when --met <id> --evidence "<proof>"` — mark one criterion met
+- `/pm:done-when --show` — show the current contract + status
+- `/pm:done-when --drop <id>` — remove a criterion (user escape hatch)
+- `/pm:done-when --clear` — deactivate the contract
+
+## Purpose
+
+Records the list of completion criteria that MUST have recorded evidence
+before Claude may declare the session finished. A `Stop` hook
+(`done-gate.sh`) returns `{ok:false, reason:"..."}` while any criterion is
+unmet — naming the specific outstanding items.
+
+This turns the `completion_criteria` concept from `task.schema.json` into a
+session-wide gate that works with or without a full `/pm:init` project.
+
+## Good criteria
+
+Criteria must be specific and *verifiable* — a binary pass/fail with
+observable evidence. Good examples:
+
+- `pnpm test:pm-plugin exits 0`
+- `GET http://localhost:3000/refresh returns 200 with JSON {token:...}`
+- `src/auth/refresh.ts exports a function rotateRefreshToken`
+- `pnpm check:marketplace passes for all 27 plugins`
+
+Avoid vague criteria like "works correctly", "is done", "looks good" — the
+decomposer and the schema already reject these, and the Stop gate would
+too because you can't attach evidence to them.
+
+## Behavior
+
+1. **Declare**: call `mcp__pm-mcp__pm_done_when_set` with `{criteria}`. Each
+   criterion is assigned an id `c1`, `c2`, … so they can be referenced by
+   the hook and the `--met` flag.
+2. **Mark met**: run the verification (usually a `Bash` call that runs a
+   test or `curl`), then call `mcp__pm-mcp__pm_done_when_met` with
+   `{id, evidence}`. The evidence string must be non-trivial — the tool
+   rejects blank or 2-character inputs.
+3. **Show**: call `mcp__pm-mcp__pm_done_when_status`.
+4. **Drop**: (human escape hatch) edit the `done-when.json` directly to
+   remove a criterion, then re-show.
+
+## Storage
+
+`done-when.json` in the active guardrail context (project dir or
+`.claude/pm-session/`).
+
+## Enforcement
+
+- **Stop hook** (`done-gate.sh`) reads `done-when.json` and, if any
+  criterion has no `met_at`, returns a structured `{ok:false}` response
+  listing exactly which criteria are missing evidence.
+
+## Example
+
+```
+/pm:done-when "pnpm test:pm-plugin passes" "pm-mcp exposes pm_anchor_set" "README describes /pm:anchor"
+  Recorded 3 criteria.
+
+# Claude does the work.
+# Run tests → "# pass 19 / # fail 0"
+/pm:done-when --met c1 --evidence "pnpm test:pm-plugin -> # pass 19 # fail 0"
+
+# Sanity-check tool listing.
+/pm:done-when --met c2 --evidence "tools/list response contains pm_anchor_set"
+
+# Confirm the doc edit.
+/pm:done-when --met c3 --evidence "grep -c '/pm:anchor' README.md = 4"
+
+# Now the Stop hook will let the session end cleanly.
+```

--- a/plugins/project-management-plugin/commands/pm-drift.md
+++ b/plugins/project-management-plugin/commands/pm-drift.md
@@ -1,0 +1,70 @@
+---
+description: Audit the breadcrumb trail for scope drift, over-engineering, and criterion advancement
+---
+
+# /pm:drift — Session Drift Auditor
+
+**Usage**: `/pm:drift [--since <iso-timestamp>] [--verbose]`
+
+## Purpose
+
+Replays the breadcrumb trail captured by the `breadcrumb-logger.sh` hook
+and classifies each tool call against the active anchor, scope, and
+done-when contract. Use it:
+
+- **Mid-task** to self-audit before continuing ("am I still on-task?").
+- **After an autonomous run** as a cheap post-mortem.
+- **During PR review** to understand what Claude actually touched vs what
+  was asked.
+
+## Behavior
+
+Call `mcp__pm-mcp__pm_drift_report` with `{since?}`. The tool returns:
+
+- `context` — `{kind, id, dir}` showing whether the active context is a
+  project or the ephemeral session.
+- `anchor` — the current focus anchor (null if unset).
+- `scope_active`, `done_criteria_total`, `done_criteria_met`.
+- `totals` — `{turns, drift_turns, advancing_turns, drift_ratio}`.
+- `entries` — per-turn list with `drift: [reasons]` and `advances: bool`.
+
+Render the result as a short table by default:
+
+```
+Task context: project foo-bar (52 turns)
+Anchor: DO refresh-token; DON'T touch UI
+Scope: active (3 patterns)
+Done-when: 2/3 criteria met
+
+Drift analysis:
+  turn  1-8   advanced c1 (token generation)
+  turn  9-12  advanced c2 (endpoint wiring)
+  turn 13     ⚠ out-of-scope: src/ui/Login.tsx (override logged)
+  turn 14-17  ⚠ overengineering: added 6-line docstring in refresh.ts
+  turn 18-22  advanced c3 (tests)
+
+Drift ratio: 19% (10 of 52 turns did not advance a criterion)
+```
+
+With `--verbose`: print every breadcrumb individually (tool + target).
+
+## Drift reasons
+
+- `out-of-scope` — a PreToolUse block fired (or should have).
+- `overengineering: <tags>` — PostToolUse detector flagged a pattern.
+- `no-criterion` — call did not plausibly advance any done-when criterion
+  (heuristic; may be a false positive for exploratory Grep/Read calls).
+
+## When to escalate
+
+A drift ratio > 30% usually means one of:
+
+1. The anchor is too narrow (Claude genuinely needs to touch adjacent
+   files). Widen it with `/pm:anchor` or `/pm:scope add`.
+2. The task was under-decomposed. Run `/pm:plan --force-redecompose`.
+3. Claude is actually drifting. Interrupt, `/pm:anchor --clear`, and redo.
+
+## Privacy note
+
+Breadcrumbs log *tool name* and *target path / command excerpt* only. No
+file contents, no secrets.

--- a/plugins/project-management-plugin/commands/pm-handoff.md
+++ b/plugins/project-management-plugin/commands/pm-handoff.md
@@ -1,0 +1,84 @@
+---
+description: Snapshot active task state for post-/compact resume, or display the current handoff
+---
+
+# /pm:handoff — Compaction-Safe Task Handoff
+
+**Usage**:
+- `/pm:handoff write` — force-snapshot right now
+- `/pm:handoff show` — print the current handoff.md
+
+## Purpose
+
+When Claude Code compacts the context window or the user resumes a
+session hours later, the in-memory understanding of the active task
+evaporates. This command (and the `Stop` / `SessionStart` hooks that
+call it automatically) keeps a structured markdown snapshot of what
+was being worked on so resuming never means "re-plan from scratch."
+
+## What the handoff contains
+
+`handoff.md` includes, in order:
+
+1. The most recent user prompt verbatim.
+2. The active focus anchor (`DO` / `DON'T`).
+3. The scope allowlist + any logged overrides.
+4. The done-when contract with each criterion's met/unmet status and
+   evidence line.
+5. Budget status (used / max / percent).
+6. Up to 20 recently-touched files.
+7. Up to 15 recent breadcrumbs (tool + target).
+8. A short "how to resume" checklist.
+
+## Automatic writes + reads
+
+- **Stop hook** (`handoff-write.sh`) writes a fresh handoff every time
+  the session ends. This covers both natural stops and the window just
+  before `/compact`.
+- **SessionStart hook** (`handoff-read.sh`) surfaces the handoff as a
+  notification so the resumed session sees it before doing anything
+  else.
+
+Manual invocation is rarely needed — but the command exists for the
+case where you want to force a snapshot mid-run or inspect the current
+handoff directly.
+
+## Behavior
+
+1. **write**: call `mcp__pm-mcp__pm_handoff_write`. Returns the file
+   path that was written.
+2. **show**: call `mcp__pm-mcp__pm_handoff_read`. Prints the markdown
+   body as-is.
+
+## Storage
+
+`handoff.md` in the active guardrail context (project dir or
+`.claude/pm-session/`). Overwritten on every Stop — not versioned; if
+you want history use checkpoints or git.
+
+## Example
+
+```
+/pm:anchor "refresh-token rotation" "no UI"
+/pm:done-when "pnpm test passes" "endpoint returns 200"
+# ...work...
+# Session ends (Stop hook fires handoff-write.sh)
+
+# New session or /compact
+# SessionStart hook surfaces:
+#
+#   TASK HANDOFF FROM PREVIOUS SESSION:
+#   ## Last user ask
+#   > ship refresh-token rotation
+#
+#   ## Focus anchor
+#   - DO: refresh-token rotation
+#   - DON'T: no UI
+#
+#   ## Done-when progress
+#   1/2 criteria met.
+#   - [x] c1 — pnpm test passes → `pnpm test → exit 0`
+#   - [ ] c2 — endpoint returns 200
+#
+#   ...
+```

--- a/plugins/project-management-plugin/commands/pm-scope.md
+++ b/plugins/project-management-plugin/commands/pm-scope.md
@@ -1,0 +1,74 @@
+---
+description: Manage the file/command allowlist that blocks out-of-scope edits during the active task
+---
+
+# /pm:scope — Scope Lock with Drift Ledger
+
+**Usage**:
+- `/pm:scope add <pattern> [<pattern> ...]` — append glob patterns to the allowlist
+- `/pm:scope remove <pattern> [...]` — drop patterns
+- `/pm:scope set <pattern> [...]` — replace the allowlist
+- `/pm:scope show` — print the current allowlist and drift ledger
+- `/pm:scope clear` — deactivate scope enforcement
+- `/pm:scope override <path> --because "<reason>"` — record a justified one-off
+
+## Purpose
+
+Declares which paths Claude is allowed to edit. A `PreToolUse` hook
+(`scope-guard.sh`) blocks `Write`, `Edit`, and `MultiEdit` calls whose
+target file falls outside the allowlist, forcing Claude to either revise
+its approach or explicitly expand scope — leaving a paper trail.
+
+This implements the `.claude/rules/review.md` stance that "only files
+relevant to the PR scope" should be modified, at tool-call time.
+
+## Behavior
+
+1. **add**: call `mcp__pm-mcp__pm_scope_add` with `{patterns}`.
+2. **remove**: call `mcp__pm-mcp__pm_scope_remove`.
+3. **set**: call `mcp__pm-mcp__pm_scope_set`.
+4. **show**: call `mcp__pm-mcp__pm_scope_status`.
+5. **clear**: call `mcp__pm-mcp__pm_scope_set` with `patterns: []`.
+6. **override**: call `mcp__pm-mcp__pm_scope_override` with `{path, reason}` —
+   appends to the drift ledger but does not permanently widen scope. Use
+   when Claude genuinely needs a one-off touch outside its current lane.
+
+## Glob syntax
+
+Minimal glob: `*` matches within a single path segment, `**` matches any
+number of segments. Patterns are relative to `CLAUDE_PROJECT_DIR` (or
+`cwd`). Examples:
+
+- `src/auth/**` — any file under src/auth at any depth
+- `tests/*.test.mjs` — test files directly under tests/
+- `plugins/project-management-plugin/**` — everything in this plugin
+
+## Storage
+
+`scope.json` in the active guardrail context (project dir or
+`.claude/pm-session/`). Overrides live in the same file under `overrides`.
+
+## Enforcement
+
+- **PreToolUse(Write|Edit|MultiEdit)** blocks out-of-scope writes with a
+  structured refusal that names the allowlist and the two escape hatches
+  (override with reason, or expand with `/pm:scope add`).
+- Read-only tools (Read, Grep, Glob) are **never** blocked — scope locks
+  writes only, never exploration.
+
+## Example session
+
+```
+/pm:scope add src/auth/** tests/auth/**
+  Scope active. Allowlist:
+    - src/auth/**
+    - tests/auth/**
+
+/pm:scope show
+  Active. 2 patterns, 0 overrides.
+
+# Claude tries to edit src/ui/Login.tsx — hook blocks.
+
+/pm:scope override src/ui/Login.tsx --because "auth endpoint requires new login form button"
+  Override logged. Proceed with the single file.
+```

--- a/plugins/project-management-plugin/hooks/hooks.json
+++ b/plugins/project-management-plugin/hooks/hooks.json
@@ -6,27 +6,54 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-resume.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/anchor-inject.sh"
           }
         ]
       }
     ],
-    "Stop": [
+    "UserPromptSubmit": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/auto-checkpoint.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/anchor-inject.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/scope-guard.sh"
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task-completion-capture.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/overengineering-detector.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/breadcrumb-logger.sh"
           }
         ]
       }
@@ -37,6 +64,20 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/risk-alert.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/auto-checkpoint.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/done-gate.sh"
           }
         ]
       }

--- a/plugins/project-management-plugin/hooks/hooks.json
+++ b/plugins/project-management-plugin/hooks/hooks.json
@@ -10,6 +10,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/anchor-inject.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/handoff-read.sh"
           }
         ]
       }
@@ -20,6 +24,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/anchor-inject.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt-archive.sh"
           }
         ]
       }
@@ -54,6 +62,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/breadcrumb-logger.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/budget-warn.sh"
           }
         ]
       }
@@ -74,6 +86,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/auto-checkpoint.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/handoff-write.sh"
           },
           {
             "type": "command",

--- a/plugins/project-management-plugin/hooks/scripts/anchor-inject.sh
+++ b/plugins/project-management-plugin/hooks/scripts/anchor-inject.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# UserPromptSubmit + SessionStart hook — surface the active focus anchor
+# to Claude at the top of every new turn and at session start so the
+# "DO X / DON'T Y" contract cannot be silently forgotten.
+set -euo pipefail
+
+cat > /dev/null
+
+CLI="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-guardrails-cli.mjs"
+[ -f "$CLI" ] || { echo "{}"; exit 0; }
+
+OUT="$(node "$CLI" anchor-reminder 2>/dev/null || echo '{}')"
+# Parse the optional "reminder" field from the CLI output and build the
+# hook JSON response. Silent when no anchor is active.
+printf '%s' "$OUT" | node -e "
+let d='';
+process.stdin.on('data',c=>d+=c);
+process.stdin.on('end',()=>{
+  try {
+    const p = JSON.parse(d);
+    if (!p.reminder) { process.stdout.write('{}'); return; }
+    const msg = 'FOCUS ANCHOR (set by /pm:anchor):\n' + p.reminder +
+      '\nIf the next step violates this anchor, pause and ask before proceeding.';
+    process.stdout.write(JSON.stringify({ notification: msg }));
+  } catch { process.stdout.write('{}'); }
+});
+"

--- a/plugins/project-management-plugin/hooks/scripts/auto-checkpoint.sh
+++ b/plugins/project-management-plugin/hooks/scripts/auto-checkpoint.sh
@@ -1,30 +1,18 @@
 #!/usr/bin/env bash
+# Stop hook — write a checkpoint for every IN_PROGRESS project so that the
+# next session can resume cleanly. All logic lives in the shared library to
+# keep this script small and testable.
 set -euo pipefail
 
-# Triggered on Stop event — save checkpoint for any IN_PROGRESS projects
-INPUT=$(cat)
-PROJECTS_DIR="${CLAUDE_PROJECT_DIR:-$HOME}/.claude/projects"
+cat > /dev/null
 
-[ -d "$PROJECTS_DIR" ] || exit 0
+LIB="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-state.mjs"
+if [ ! -f "$LIB" ]; then
+  echo "{}"; exit 0
+fi
 
-for meta_file in "$PROJECTS_DIR"/*/meta.json; do
-  [ -f "$meta_file" ] || continue
-  STATUS=$(node -e "try{const d=require('$meta_file');process.stdout.write(d.status||'')}catch(e){}" 2>/dev/null || true)
-  if [ "$STATUS" = "IN_PROGRESS" ]; then
-    PROJECT_DIR=$(dirname "$meta_file")
-    CHECKPOINTS_DIR="$PROJECT_DIR/checkpoints"
-    mkdir -p "$CHECKPOINTS_DIR"
-    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    CHECKPOINT_FILE="$CHECKPOINTS_DIR/${TIMESTAMP}.json"
-    # Write minimal checkpoint: timestamp + project metadata snapshot
-    node -e "
-      const meta = require('$meta_file');
-      const tasks = (() => { try { return require('$PROJECT_DIR/tasks.json'); } catch(e) { return []; } })();
-      const statuses = tasks.map(t => ({id: t.id, status: t.status, blocked_reason: t.blocked_reason || null}));
-      const cp = { timestamp: '$TIMESTAMP', meta_snapshot: meta, task_statuses: statuses, resume_from: 'Phase 1' };
-      require('fs').writeFileSync('$CHECKPOINT_FILE', JSON.stringify(cp, null, 2));
-    " 2>/dev/null || true
-  fi
-done
+# The library prints the list of checkpoints it wrote; we don't need to parse
+# it here — we just want the side effect and a quiet hook response.
+node "$LIB" checkpoint > /dev/null 2>&1 || true
 
 echo "{}"

--- a/plugins/project-management-plugin/hooks/scripts/breadcrumb-logger.sh
+++ b/plugins/project-management-plugin/hooks/scripts/breadcrumb-logger.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# PostToolUse(*) hook — append every tool invocation to the breadcrumb
+# trail for later drift auditing via /pm:drift.
+set -euo pipefail
+
+INPUT="$(cat)"
+
+CLI="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-guardrails-cli.mjs"
+[ -f "$CLI" ] || { echo "{}"; exit 0; }
+
+READ="$(printf '%s' "$INPUT" | node -e "
+let d='';
+process.stdin.on('data',c=>d+=c);
+process.stdin.on('end',()=>{
+  try {
+    const p = JSON.parse(d);
+    const tool = p.tool_name || 'unknown';
+    const tgt = (p.tool_input||{}).file_path
+      || (p.tool_input||{}).path
+      || (p.tool_input||{}).command
+      || (p.tool_input||{}).pattern
+      || '';
+    process.stdout.write(JSON.stringify({ tool, target: String(tgt).slice(0, 300) }));
+  } catch { process.stdout.write('{}'); }
+});
+" 2>/dev/null || echo '{}')"
+
+TOOL="$(printf '%s' "$READ" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{process.stdout.write(JSON.parse(d).tool||'')}catch{}})")"
+TARGET="$(printf '%s' "$READ" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{process.stdout.write(JSON.parse(d).target||'')}catch{}})")"
+
+[ -z "$TOOL" ] && echo "{}" && exit 0
+
+node "$CLI" breadcrumb "$TOOL" "$TARGET" > /dev/null 2>&1 || true
+
+echo "{}"

--- a/plugins/project-management-plugin/hooks/scripts/budget-warn.sh
+++ b/plugins/project-management-plugin/hooks/scripts/budget-warn.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PostToolUse(*) hook — check the active turn budget and surface a
+# warning when 80% consumed, a stronger warning when over. Never blocks
+# the tool call itself; only injects a notification so Claude can self-
+# correct. Explicit blocking is the user's call via /pm:budget clear or
+# raising the cap.
+set -euo pipefail
+
+cat > /dev/null
+
+CLI="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-guardrails-cli.mjs"
+[ -f "$CLI" ] || { echo "{}"; exit 0; }
+
+STATUS="$(node "$CLI" budget-status 2>/dev/null || echo '{}')"
+
+printf '%s' "$STATUS" | node -e "
+let d='';
+process.stdin.on('data',c=>d+=c);
+process.stdin.on('end',()=>{
+  try {
+    const p = JSON.parse(d);
+    if (!p.active) { process.stdout.write('{}'); return; }
+    if (p.status === 'ok') { process.stdout.write('{}'); return; }
+    const pct = Math.round((p.pct || 0) * 100);
+    let msg;
+    if (p.status === 'over') {
+      msg = 'OVER turn budget: ' + p.used + '/' + p.max_turns + ' turns used (' + pct +
+        '%). You have blown past the cap. Stop, summarize progress, and ask the user whether ' +
+        'to raise the cap with /pm:budget set <N> or call it and close out.';
+    } else {
+      msg = 'Turn budget approaching: ' + p.used + '/' + p.max_turns + ' (' + pct +
+        '%). Consider wrapping up the current task or raising the cap.';
+    }
+    process.stdout.write(JSON.stringify({ notification: msg }));
+  } catch { process.stdout.write('{}'); }
+});
+"

--- a/plugins/project-management-plugin/hooks/scripts/done-gate.sh
+++ b/plugins/project-management-plugin/hooks/scripts/done-gate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Stop hook — refuse to end the session while any /pm:done-when criterion
+# lacks recorded evidence. The hook's block reason names the specific
+# criteria so Claude knows exactly what is outstanding.
+set -euo pipefail
+
+cat > /dev/null
+
+CLI="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-guardrails-cli.mjs"
+[ -f "$CLI" ] || { echo "{}"; exit 0; }
+
+STATUS="$(node "$CLI" done-status 2>/dev/null || echo '{}')"
+
+printf '%s' "$STATUS" | node -e "
+let d='';
+process.stdin.on('data',c=>d+=c);
+process.stdin.on('end',()=>{
+  try {
+    const p = JSON.parse(d);
+    if (!p.active) { process.stdout.write('{}'); return; }
+    if (!p.unmet || p.unmet.length === 0) {
+      process.stdout.write(JSON.stringify({ notification: 'All done-when criteria (' + p.total + ') have evidence. Session may end.' }));
+      return;
+    }
+    const lines = p.unmet.map(c => '  - ' + c.id + ': ' + c.text).join('\n');
+    const reason = 'Cannot end session — ' + p.unmet.length + ' of ' + p.total +
+      ' done-when criteria have no evidence:\n' + lines +
+      '\n\nFor each, run the verification and call mcp__pm-mcp__pm_done_when_met ' +
+      \"with {id, evidence: 'exact proof line'}. If a criterion genuinely cannot be met, \" +
+      'explain why and ask the user to relax it with /pm:done-when --drop <id>.';
+    process.stdout.write(JSON.stringify({ ok: false, reason, decision: 'block' }));
+  } catch { process.stdout.write('{}'); }
+});
+"

--- a/plugins/project-management-plugin/hooks/scripts/handoff-read.sh
+++ b/plugins/project-management-plugin/hooks/scripts/handoff-read.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SessionStart hook — if a recent handoff.md exists, surface it as a
+# notification so the resumed session (especially after /compact) can
+# re-anchor on the task without re-reading the whole history.
+set -euo pipefail
+
+cat > /dev/null
+
+CLI="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-guardrails-cli.mjs"
+[ -f "$CLI" ] || { echo "{}"; exit 0; }
+
+OUT="$(node "$CLI" handoff-read 2>/dev/null || echo '{}')"
+
+printf '%s' "$OUT" | node -e "
+let d='';
+process.stdin.on('data',c=>d+=c);
+process.stdin.on('end',()=>{
+  try {
+    const p = JSON.parse(d);
+    if (!p.markdown) { process.stdout.write('{}'); return; }
+    // Truncate to keep the SessionStart notification bounded — handoff can
+    // be large for long tasks.
+    const md = p.markdown.length > 3500
+      ? p.markdown.slice(0, 3500) + '\n\n(handoff truncated — full content in handoff.md)'
+      : p.markdown;
+    const msg = 'TASK HANDOFF FROM PREVIOUS SESSION:\n' + md +
+      '\n\nDo not re-plan from scratch; resume where the last session left off.';
+    process.stdout.write(JSON.stringify({ notification: msg }));
+  } catch { process.stdout.write('{}'); }
+});
+"

--- a/plugins/project-management-plugin/hooks/scripts/handoff-write.sh
+++ b/plugins/project-management-plugin/hooks/scripts/handoff-write.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Stop hook — snapshot the active guardrail state to handoff.md so that a
+# post-/compact or resumed session can re-anchor. Side-effect only; does
+# not influence the Stop decision itself (that's done-gate.sh's job).
+set -euo pipefail
+
+cat > /dev/null
+
+CLI="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-guardrails-cli.mjs"
+[ -f "$CLI" ] || { echo "{}"; exit 0; }
+
+node "$CLI" handoff-write > /dev/null 2>&1 || true
+
+echo "{}"

--- a/plugins/project-management-plugin/hooks/scripts/overengineering-detector.sh
+++ b/plugins/project-management-plugin/hooks/scripts/overengineering-detector.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# PostToolUse(Write|Edit|MultiEdit) hook — scan the just-written file's
+# staged diff against the overengineering ruleset and surface any hits
+# so Claude can self-correct before the pattern compounds.
+set -euo pipefail
+
+INPUT="$(cat)"
+
+CLI="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-guardrails-cli.mjs"
+[ -f "$CLI" ] || { echo "{}"; exit 0; }
+
+FILE_PATH="$(printf '%s' "$INPUT" | node -e "
+let d='';
+process.stdin.on('data',c=>d+=c);
+process.stdin.on('end',()=>{
+  try {
+    const p = JSON.parse(d);
+    const fp = (p.tool_input||{}).file_path || (p.tool_input||{}).path || '';
+    process.stdout.write(fp);
+  } catch { process.stdout.write(''); }
+});
+" 2>/dev/null || true)"
+
+[ -z "$FILE_PATH" ] && echo "{}" && exit 0
+
+RESULT="$(node "$CLI" overeng "$FILE_PATH" 2>/dev/null || echo '{}')"
+
+printf '%s' "$RESULT" | node -e "
+let d='';
+process.stdin.on('data',c=>d+=c);
+process.stdin.on('end',()=>{
+  try {
+    const p = JSON.parse(d);
+    if (!p.hits || p.hits.length === 0) { process.stdout.write('{}'); return; }
+    const bullets = p.hits.map(h => '- ' + h.reason + '\n  rule: \"' + h.rule + '\"').join('\n');
+    const msg = 'Over-engineering detected in the last edit:\n' + bullets +
+      '\n\nConsider whether these additions are actually required by the task. ' +
+      'If not, revert them before continuing.';
+    process.stdout.write(JSON.stringify({ notification: msg }));
+  } catch { process.stdout.write('{}'); }
+});
+"

--- a/plugins/project-management-plugin/hooks/scripts/prompt-archive.sh
+++ b/plugins/project-management-plugin/hooks/scripts/prompt-archive.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook — archive the user's message to user-prompts.jsonl
+# so later hooks (done-gate, /pm:drift) can remind Claude what was asked.
+# Best-effort: never blocks the turn.
+set -euo pipefail
+
+INPUT="$(cat)"
+
+LIB_DIR="$(cd "$(dirname "$0")/../../lib" && pwd)"
+[ -f "$LIB_DIR/pm-guardrails.mjs" ] || { echo "{}"; exit 0; }
+
+# Single node invocation: parse the hook payload, extract the prompt
+# text, and call recordUserPrompt() directly from the guardrails module.
+printf '%s' "$INPUT" | node --input-type=module -e "
+import { recordUserPrompt } from 'file://$LIB_DIR/pm-guardrails.mjs';
+let d='';
+process.stdin.on('data', c => d += c);
+process.stdin.on('end', () => {
+  try {
+    const p = JSON.parse(d);
+    const t = p.prompt || p.user_message || (p.message && p.message.content) || '';
+    if (typeof t === 'string' && t.trim()) recordUserPrompt(t);
+  } catch {}
+});
+" > /dev/null 2>&1 || true
+
+echo "{}"

--- a/plugins/project-management-plugin/hooks/scripts/risk-alert.sh
+++ b/plugins/project-management-plugin/hooks/scripts/risk-alert.sh
@@ -1,35 +1,43 @@
 #!/usr/bin/env bash
+# PostToolUseFailure hook — log failures to a project-scoped risk journal
+# so that retrospective / risk-assessor can surface recurring failure modes.
 set -euo pipefail
 
-# Triggered on PostToolUseFailure — flag the failing tool for risk tracking
-INPUT=$(cat)
+INPUT="$(cat)"
 
-TOOL_NAME=$(echo "$INPUT" | node -e "
+PARSED="$(printf '%s' "$INPUT" | node -e "
   let d='';
-  process.stdin.on('data',c=>d+=c);
-  process.stdin.on('end',()=>{
-    try{
-      const p=JSON.parse(d);
-      process.stdout.write(p.tool_name||'unknown');
-    }catch(e){process.stdout.write('unknown');}
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const p = JSON.parse(d);
+      process.stdout.write(JSON.stringify({
+        tool: p.tool_name || 'unknown',
+        error: String(p.error || '').substring(0, 240)
+      }));
+    } catch { process.stdout.write('{}'); }
   });
-" 2>/dev/null || echo "unknown")
+" 2>/dev/null || echo '{}')"
 
-ERROR=$(echo "$INPUT" | node -e "
+PROJECTS_ROOT="${CLAUDE_PROJECT_DIR:-$HOME}/.claude/projects"
+mkdir -p "$PROJECTS_ROOT" 2>/dev/null || true
+JOURNAL="$PROJECTS_ROOT/.risk-journal.jsonl"
+
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+printf '%s' "$PARSED" | node -e "
   let d='';
-  process.stdin.on('data',c=>d+=c);
-  process.stdin.on('end',()=>{
-    try{
-      const p=JSON.parse(d);
-      const e=(p.error||'').substring(0,120);
-      process.stdout.write(e);
-    }catch(e){process.stdout.write('');}
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const parsed = JSON.parse(d);
+      const entry = { timestamp: '${TIMESTAMP}', tool: parsed.tool || 'unknown', error: parsed.error || '' };
+      process.stdout.write(JSON.stringify(entry));
+    } catch { process.stdout.write(''); }
   });
-" 2>/dev/null || echo "")
+" >> "$JOURNAL" 2>/dev/null || true
 
-# Log to risk journal
-RISK_LOG="${CLAUDE_PROJECT_DIR:-$HOME}/.claude/projects/.risk-journal.jsonl"
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-echo "{\"timestamp\":\"$TIMESTAMP\",\"tool\":\"$TOOL_NAME\",\"error\":\"$(echo $ERROR | sed 's/"/\\"/g')\"}" >> "$RISK_LOG" 2>/dev/null || true
+# Every line in JSONL must end with \n; add one if the node append did not.
+printf '\n' >> "$JOURNAL" 2>/dev/null || true
 
 echo "{}"

--- a/plugins/project-management-plugin/hooks/scripts/scope-guard.sh
+++ b/plugins/project-management-plugin/hooks/scripts/scope-guard.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# PreToolUse(Write|Edit|MultiEdit) hook — block edits to paths outside the
+# active /pm:scope allowlist, nudging Claude to justify or abort. Writes
+# within the allowlist pass silently. Non-Write tools are not checked.
+set -euo pipefail
+
+INPUT="$(cat)"
+
+CLI="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-guardrails-cli.mjs"
+[ -f "$CLI" ] || { echo '{"decision":"approve"}'; exit 0; }
+
+FILE_PATH="$(printf '%s' "$INPUT" | node -e "
+let d='';
+process.stdin.on('data',c=>d+=c);
+process.stdin.on('end',()=>{
+  try {
+    const p = JSON.parse(d);
+    const fp = (p.tool_input||{}).file_path || (p.tool_input||{}).path || '';
+    process.stdout.write(fp);
+  } catch { process.stdout.write(''); }
+});
+" 2>/dev/null || true)"
+
+# No file path means nothing to check — approve.
+if [ -z "$FILE_PATH" ]; then echo '{"decision":"approve"}'; exit 0; fi
+
+RESULT="$(node "$CLI" scope-check "$FILE_PATH" 2>/dev/null || echo '{}')"
+
+printf '%s' "$RESULT" | node -e "
+let d='';
+process.stdin.on('data',c=>d+=c);
+process.stdin.on('end',()=>{
+  try {
+    const p = JSON.parse(d);
+    if (!p.active || p.in_scope) { process.stdout.write(JSON.stringify({ decision: 'approve' })); return; }
+    const allow = (p.allowlist || []).join(', ');
+    const reason = 'Path is outside the active /pm:scope allowlist (' + allow + '). ' +
+      'If this edit is genuinely required for the current task, call mcp__pm-mcp__pm_scope_override ' +
+      'with a one-line reason (which will be logged to the drift ledger), or call mcp__pm-mcp__pm_scope_add ' +
+      'to expand scope. Otherwise, revise your approach to stay within scope.';
+    process.stdout.write(JSON.stringify({ decision: 'block', reason }));
+  } catch { process.stdout.write(JSON.stringify({ decision: 'approve' })); }
+});
+"

--- a/plugins/project-management-plugin/hooks/scripts/session-resume.sh
+++ b/plugins/project-management-plugin/hooks/scripts/session-resume.sh
@@ -1,29 +1,31 @@
 #!/usr/bin/env bash
+# SessionStart hook — if any project is IN_PROGRESS, nudge the user to resume.
+# Delegates all state reading to the shared pm-state library so that bash is
+# only responsible for hook-shaped stdin/stdout JSON.
 set -euo pipefail
 
-# Read hook context from stdin
-INPUT=$(cat)
-PROJECTS_DIR="${CLAUDE_PROJECT_DIR:-$HOME}/.claude/projects"
+# Drain stdin (hook context is unused here but some runners require read).
+cat > /dev/null
 
-# Scan for any IN_PROGRESS projects
-if [ ! -d "$PROJECTS_DIR" ]; then
+LIB="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-state.mjs"
+if [ ! -f "$LIB" ]; then
+  echo "{}"; exit 0
+fi
+
+ACTIVE="$(node "$LIB" active 2>/dev/null || echo '{}')"
+
+if [ "$ACTIVE" = "{}" ] || [ -z "$ACTIVE" ]; then
+  echo "{}"
   exit 0
 fi
 
-ACTIVE=""
-for meta_file in "$PROJECTS_DIR"/*/meta.json; do
-  [ -f "$meta_file" ] || continue
-  STATUS=$(node -e "try{const d=require('$meta_file');process.stdout.write(d.status||'')}catch(e){}" 2>/dev/null || true)
-  if [ "$STATUS" = "IN_PROGRESS" ]; then
-    NAME=$(node -e "try{const d=require('$meta_file');process.stdout.write(d.name||'')}catch(e){}" 2>/dev/null || true)
-    ID=$(node -e "try{const d=require('$meta_file');process.stdout.write(d.id||'')}catch(e){}" 2>/dev/null || true)
-    ACTIVE="$ID ($NAME)"
-    break
-  fi
-done
+ID="$(printf '%s' "$ACTIVE" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{process.stdout.write(JSON.parse(d).id||'')}catch{}})")"
+NAME="$(printf '%s' "$ACTIVE" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{process.stdout.write(JSON.parse(d).name||'')}catch{}})")"
 
-if [ -n "$ACTIVE" ]; then
-  echo "{\"notification\": \"Active project: $ACTIVE — run /pm:status $ACTIVE to resume\"}"
+if [ -n "$ID" ]; then
+  MSG="Active PM project: ${ID} (${NAME}). Run /pm:status ${ID} to resume."
+  # Build JSON safely via node to avoid quoting issues with names.
+  printf '%s' "$MSG" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{process.stdout.write(JSON.stringify({notification:d}))})"
 else
   echo "{}"
 fi

--- a/plugins/project-management-plugin/hooks/scripts/task-completion-capture.sh
+++ b/plugins/project-management-plugin/hooks/scripts/task-completion-capture.sh
@@ -1,39 +1,35 @@
 #!/usr/bin/env bash
+# PostToolUse(Write|Edit) hook — if a write lands inside a project's artifacts/
+# directory and the path carries a T-XXX id, surface a notification so Claude
+# can consider marking the task complete.
 set -euo pipefail
 
-# Triggered on Write|Edit PostToolUse — check if the written file matches an artifact
-# for an IN_PROGRESS task; if so, notify Claude to consider checking it off
-INPUT=$(cat)
+INPUT="$(cat)"
 
-# Extract tool input file path from hook context
-FILE_PATH=$(echo "$INPUT" | node -e "
+LIB="$(cd "$(dirname "$0")/../../lib" && pwd)/pm-state.mjs"
+if [ ! -f "$LIB" ]; then
+  echo "{}"; exit 0
+fi
+
+FILE_PATH="$(printf '%s' "$INPUT" | node -e "
   let d='';
-  process.stdin.on('data',c=>d+=c);
-  process.stdin.on('end',()=>{
-    try{
-      const p=JSON.parse(d);
-      const fp=(p.tool_input||{}).file_path||(p.tool_input||{}).path||'';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const p = JSON.parse(d);
+      const fp = (p.tool_input || {}).file_path || (p.tool_input || {}).path || '';
       process.stdout.write(fp);
-    }catch(e){process.stdout.write('');}
+    } catch { process.stdout.write(''); }
   });
-" 2>/dev/null || true)
+" 2>/dev/null || true)"
 
 [ -z "$FILE_PATH" ] && echo "{}" && exit 0
 
-# Check if path is under any project's artifacts directory
-PROJECTS_DIR="${CLAUDE_PROJECT_DIR:-$HOME}/.claude/projects"
-[ -d "$PROJECTS_DIR" ] || { echo "{}"; exit 0; }
+TASK_ID="$(node "$LIB" artifact-task "$FILE_PATH" 2>/dev/null || true)"
 
-for meta_file in "$PROJECTS_DIR"/*/meta.json; do
-  [ -f "$meta_file" ] || continue
-  PROJECT_DIR=$(dirname "$meta_file")
-  if [[ "$FILE_PATH" == *"$PROJECT_DIR/artifacts"* ]]; then
-    TASK_ID=$(echo "$FILE_PATH" | grep -oE 'T-[0-9]+' | head -1 || true)
-    if [ -n "$TASK_ID" ]; then
-      echo "{\"notification\": \"Artifact written for $TASK_ID — run validation or /pm:task complete $TASK_ID\"}"
-      exit 0
-    fi
-  fi
-done
-
-echo "{}"
+if [ -n "$TASK_ID" ]; then
+  MSG="Artifact written for ${TASK_ID} — consider /pm:task complete ${TASK_ID}"
+  printf '%s' "$MSG" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{process.stdout.write(JSON.stringify({notification:d}))})"
+else
+  echo "{}"
+fi

--- a/plugins/project-management-plugin/lib/overengineering-rules.mjs
+++ b/plugins/project-management-plugin/lib/overengineering-rules.mjs
@@ -1,0 +1,121 @@
+// Rules that flag over-engineering patterns CLAUDE.md forbids.
+// Each rule returns a short reason string when matched; the hook prints the
+// matched reason alongside the quoted CLAUDE.md rule so Claude can self-correct.
+//
+// Keep rules tight. False positives here undermine the entire gate — prefer
+// "no rule" over "ambiguous rule." Each rule carries a tag so we can test it.
+
+const RULES = [
+  {
+    tag: 'multiline-comment',
+    rule: 'Default to writing no comments. One short line max.',
+    test: ({ diff }) => {
+      if (!diff) return null;
+      // Multi-line comment blocks added (3+ added comment lines in a row).
+      const added = diff.split('\n').filter((l) => l.startsWith('+') && !l.startsWith('+++'));
+      let streak = 0;
+      let maxStreak = 0;
+      for (const line of added) {
+        const body = line.slice(1).trim();
+        const isComment = /^(\/\/|#|\*|\/\*|<!--)/.test(body) || /"""|'''/.test(body);
+        if (isComment) { streak++; maxStreak = Math.max(maxStreak, streak); } else { streak = 0; }
+      }
+      return maxStreak >= 3 ? `added ${maxStreak} consecutive comment lines` : null;
+    },
+  },
+  {
+    tag: 'added-feature-flag',
+    rule: 'Don\'t use feature flags or backwards-compatibility shims when you can just change the code.',
+    test: ({ diff }) => {
+      if (!diff) return null;
+      const added = diff.split('\n').filter((l) => l.startsWith('+') && !l.startsWith('+++')).join('\n');
+      if (/\b(featureFlag|FEATURE_FLAG|isFeatureEnabled|enableFeature)\b/.test(added)) {
+        return 'added a feature flag';
+      }
+      return null;
+    },
+  },
+  {
+    tag: 'backcompat-shim',
+    rule: 'Avoid backwards-compatibility hacks like renaming unused _vars, re-exporting types for removed code, adding // removed comments.',
+    test: ({ diff }) => {
+      if (!diff) return null;
+      const added = diff.split('\n').filter((l) => l.startsWith('+') && !l.startsWith('+++')).join('\n');
+      const hits = [];
+      if (/\/\/\s*removed\b/i.test(added)) hits.push('"// removed" comment');
+      if (/\bexport\s*\{\s*[^}]+\s*\}\s*;?\s*\/\/\s*re-?export\b/i.test(added)) hits.push('re-export shim');
+      if (/\b_[a-zA-Z]+\s*=/.test(added) && /kept for backwards compat/i.test(added)) hits.push('_var kept for compat');
+      return hits.length ? hits.join(', ') : null;
+    },
+  },
+  {
+    tag: 'speculative-validation',
+    rule: 'Don\'t add error handling, fallbacks, or validation for scenarios that can\'t happen.',
+    test: ({ diff }) => {
+      if (!diff) return null;
+      const added = diff.split('\n').filter((l) => l.startsWith('+') && !l.startsWith('+++')).join('\n');
+      // Paranoid checks like: if (!obj) return; if (typeof foo !== 'undefined') { ... }
+      const paranoid =
+        (added.match(/if\s*\(\s*typeof\s+\w+\s*!==?\s*['"]undefined['"]/g) || []).length +
+        (added.match(/if\s*\(\s*!\s*\w+\s*\)\s*return\s*;/g) || []).length;
+      return paranoid >= 3 ? `added ${paranoid} speculative null/type guards` : null;
+    },
+  },
+  {
+    tag: 'docstring-bloat',
+    rule: 'Never write multi-paragraph docstrings or multi-line comment blocks — one short line max.',
+    test: ({ diff, path }) => {
+      if (!diff) return null;
+      // A triple-quoted docstring or JSDoc /** ... */ spanning >= 5 added lines.
+      const added = diff.split('\n');
+      let inBlock = false;
+      let blockLines = 0;
+      let maxBlock = 0;
+      for (const line of added) {
+        if (!line.startsWith('+') || line.startsWith('+++')) continue;
+        const body = line.slice(1);
+        if (!inBlock && /^\s*(\/\*\*|"""|''')/.test(body)) { inBlock = true; blockLines = 1; continue; }
+        if (inBlock) {
+          blockLines++;
+          if (/\*\/|"""|'''/.test(body)) { maxBlock = Math.max(maxBlock, blockLines); inBlock = false; blockLines = 0; }
+        }
+      }
+      return maxBlock >= 5 ? `added ${maxBlock}-line docstring${path ? ` in ${path}` : ''}` : null;
+    },
+  },
+  {
+    tag: 'task-reference-comment',
+    rule: 'Don\'t reference the current task, fix, or callers in comments ("used by X", "added for Y", "#issue-123").',
+    test: ({ diff }) => {
+      if (!diff) return null;
+      const added = diff.split('\n').filter((l) => l.startsWith('+') && !l.startsWith('+++')).join('\n');
+      const hits = [];
+      if (/\/\/\s*added for\b/i.test(added)) hits.push('"added for X" comment');
+      if (/\/\/\s*used by\b/i.test(added)) hits.push('"used by X" comment');
+      if (/#issue[-_ ]?\d+/i.test(added)) hits.push('issue-# reference in comment');
+      return hits.length ? hits.join(', ') : null;
+    },
+  },
+];
+
+export function matchOverengineering({ diff, path }) {
+  const hits = [];
+  for (const rule of RULES) {
+    try {
+      const reason = rule.test({ diff, path });
+      if (reason) hits.push({ tag: rule.tag, rule: rule.rule, reason });
+    } catch {
+      // A broken rule should never block a tool call.
+    }
+  }
+  return hits;
+}
+
+export function formatHits(hits) {
+  if (!hits || hits.length === 0) return '';
+  return hits
+    .map((h) => `- ${h.reason}\n  CLAUDE.md rule: "${h.rule}"`)
+    .join('\n');
+}
+
+export { RULES as _OVERENG_RULES }; // exported for tests

--- a/plugins/project-management-plugin/lib/pm-guardrails-cli.mjs
+++ b/plugins/project-management-plugin/lib/pm-guardrails-cli.mjs
@@ -21,6 +21,8 @@ import {
   readDoneWhen, unmetCriteria,
   detectOverengineering,
   recordBreadcrumb, activeContextSummary,
+  budgetStatus, recordUserPrompt, lastUserPrompt,
+  writeHandoff, readHandoff,
 } from './pm-guardrails.mjs';
 
 const verb = process.argv[2];
@@ -91,6 +93,31 @@ async function main() {
       }
       case 'active-context': {
         printJSON(activeContextSummary());
+        return;
+      }
+      case 'budget-status': {
+        printJSON(budgetStatus());
+        return;
+      }
+      case 'record-user-prompt': {
+        const text = process.argv.slice(3).join(' ');
+        recordUserPrompt(text);
+        printJSON({ logged: !!text });
+        return;
+      }
+      case 'last-user-prompt': {
+        const p = lastUserPrompt();
+        printJSON(p ? { prompt: p } : {});
+        return;
+      }
+      case 'handoff-write': {
+        const file = writeHandoff();
+        printJSON({ file });
+        return;
+      }
+      case 'handoff-read': {
+        const md = readHandoff();
+        printJSON(md ? { markdown: md } : {});
         return;
       }
       default:

--- a/plugins/project-management-plugin/lib/pm-guardrails-cli.mjs
+++ b/plugins/project-management-plugin/lib/pm-guardrails-cli.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Thin CLI wrapper around pm-guardrails used by the bash hook scripts.
+// Every verb prints a single line of JSON to stdout and exits 0. Failures
+// print {} and exit 0 so hooks never block Claude on infra errors.
+//
+// Verbs:
+//   anchor-reminder           — prints {reminder: "..."} or {}
+//   scope-check <path>        — prints {in_scope, active, matched_pattern?}
+//   done-status               — prints {active, total, met, unmet:[...]}
+//   overeng <path>            — prints {hits:[{tag,reason,rule}], count}
+//   breadcrumb <tool> <tgt>   — appends a breadcrumb; prints {logged:true}
+//   active-context            — prints {kind, id, dir}
+
+import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import {
+  readAnchor, formatAnchorReminder,
+  readScope, isInScope,
+  readDoneWhen, unmetCriteria,
+  detectOverengineering,
+  recordBreadcrumb, activeContextSummary,
+} from './pm-guardrails.mjs';
+
+const verb = process.argv[2];
+const arg1 = process.argv[3];
+const arg2 = process.argv[4];
+
+function safeGitDiff(path) {
+  if (!path || !existsSync(path)) return '';
+  try {
+    // Prefer a staged diff (what Claude just wrote) over working-tree diff
+    // so we score the actual change, not the accumulated delta.
+    const diff = execFileSync('git', ['diff', 'HEAD', '--', path], {
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000,
+    });
+    return diff;
+  } catch {
+    // Non-git contexts: fall back to treating the entire file as "added".
+    try {
+      const body = readFileSync(path, 'utf8');
+      return body.split('\n').map((l) => '+' + l).join('\n');
+    } catch { return ''; }
+  }
+}
+
+function printJSON(obj) { process.stdout.write(JSON.stringify(obj)); }
+
+async function main() {
+  try {
+    switch (verb) {
+      case 'anchor-reminder': {
+        const anchor = readAnchor();
+        const reminder = formatAnchorReminder(anchor);
+        printJSON(reminder ? { reminder } : {});
+        return;
+      }
+      case 'scope-check': {
+        const scope = readScope();
+        if (!scope.active) { printJSON({ in_scope: true, active: false }); return; }
+        const pathArg = arg1 ? resolve(arg1) : '';
+        const inScope = isInScope(pathArg, { allowlist: scope.allowlist });
+        const matched = inScope ? scope.allowlist.find((p) => isInScope(pathArg, { allowlist: [p] })) : null;
+        printJSON({ in_scope: inScope, active: true, matched_pattern: matched, allowlist: scope.allowlist });
+        return;
+      }
+      case 'done-status': {
+        const rec = readDoneWhen();
+        if (!rec) { printJSON({ active: false }); return; }
+        const unmet = unmetCriteria(rec);
+        printJSON({ active: !!rec.active, total: rec.criteria.length, met: rec.criteria.length - unmet.length, unmet });
+        return;
+      }
+      case 'overeng': {
+        const pathArg = arg1 || '';
+        if (!pathArg) { printJSON({ hits: [], count: 0 }); return; }
+        const diff = safeGitDiff(pathArg);
+        const hits = detectOverengineering({ diff, path: pathArg });
+        printJSON({ hits, count: hits.length });
+        return;
+      }
+      case 'breadcrumb': {
+        recordBreadcrumb({
+          tool: arg1 || 'unknown',
+          target: arg2 || null,
+          ts: new Date().toISOString(),
+        });
+        printJSON({ logged: true });
+        return;
+      }
+      case 'active-context': {
+        printJSON(activeContextSummary());
+        return;
+      }
+      default:
+        process.stderr.write(`unknown verb: ${verb}\n`);
+        printJSON({});
+    }
+  } catch {
+    printJSON({});
+  }
+}
+
+main();

--- a/plugins/project-management-plugin/lib/pm-guardrails.mjs
+++ b/plugins/project-management-plugin/lib/pm-guardrails.mjs
@@ -313,3 +313,186 @@ export function analyzeDrift({ since = null } = {}) {
 export function detectOverengineering({ diff, path }) {
   return matchOverengineering({ diff, path });
 }
+
+// ---------------------------------------------------------------------------
+// Turn budget (upgrade F)
+// ---------------------------------------------------------------------------
+
+const BUDGET_FILE = 'budget.json';
+
+export function readBudget(dir = activeContextDir()) {
+  const file = join(dir, BUDGET_FILE);
+  if (!existsSync(file)) return null;
+  try { return JSON.parse(readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+export async function setBudget({ max_turns, task_id = null }) {
+  const n = parseInt(max_turns, 10);
+  if (!Number.isFinite(n) || n <= 0) throw new Error('max_turns must be a positive integer');
+  const dir = activeContextDir();
+  mkdirSync(dir, { recursive: true });
+  const record = {
+    version: 1,
+    active: true,
+    max_turns: n,
+    started_at: new Date().toISOString(),
+    task_id,
+    baseline_crumb_count: readBreadcrumbs(dir).length,
+  };
+  await withLock(join(dir, '.locks', 'budget.lock'), async () => {
+    writeFileSync(join(dir, BUDGET_FILE), JSON.stringify(record, null, 2) + '\n');
+  });
+  return record;
+}
+
+export async function clearBudget() {
+  const dir = activeContextDir();
+  const current = readBudget(dir);
+  if (!current) return null;
+  const next = { ...current, active: false, cleared_at: new Date().toISOString() };
+  await withLock(join(dir, '.locks', 'budget.lock'), async () => {
+    writeFileSync(join(dir, BUDGET_FILE), JSON.stringify(next, null, 2) + '\n');
+  });
+  return next;
+}
+
+export function budgetStatus() {
+  const budget = readBudget();
+  if (!budget || !budget.active) return { active: false };
+  const crumbs = readBreadcrumbs();
+  const used = Math.max(0, crumbs.length - (budget.baseline_crumb_count || 0));
+  const pct = budget.max_turns ? +(used / budget.max_turns).toFixed(3) : 0;
+  let status = 'ok';
+  if (pct >= 1.2) status = 'over';
+  else if (pct >= 0.8) status = 'warn';
+  return {
+    active: true,
+    used,
+    max_turns: budget.max_turns,
+    pct,
+    status,
+    started_at: budget.started_at,
+    task_id: budget.task_id,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// User-prompt archive (upgrade H)
+// ---------------------------------------------------------------------------
+
+const PROMPTS_FILE = 'user-prompts.jsonl';
+
+export function recordUserPrompt(text) {
+  if (!text || typeof text !== 'string') return;
+  const trimmed = text.trim();
+  if (!trimmed) return;
+  const dir = activeContextDir();
+  mkdirSync(dir, { recursive: true });
+  appendFileSync(
+    join(dir, PROMPTS_FILE),
+    JSON.stringify({ ts: new Date().toISOString(), text: trimmed.slice(0, 4000) }) + '\n',
+  );
+}
+
+export function readUserPrompts({ limit = 10 } = {}) {
+  const dir = activeContextDir();
+  const file = join(dir, PROMPTS_FILE);
+  if (!existsSync(file)) return [];
+  const lines = readFileSync(file, 'utf8').split('\n').filter((l) => l.trim());
+  const parsed = lines.map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+  return parsed.slice(-limit);
+}
+
+export function lastUserPrompt() {
+  const recent = readUserPrompts({ limit: 1 });
+  return recent[0] || null;
+}
+
+// ---------------------------------------------------------------------------
+// Compaction-safe handoff (upgrade G)
+// ---------------------------------------------------------------------------
+
+const HANDOFF_FILE = 'handoff.md';
+
+export function writeHandoff() {
+  const dir = activeContextDir();
+  mkdirSync(dir, { recursive: true });
+  const anchor = readAnchor(dir);
+  const scope = readScope(dir);
+  const done = readDoneWhen(dir);
+  const budget = budgetStatus();
+  const lastAsk = lastUserPrompt();
+  const crumbs = readBreadcrumbs(dir).slice(-15);
+  const touchedFiles = Array.from(
+    new Set(
+      crumbs
+        .filter((c) => ['Edit', 'Write', 'MultiEdit'].includes(c.tool))
+        .map((c) => c.target)
+        .filter(Boolean),
+    ),
+  ).slice(0, 20);
+  const lines = [
+    '# Task Handoff',
+    '',
+    `_Snapshot written at ${new Date().toISOString()} — read by SessionStart to restore context after /compact or resume._`,
+    '',
+  ];
+  if (lastAsk) {
+    lines.push('## Last user ask', '', '> ' + lastAsk.text.split('\n').join('\n> '), '');
+  }
+  if (anchor && anchor.active) {
+    lines.push('## Focus anchor', '', `- DO: ${anchor.do}`);
+    if (anchor.dont) lines.push(`- DON'T: ${anchor.dont}`);
+    if (anchor.task_id) lines.push(`- TASK: ${anchor.task_id}`);
+    lines.push('');
+  }
+  if (scope.active) {
+    lines.push('## Scope allowlist', '');
+    for (const p of scope.allowlist) lines.push(`- \`${p}\``);
+    if ((scope.overrides || []).length) {
+      lines.push('', 'Overrides logged:');
+      for (const ov of scope.overrides.slice(-5)) lines.push(`- ${ov.path} — ${ov.reason}`);
+    }
+    lines.push('');
+  }
+  if (done) {
+    const met = (done.criteria || []).filter((c) => c.met_at).length;
+    lines.push('## Done-when progress', '', `${met}/${(done.criteria || []).length} criteria met.`, '');
+    for (const c of done.criteria || []) {
+      const box = c.met_at ? '[x]' : '[ ]';
+      lines.push(`- ${box} **${c.id}** — ${c.text}${c.evidence ? ` → \`${c.evidence}\`` : ''}`);
+    }
+    lines.push('');
+  }
+  if (budget.active) {
+    lines.push('## Turn budget', '', `${budget.used}/${budget.max_turns} turns used (${Math.round(budget.pct * 100)}%, status: ${budget.status})`, '');
+  }
+  if (touchedFiles.length) {
+    lines.push('## Recently touched files', '');
+    for (const f of touchedFiles) lines.push(`- ${f}`);
+    lines.push('');
+  }
+  if (crumbs.length) {
+    lines.push('## Recent breadcrumbs', '');
+    for (const c of crumbs) lines.push(`- \`${c.tool}\` ${c.target || ''}`);
+    lines.push('');
+  }
+  lines.push(
+    '## How to resume',
+    '',
+    '1. Re-read the focus anchor (above).',
+    '2. Check `/pm:done-when --show` for outstanding criteria.',
+    '3. Run `/pm:drift` for a classification of recent turns.',
+    '4. Continue the task; do not re-plan from scratch.',
+    '',
+  );
+  writeFileSync(join(dir, HANDOFF_FILE), lines.join('\n'));
+  return join(dir, HANDOFF_FILE);
+}
+
+export function readHandoff() {
+  const dir = activeContextDir();
+  const file = join(dir, HANDOFF_FILE);
+  if (!existsSync(file)) return null;
+  return readFileSync(file, 'utf8');
+}

--- a/plugins/project-management-plugin/lib/pm-guardrails.mjs
+++ b/plugins/project-management-plugin/lib/pm-guardrails.mjs
@@ -1,0 +1,315 @@
+// Guardrail state for keeping Claude Code on task.
+//
+// Introduces a small set of task-scoped artifacts that live next to (or
+// independently of) the existing project state:
+//
+//   anchor.json        — focus receipt ("do X, don't do Y")
+//   scope.json         — file/command allowlist + override ledger
+//   done-when.json     — explicit completion criteria + evidence
+//   breadcrumbs.jsonl  — append-only log of tool calls for drift auditing
+//
+// Active context resolution:
+//   1. The first project with status IN_PROGRESS, if any.
+//   2. Otherwise an ephemeral `.claude/pm-session/` directory so users can
+//      use these guardrails without running /pm:init first.
+//
+// All writes go through the shared withLock() primitive from pm-state.mjs.
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, appendFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { projectsRoot, listProjects, withLock } from './pm-state.mjs';
+import { matchOverengineering } from './overengineering-rules.mjs';
+
+// ---------------------------------------------------------------------------
+// Active-context resolution
+// ---------------------------------------------------------------------------
+
+export function sessionDir() {
+  const base = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  return join(base, '.claude', 'pm-session');
+}
+
+export function activeContextDir() {
+  const active = listProjects().find((p) => p.project.status === 'IN_PROGRESS');
+  if (active) return active.dir;
+  const fallback = sessionDir();
+  mkdirSync(fallback, { recursive: true });
+  return fallback;
+}
+
+export function activeContextSummary() {
+  const active = listProjects().find((p) => p.project.status === 'IN_PROGRESS');
+  if (active) return { kind: 'project', id: active.id, dir: active.dir };
+  return { kind: 'session', id: null, dir: sessionDir() };
+}
+
+// ---------------------------------------------------------------------------
+// Focus anchor (upgrade A)
+// ---------------------------------------------------------------------------
+
+const ANCHOR_FILE = 'anchor.json';
+const ANCHOR_MD = 'focus.md';
+
+export function readAnchor(dir = activeContextDir()) {
+  const file = join(dir, ANCHOR_FILE);
+  if (!existsSync(file)) return null;
+  try { return JSON.parse(readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+export async function setAnchor({ doItem, dontItem, task_id = null }) {
+  if (!doItem || typeof doItem !== 'string') throw new Error('doItem is required');
+  const dir = activeContextDir();
+  mkdirSync(dir, { recursive: true });
+  const record = {
+    version: 1,
+    active: true,
+    do: doItem.trim(),
+    dont: (dontItem || '').trim() || null,
+    task_id,
+    set_at: new Date().toISOString(),
+    cleared_at: null,
+  };
+  await withLock(join(dir, '.locks', 'anchor.lock'), async () => {
+    writeFileSync(join(dir, ANCHOR_FILE), JSON.stringify(record, null, 2) + '\n');
+    const md = [
+      '---',
+      `set_at: ${record.set_at}`,
+      record.task_id ? `task_id: ${record.task_id}` : null,
+      '---',
+      '',
+      `DO: ${record.do}`,
+      record.dont ? `DON'T: ${record.dont}` : "DON'T: (no explicit guardrails)",
+      '',
+    ].filter((l) => l !== null).join('\n');
+    writeFileSync(join(dir, ANCHOR_MD), md);
+  });
+  return record;
+}
+
+export async function clearAnchor() {
+  const dir = activeContextDir();
+  const current = readAnchor(dir);
+  if (!current) return null;
+  const next = { ...current, active: false, cleared_at: new Date().toISOString() };
+  await withLock(join(dir, '.locks', 'anchor.lock'), async () => {
+    writeFileSync(join(dir, ANCHOR_FILE), JSON.stringify(next, null, 2) + '\n');
+  });
+  return next;
+}
+
+export function formatAnchorReminder(anchor) {
+  if (!anchor || !anchor.active) return null;
+  const lines = [`DO: ${anchor.do}`];
+  if (anchor.dont) lines.push(`DON'T: ${anchor.dont}`);
+  if (anchor.task_id) lines.push(`TASK: ${anchor.task_id}`);
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Scope lock (upgrade B)
+// ---------------------------------------------------------------------------
+
+const SCOPE_FILE = 'scope.json';
+
+export function readScope(dir = activeContextDir()) {
+  const file = join(dir, SCOPE_FILE);
+  if (!existsSync(file)) return { version: 1, active: false, allowlist: [], overrides: [] };
+  try { return JSON.parse(readFileSync(file, 'utf8')); } catch { return { version: 1, active: false, allowlist: [], overrides: [] }; }
+}
+
+export async function setScope(patterns) {
+  if (!Array.isArray(patterns)) throw new Error('patterns must be an array');
+  const dir = activeContextDir();
+  mkdirSync(dir, { recursive: true });
+  const record = {
+    version: 1,
+    active: patterns.length > 0,
+    allowlist: dedupe(patterns.map(String)),
+    overrides: [],
+    set_at: new Date().toISOString(),
+  };
+  await withLock(join(dir, '.locks', 'scope.lock'), async () => {
+    writeFileSync(join(dir, SCOPE_FILE), JSON.stringify(record, null, 2) + '\n');
+  });
+  return record;
+}
+
+export async function addScopePatterns(patterns) {
+  const current = readScope();
+  return setScope(dedupe([...(current.allowlist || []), ...patterns]));
+}
+
+export async function removeScopePatterns(patterns) {
+  const current = readScope();
+  return setScope((current.allowlist || []).filter((p) => !patterns.includes(p)));
+}
+
+export async function recordOverride({ path, reason }) {
+  const dir = activeContextDir();
+  mkdirSync(dir, { recursive: true });
+  await withLock(join(dir, '.locks', 'scope.lock'), async () => {
+    const current = readScope(dir);
+    current.overrides = current.overrides || [];
+    current.overrides.push({ ts: new Date().toISOString(), path, reason });
+    writeFileSync(join(dir, SCOPE_FILE), JSON.stringify(current, null, 2) + '\n');
+  });
+}
+
+export function isInScope(absPath, { allowlist, baseDir } = {}) {
+  if (!allowlist || allowlist.length === 0) return true;
+  const base = baseDir || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const rel = relative(base, absPath).split(sep).join('/');
+  // Never treat paths that escape the base as in-scope — those bypass
+  // any containment the user configured.
+  if (rel.startsWith('..')) return false;
+  for (const pattern of allowlist) {
+    if (globMatch(pattern, rel)) return true;
+  }
+  return false;
+}
+
+// Minimal glob: supports * and ** only (no brace expansion, no negation).
+// Sufficient for scope patterns like "src/auth/**" or "tests/*.test.mjs".
+export function globMatch(pattern, subject) {
+  const re = new RegExp(
+    '^' +
+      pattern
+        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+        .replace(/\*\*/g, '§§DOUBLE§§')
+        .replace(/\*/g, '[^/]*')
+        .replace(/§§DOUBLE§§/g, '.*') +
+      '$',
+  );
+  return re.test(subject);
+}
+
+function dedupe(arr) { return Array.from(new Set(arr)); }
+
+// ---------------------------------------------------------------------------
+// Done-when contract (upgrade C)
+// ---------------------------------------------------------------------------
+
+const DONE_FILE = 'done-when.json';
+
+export function readDoneWhen(dir = activeContextDir()) {
+  const file = join(dir, DONE_FILE);
+  if (!existsSync(file)) return null;
+  try { return JSON.parse(readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+export async function setDoneWhen({ criteria, task_id = null }) {
+  if (!Array.isArray(criteria) || criteria.length === 0) {
+    throw new Error('criteria must be a non-empty array of strings');
+  }
+  const dir = activeContextDir();
+  mkdirSync(dir, { recursive: true });
+  const record = {
+    version: 1,
+    active: true,
+    task_id,
+    set_at: new Date().toISOString(),
+    criteria: criteria.map((c, i) => ({
+      id: `c${i + 1}`,
+      text: String(c).trim(),
+      evidence: null,
+      met_at: null,
+    })),
+  };
+  await withLock(join(dir, '.locks', 'done.lock'), async () => {
+    writeFileSync(join(dir, DONE_FILE), JSON.stringify(record, null, 2) + '\n');
+  });
+  return record;
+}
+
+export async function markCriterionMet({ id, evidence }) {
+  if (!id) throw new Error('id is required');
+  if (!evidence || !String(evidence).trim()) throw new Error('evidence is required');
+  const dir = activeContextDir();
+  return withLock(join(dir, '.locks', 'done.lock'), async () => {
+    const current = readDoneWhen(dir);
+    if (!current) throw new Error('no done-when contract active; run /pm:done-when first');
+    const hit = (current.criteria || []).find((c) => c.id === id || c.text === id);
+    if (!hit) throw new Error(`criterion not found: ${id}`);
+    hit.evidence = String(evidence).trim();
+    hit.met_at = new Date().toISOString();
+    writeFileSync(join(dir, DONE_FILE), JSON.stringify(current, null, 2) + '\n');
+    return hit;
+  });
+}
+
+export function unmetCriteria(record) {
+  if (!record) return [];
+  return (record.criteria || []).filter((c) => !c.met_at);
+}
+
+// ---------------------------------------------------------------------------
+// Breadcrumbs + drift auditor (upgrade E)
+// ---------------------------------------------------------------------------
+
+const BREADCRUMB_FILE = 'breadcrumbs.jsonl';
+
+export function recordBreadcrumb(entry) {
+  // Single-line append; jsonl format. No lock needed because append(2) is
+  // atomic under POSIX line buffering for small writes, and Windows
+  // tolerates it for our sub-4k line sizes.
+  const dir = activeContextDir();
+  mkdirSync(dir, { recursive: true });
+  const ts = entry.ts || new Date().toISOString();
+  const line = JSON.stringify({ ...entry, ts }) + '\n';
+  appendFileSync(join(dir, BREADCRUMB_FILE), line);
+}
+
+export function readBreadcrumbs(dir = activeContextDir()) {
+  const file = join(dir, BREADCRUMB_FILE);
+  if (!existsSync(file)) return [];
+  return readFileSync(file, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+    .filter(Boolean);
+}
+
+export function analyzeDrift({ since = null } = {}) {
+  const crumbs = readBreadcrumbs();
+  const anchor = readAnchor();
+  const scope = readScope();
+  const done = readDoneWhen();
+
+  const filtered = since ? crumbs.filter((c) => c.ts >= since) : crumbs;
+  const classified = filtered.map((c) => {
+    const reasons = [];
+    if (scope.active && c.target && c.scope_ok === false) reasons.push('out-of-scope');
+    if (c.tool === 'Edit' || c.tool === 'Write') {
+      if (c.overengineering_hits && c.overengineering_hits.length) {
+        reasons.push(`overengineering: ${c.overengineering_hits.join(', ')}`);
+      }
+    }
+    const advances = (c.criterion_hint && done)
+      || (c.tool === 'Bash' && c.target && /(test|pnpm|npm|vitest|jest|pytest|cargo)/.test(c.target));
+    return { ...c, drift: reasons, advances: !!advances };
+  });
+
+  const totals = {
+    turns: classified.length,
+    drift_turns: classified.filter((c) => c.drift.length).length,
+    advancing_turns: classified.filter((c) => c.advances).length,
+  };
+  totals.drift_ratio = totals.turns ? +(totals.drift_turns / totals.turns).toFixed(3) : 0;
+  return {
+    context: activeContextSummary(),
+    anchor,
+    scope_active: !!scope.active,
+    done_criteria_total: (done?.criteria || []).length,
+    done_criteria_met: (done?.criteria || []).filter((c) => c.met_at).length,
+    totals,
+    entries: classified,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Overengineering detector (upgrade D)
+// ---------------------------------------------------------------------------
+
+export function detectOverengineering({ diff, path }) {
+  return matchOverengineering({ diff, path });
+}

--- a/plugins/project-management-plugin/lib/pm-state.mjs
+++ b/plugins/project-management-plugin/lib/pm-state.mjs
@@ -1,0 +1,378 @@
+// Shared state library for project-management-plugin.
+//
+// Used by:
+//   - hooks/scripts/*.sh (via the CLI at the bottom of this file)
+//   - mcp/pm-server.mjs (imported directly as an ES module)
+//   - tests/*.test.mjs
+//
+// Guarantees:
+//   - All mutating writes are guarded by an exclusive O_EXCL lockfile
+//     that works on POSIX and Windows. Stale locks older than 30s are broken.
+//   - All writes to project.json / tasks.json are validated against the
+//     plugin's JSON schemas before rename.
+//   - Writes are atomic: data is serialized to temp/.write-<uuid>, then
+//     renamed into place.
+
+import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync, readdirSync, statSync, unlinkSync, openSync, closeSync } from 'node:fs';
+import { join, resolve, dirname, basename } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const PLUGIN_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
+const SCHEMA_DIR = join(PLUGIN_ROOT, 'schemas');
+
+const LOCK_STALE_MS = 30_000;
+const LOCK_MAX_WAIT_MS = 5_000;
+const LOCK_POLL_MS = 25;
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+export function projectsRoot() {
+  const base = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  return join(base, '.claude', 'projects');
+}
+
+export function projectDir(id) {
+  return join(projectsRoot(), id);
+}
+
+// ---------------------------------------------------------------------------
+// Project + tasks readers
+// ---------------------------------------------------------------------------
+
+export function listProjects() {
+  const root = projectsRoot();
+  if (!existsSync(root)) return [];
+  const out = [];
+  for (const entry of readdirSync(root)) {
+    const dir = join(root, entry);
+    let stat;
+    try { stat = statSync(dir); } catch { continue; }
+    if (!stat.isDirectory()) continue;
+    const projectFile = join(dir, 'project.json');
+    if (!existsSync(projectFile)) continue;
+    let project = null;
+    try { project = JSON.parse(readFileSync(projectFile, 'utf8')); } catch { continue; }
+    out.push({ id: project.id || entry, dir, project });
+  }
+  return out;
+}
+
+export function readProject(id) {
+  const file = join(projectDir(id), 'project.json');
+  if (!existsSync(file)) return null;
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+export function readTasks(id) {
+  const file = join(projectDir(id), 'tasks.json');
+  if (!existsSync(file)) return { version: 1, tasks: [] };
+  const raw = JSON.parse(readFileSync(file, 'utf8'));
+  // Accept two on-disk shapes: a bare array (legacy) or the {version, tasks}
+  // wrapper described in pm-plan.md. Always normalize to the wrapper form.
+  if (Array.isArray(raw)) return { version: 1, tasks: raw };
+  return raw;
+}
+
+export function findTask(tasksJson, taskId) {
+  if (!tasksJson || !Array.isArray(tasksJson.tasks)) return null;
+  return tasksJson.tasks.find((t) => t.id === taskId) || null;
+}
+
+// ---------------------------------------------------------------------------
+// Locking: O_EXCL lockfile, works on POSIX + Windows.
+// ---------------------------------------------------------------------------
+
+export async function withLock(lockPath, fn) {
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + LOCK_MAX_WAIT_MS;
+  let fd = null;
+  while (fd === null) {
+    try {
+      fd = openSync(lockPath, 'wx');
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+      // Break stale locks.
+      try {
+        const age = Date.now() - statSync(lockPath).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          try { unlinkSync(lockPath); } catch {}
+          continue;
+        }
+      } catch {}
+      if (Date.now() > deadline) {
+        throw new Error(`timed out waiting for lock: ${lockPath}`);
+      }
+      await sleep(LOCK_POLL_MS);
+    }
+  }
+  try {
+    writeFileSync(fd, String(process.pid));
+    closeSync(fd);
+    return await fn();
+  } finally {
+    try { unlinkSync(lockPath); } catch {}
+  }
+}
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+// ---------------------------------------------------------------------------
+// Atomic writes with schema validation
+// ---------------------------------------------------------------------------
+
+export async function writeProject(id, project, { skipValidation = false } = {}) {
+  const dir = projectDir(id);
+  mkdirSync(dir, { recursive: true });
+  if (!skipValidation) {
+    const errors = validateProject(project);
+    if (errors.length) throw new Error(`project.json failed validation:\n  ${errors.join('\n  ')}`);
+  }
+  const lockPath = join(dir, '.locks', 'project.lock');
+  await withLock(lockPath, () => atomicWriteJSON(join(dir, 'project.json'), project));
+}
+
+export async function writeTasks(id, tasksJson, { skipValidation = false } = {}) {
+  const dir = projectDir(id);
+  mkdirSync(dir, { recursive: true });
+  if (!skipValidation) {
+    const errors = validateTasks(tasksJson);
+    if (errors.length) throw new Error(`tasks.json failed validation:\n  ${errors.join('\n  ')}`);
+  }
+  const lockPath = join(dir, '.locks', 'tasks.lock');
+  await withLock(lockPath, () => atomicWriteJSON(join(dir, 'tasks.json'), tasksJson));
+}
+
+export async function mutateTasks(id, mutator) {
+  const dir = projectDir(id);
+  mkdirSync(dir, { recursive: true });
+  const lockPath = join(dir, '.locks', 'tasks.lock');
+  return withLock(lockPath, async () => {
+    const current = readTasks(id);
+    const next = await mutator(current);
+    if (!next) return null; // mutator aborted
+    const errors = validateTasks(next);
+    if (errors.length) throw new Error(`tasks.json failed validation:\n  ${errors.join('\n  ')}`);
+    atomicWriteJSON(join(dir, 'tasks.json'), next);
+    return next;
+  });
+}
+
+export async function mutateProject(id, mutator) {
+  const dir = projectDir(id);
+  mkdirSync(dir, { recursive: true });
+  const lockPath = join(dir, '.locks', 'project.lock');
+  return withLock(lockPath, async () => {
+    const current = readProject(id);
+    if (!current) throw new Error(`project not found: ${id}`);
+    const next = await mutator(current);
+    if (!next) return null;
+    const errors = validateProject(next);
+    if (errors.length) throw new Error(`project.json failed validation:\n  ${errors.join('\n  ')}`);
+    atomicWriteJSON(join(dir, 'project.json'), next);
+    return next;
+  });
+}
+
+function atomicWriteJSON(targetPath, obj) {
+  const tempDir = join(dirname(targetPath), 'temp');
+  mkdirSync(tempDir, { recursive: true });
+  const tempPath = join(tempDir, `.write-${randomUUID()}`);
+  writeFileSync(tempPath, JSON.stringify(obj, null, 2) + '\n');
+  try {
+    renameSync(tempPath, targetPath);
+  } catch (err) {
+    if (err.code === 'EEXIST' || err.code === 'EPERM') {
+      // Windows rename-over-existing edge case.
+      try { unlinkSync(targetPath); } catch {}
+      renameSync(tempPath, targetPath);
+    } else {
+      try { unlinkSync(tempPath); } catch {}
+      throw err;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoints
+// ---------------------------------------------------------------------------
+
+export function writeCheckpoint(id) {
+  const dir = projectDir(id);
+  const checkpointsDir = join(dir, 'checkpoints');
+  mkdirSync(checkpointsDir, { recursive: true });
+  const project = readProject(id);
+  if (!project) return null;
+  const tasks = readTasks(id);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const file = join(checkpointsDir, `${timestamp}.json`);
+  const snapshot = {
+    timestamp: new Date().toISOString(),
+    project_snapshot: project,
+    task_statuses: (tasks.tasks || []).map((t) => ({
+      id: t.id,
+      status: t.status,
+      blocked_reason: t.blocked_reason || null,
+    })),
+    resume_from: 'Phase 1',
+  };
+  atomicWriteJSON(file, snapshot);
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+// Validation (Ajv loaded lazily to keep CLI startup fast)
+// ---------------------------------------------------------------------------
+
+let _ajv = null;
+let _validateProject = null;
+let _validateTasks = null;
+
+async function ensureValidators() {
+  if (_validateProject && _validateTasks) return;
+  const { default: Ajv } = await import('ajv');
+  const { default: addFormats } = await import('ajv-formats');
+  _ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(_ajv);
+  const projectSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, 'project.schema.json'), 'utf8'));
+  const taskSchema = JSON.parse(readFileSync(join(SCHEMA_DIR, 'task.schema.json'), 'utf8'));
+  _validateProject = _ajv.compile(projectSchema);
+  _validateTasks = _ajv.compile({
+    type: 'object',
+    required: ['tasks'],
+    additionalProperties: true,
+    properties: {
+      version: { type: 'integer' },
+      project_id: { type: 'string' },
+      generated_at: { type: 'string' },
+      depth: { type: 'string' },
+      tasks: {
+        type: 'array',
+        items: taskSchema,
+      },
+    },
+  });
+}
+
+function ajvErrorsToMessages(errors) {
+  if (!errors) return [];
+  return errors.map((e) => `${e.instancePath || '/'} ${e.message}`);
+}
+
+// Sync wrappers that throw if validators are not ready. Call loadValidators() first.
+export function validateProject(obj) {
+  if (!_validateProject) throw new Error('validators not loaded; call loadValidators() first');
+  return _validateProject(obj) ? [] : ajvErrorsToMessages(_validateProject.errors);
+}
+
+export function validateTasks(obj) {
+  if (!_validateTasks) throw new Error('validators not loaded; call loadValidators() first');
+  return _validateTasks(obj) ? [] : ajvErrorsToMessages(_validateTasks.errors);
+}
+
+export async function loadValidators() {
+  await ensureValidators();
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: derived queries
+// ---------------------------------------------------------------------------
+
+export function unblockedTasks(tasksJson) {
+  const tasks = tasksJson.tasks || [];
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+  return tasks.filter((t) => {
+    if (t.status !== 'PENDING' && t.status !== 'RESEARCHED') return false;
+    for (const depId of t.dependencies || []) {
+      const dep = byId.get(depId);
+      if (!dep) return false;
+      if (dep.status !== 'COMPLETE' && dep.status !== 'SKIPPED') return false;
+    }
+    return true;
+  });
+}
+
+export function nextTask(tasksJson, { focus = null } = {}) {
+  const priorityWeight = { CRITICAL: 4, HIGH: 3, MEDIUM: 2, LOW: 1 };
+  const unblocked = unblockedTasks(tasksJson).filter((t) => {
+    if (!focus) return true;
+    if (focus.phase_id && t.phase_id !== focus.phase_id && t.phase !== focus.phase_id) return false;
+    if (focus.epic_id && t.epic_id !== focus.epic_id) return false;
+    if (focus.story_id && t.story_id !== focus.story_id) return false;
+    return true;
+  });
+  unblocked.sort((a, b) => {
+    const aScore = (priorityWeight[a.priority] || 0) * (a.on_critical_path ? 2 : 1);
+    const bScore = (priorityWeight[b.priority] || 0) * (b.on_critical_path ? 2 : 1);
+    if (bScore !== aScore) return bScore - aScore;
+    return (a.estimate_minutes || 0) - (b.estimate_minutes || 0);
+  });
+  return unblocked[0] || null;
+}
+
+// ---------------------------------------------------------------------------
+// CLI — keeps bash hooks fast by using a single node process per call.
+// Usage:
+//   node pm-state.mjs active       -> prints {"id":"...","name":"..."} or {}
+//   node pm-state.mjs checkpoint   -> writes checkpoints for every IN_PROGRESS project
+//   node pm-state.mjs artifact-task <path>  -> prints the matching task id or ''
+// ---------------------------------------------------------------------------
+
+const isCli = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+if (isCli) {
+  const cmd = process.argv[2];
+  try {
+    if (cmd === 'active') {
+      const active = listProjects().find((p) => p.project.status === 'IN_PROGRESS');
+      if (active) {
+        process.stdout.write(JSON.stringify({ id: active.id, name: active.project.name || active.id }));
+      } else {
+        process.stdout.write('{}');
+      }
+    } else if (cmd === 'checkpoint') {
+      const results = [];
+      for (const p of listProjects()) {
+        if (p.project.status !== 'IN_PROGRESS') continue;
+        const file = writeCheckpoint(p.id);
+        if (file) results.push({ id: p.id, file: basename(file) });
+      }
+      process.stdout.write(JSON.stringify(results));
+    } else if (cmd === 'artifact-task') {
+      const filePath = process.argv[3] || '';
+      const m = filePath.match(/T-\d+/);
+      if (!m) { process.stdout.write(''); }
+      else {
+        // Confirm the path is under *some* project's artifacts dir.
+        let hit = '';
+        for (const p of listProjects()) {
+          if (filePath.includes(join(p.dir, 'artifacts'))) { hit = m[0]; break; }
+        }
+        process.stdout.write(hit);
+      }
+    } else if (cmd === 'validate') {
+      await loadValidators();
+      const id = process.argv[3];
+      if (!id) { console.error('usage: pm-state validate <project-id>'); process.exit(2); }
+      const project = readProject(id);
+      const tasks = readTasks(id);
+      const pErr = project ? validateProject(project) : ['project.json missing'];
+      const tErr = validateTasks(tasks);
+      const out = { project_errors: pErr, tasks_errors: tErr };
+      process.stdout.write(JSON.stringify(out, null, 2));
+      if (pErr.length || tErr.length) process.exit(1);
+    } else {
+      console.error('commands: active | checkpoint | artifact-task <path> | validate <id>');
+      process.exit(2);
+    }
+  } catch (err) {
+    // Hooks must never block Claude; they swallow errors and emit {}.
+    if (process.env.PM_STATE_STRICT === '1') {
+      console.error(err.message);
+      process.exit(1);
+    }
+    process.stdout.write('{}');
+  }
+}

--- a/plugins/project-management-plugin/mcp/pm-server.mjs
+++ b/plugins/project-management-plugin/mcp/pm-server.mjs
@@ -31,9 +31,12 @@ import {
   readDoneWhen, setDoneWhen, markCriterionMet, unmetCriteria,
   recordBreadcrumb, readBreadcrumbs, analyzeDrift,
   detectOverengineering,
+  setBudget, readBudget, clearBudget, budgetStatus,
+  recordUserPrompt, readUserPrompts, lastUserPrompt,
+  writeHandoff, readHandoff,
 } from '../lib/pm-guardrails.mjs';
 
-const SERVER_INFO = { name: 'pm-mcp', version: '1.2.0' };
+const SERVER_INFO = { name: 'pm-mcp', version: '1.3.0' };
 const PROTOCOL_VERSION = '2024-11-05';
 
 // ---------------------------------------------------------------------------
@@ -373,6 +376,61 @@ const TOOLS = [
     description: 'Return {kind, id, dir} for the active guardrail context — either an IN_PROGRESS project or the ephemeral session directory.',
     inputSchema: { type: 'object', properties: {} },
   },
+
+  // --- Guardrails: turn budget (upgrade F) -----------------------------------
+  {
+    name: 'pm_budget_set',
+    description: 'Cap the number of tool calls allowed for the current task. Warn at 80%, over-budget at 120%.',
+    inputSchema: {
+      type: 'object',
+      required: ['max_turns'],
+      properties: {
+        max_turns: { type: 'integer', minimum: 1 },
+        task_id: { type: 'string', pattern: '^T-[0-9]+$' },
+      },
+    },
+  },
+  {
+    name: 'pm_budget_status',
+    description: 'Return {active, used, max_turns, pct, status: ok|warn|over} for the current budget.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'pm_budget_clear',
+    description: 'Deactivate the turn budget (e.g. after legitimate scope expansion).',
+    inputSchema: { type: 'object', properties: {} },
+  },
+
+  // --- Guardrails: user-prompt archive (upgrade H) ---------------------------
+  {
+    name: 'pm_user_prompt_record',
+    description: 'Append the user\'s latest prompt to user-prompts.jsonl. Normally called by the UserPromptSubmit hook.',
+    inputSchema: {
+      type: 'object',
+      required: ['text'],
+      properties: { text: { type: 'string', minLength: 1 } },
+    },
+  },
+  {
+    name: 'pm_user_prompts_recent',
+    description: 'Return the last N user prompts archived in this context.',
+    inputSchema: {
+      type: 'object',
+      properties: { limit: { type: 'integer', minimum: 1, maximum: 50 } },
+    },
+  },
+
+  // --- Guardrails: compaction-safe handoff (upgrade G) -----------------------
+  {
+    name: 'pm_handoff_write',
+    description: 'Snapshot the active anchor, scope, done-when status, budget, last user prompt, and recent breadcrumbs to handoff.md so that a post-/compact or resumed session can re-anchor.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'pm_handoff_read',
+    description: 'Read the current handoff.md as raw markdown.',
+    inputSchema: { type: 'object', properties: {} },
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -644,6 +702,36 @@ const HANDLERS = {
   async pm_overengineering_scan(args) {
     const hits = detectOverengineering({ diff: requireArg(args, 'diff'), path: args.path });
     return { hits, count: hits.length };
+  },
+
+  // --- Round 3: budget + prompts + handoff ----------------------------------
+
+  async pm_budget_set(args) {
+    const rec = await setBudget({ max_turns: requireArg(args, 'max_turns'), task_id: args.task_id || null });
+    return { set: true, budget: rec };
+  },
+  async pm_budget_status() { return budgetStatus(); },
+  async pm_budget_clear() {
+    const cleared = await clearBudget();
+    return { cleared: !!cleared };
+  },
+
+  async pm_user_prompt_record(args) {
+    recordUserPrompt(requireArg(args, 'text'));
+    return { logged: true };
+  },
+  async pm_user_prompts_recent(args) {
+    const limit = args && args.limit ? Math.min(50, Math.max(1, args.limit)) : 10;
+    return { prompts: readUserPrompts({ limit }) };
+  },
+
+  async pm_handoff_write() {
+    const file = writeHandoff();
+    return { file };
+  },
+  async pm_handoff_read() {
+    const md = readHandoff();
+    return md ? { found: true, markdown: md } : { found: false };
   },
 };
 

--- a/plugins/project-management-plugin/mcp/pm-server.mjs
+++ b/plugins/project-management-plugin/mcp/pm-server.mjs
@@ -1,0 +1,493 @@
+#!/usr/bin/env node
+// Project Management Plugin — MCP Server (stdio, JSON-RPC).
+//
+// Exposes transactional tools over the state in .claude/projects/{id}/.
+// All mutations go through the shared pm-state library so locking, schema
+// validation, and atomic rename semantics apply uniformly.
+
+import { createInterface } from 'node:readline';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  projectDir,
+  listProjects,
+  readProject,
+  readTasks,
+  findTask,
+  mutateTasks,
+  mutateProject,
+  writeCheckpoint,
+  nextTask,
+  unblockedTasks,
+  loadValidators,
+  validateProject,
+  validateTasks,
+} from '../lib/pm-state.mjs';
+
+const SERVER_INFO = { name: 'pm-mcp', version: '1.0.0' };
+const PROTOCOL_VERSION = '2024-11-05';
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+const TOOLS = [
+  {
+    name: 'pm_list_projects',
+    description: 'List every project under .claude/projects/ with id, name, status, and task counts.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'pm_get_project',
+    description: 'Return the full project.json record for a given project id.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id'],
+      properties: {
+        project_id: { type: 'string', description: 'Project id (lowercase slug).' },
+      },
+    },
+  },
+  {
+    name: 'pm_get_tasks',
+    description: 'Return tasks.json for a project, optionally filtered by status, phase, or parent.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id'],
+      properties: {
+        project_id: { type: 'string' },
+        status: { type: 'string', description: 'Filter to a single status (e.g. PENDING).' },
+        phase_id: { type: 'string' },
+        parent_id: { type: 'string' },
+        limit: { type: 'integer', minimum: 1, maximum: 500 },
+      },
+    },
+  },
+  {
+    name: 'pm_get_task',
+    description: 'Fetch a single task by id.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id', 'task_id'],
+      properties: {
+        project_id: { type: 'string' },
+        task_id: { type: 'string', pattern: '^T-[0-9]+$' },
+      },
+    },
+  },
+  {
+    name: 'pm_next_task',
+    description: 'Return the highest-priority unblocked task. Uses the same scoring as /pm:work Phase 1.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id'],
+      properties: {
+        project_id: { type: 'string' },
+        focus_phase_id: { type: 'string' },
+        focus_epic_id: { type: 'string' },
+        focus_story_id: { type: 'string' },
+      },
+    },
+  },
+  {
+    name: 'pm_unblocked_tasks',
+    description: 'List all currently unblocked PENDING or RESEARCHED tasks.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id'],
+      properties: { project_id: { type: 'string' } },
+    },
+  },
+  {
+    name: 'pm_update_task_status',
+    description: 'Transition a task to a new status. Applies atomic write + schema validation.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id', 'task_id', 'status'],
+      properties: {
+        project_id: { type: 'string' },
+        task_id: { type: 'string', pattern: '^T-[0-9]+$' },
+        status: {
+          type: 'string',
+          enum: [
+            'PENDING', 'IN_RESEARCH', 'RESEARCHED', 'IN_PROGRESS',
+            'VALIDATING', 'PARENT', 'COMPLETE', 'BLOCKED', 'SKIPPED', 'FAILED',
+          ],
+        },
+        blocked_reason: { type: 'string' },
+        actual_minutes: { type: 'integer', minimum: 0 },
+        execution_notes: { type: 'string' },
+      },
+    },
+  },
+  {
+    name: 'pm_add_task',
+    description: 'Append a new task to tasks.json. Id may be omitted (auto-assigned).',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id', 'task'],
+      properties: {
+        project_id: { type: 'string' },
+        task: {
+          type: 'object',
+          description: 'Partial task record. id/status/priority/created_at are auto-filled when missing.',
+        },
+      },
+    },
+  },
+  {
+    name: 'pm_complete_task',
+    description: 'Mark a task COMPLETE. Records actual_minutes and completed_at.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id', 'task_id'],
+      properties: {
+        project_id: { type: 'string' },
+        task_id: { type: 'string', pattern: '^T-[0-9]+$' },
+        actual_minutes: { type: 'integer', minimum: 0 },
+        execution_notes: { type: 'string' },
+      },
+    },
+  },
+  {
+    name: 'pm_block_task',
+    description: 'Mark a task BLOCKED with a human-readable reason.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id', 'task_id', 'reason'],
+      properties: {
+        project_id: { type: 'string' },
+        task_id: { type: 'string', pattern: '^T-[0-9]+$' },
+        reason: { type: 'string', minLength: 3 },
+      },
+    },
+  },
+  {
+    name: 'pm_checkpoint',
+    description: 'Write a checkpoint snapshot of project.json + tasks.json to checkpoints/.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id'],
+      properties: { project_id: { type: 'string' } },
+    },
+  },
+  {
+    name: 'pm_get_research',
+    description: 'Read the cached research brief for a task, if any.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id', 'task_id'],
+      properties: {
+        project_id: { type: 'string' },
+        task_id: { type: 'string', pattern: '^T-[0-9]+$' },
+      },
+    },
+  },
+  {
+    name: 'pm_put_research',
+    description: 'Write a research brief to research/{task_id}.md and update the task record.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id', 'task_id', 'markdown'],
+      properties: {
+        project_id: { type: 'string' },
+        task_id: { type: 'string', pattern: '^T-[0-9]+$' },
+        markdown: { type: 'string', minLength: 1 },
+      },
+    },
+  },
+  {
+    name: 'pm_validate',
+    description: 'Validate project.json and tasks.json against the plugin schemas. Returns the list of errors.',
+    inputSchema: {
+      type: 'object',
+      required: ['project_id'],
+      properties: { project_id: { type: 'string' } },
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handlers
+// ---------------------------------------------------------------------------
+
+function requireArg(args, key) {
+  if (args[key] === undefined || args[key] === null || args[key] === '') {
+    throw new Error(`missing required argument: ${key}`);
+  }
+  return args[key];
+}
+
+function summary(project) {
+  const tasks = readTasks(project.id);
+  const counts = { total: 0, pending: 0, in_progress: 0, complete: 0, blocked: 0 };
+  for (const t of tasks.tasks || []) {
+    counts.total += 1;
+    if (t.status === 'PENDING') counts.pending += 1;
+    else if (t.status === 'IN_PROGRESS') counts.in_progress += 1;
+    else if (t.status === 'COMPLETE') counts.complete += 1;
+    else if (t.status === 'BLOCKED') counts.blocked += 1;
+  }
+  return {
+    id: project.id,
+    name: project.name,
+    status: project.status,
+    counts,
+  };
+}
+
+function autoTaskId(tasks) {
+  let maxN = 0;
+  for (const t of tasks) {
+    const m = (t.id || '').match(/^T-(\d+)$/);
+    if (m) maxN = Math.max(maxN, parseInt(m[1], 10));
+  }
+  return `T-${String(maxN + 1).padStart(3, '0')}`;
+}
+
+const HANDLERS = {
+  async pm_list_projects() {
+    return listProjects().map((p) => summary(p.project));
+  },
+
+  async pm_get_project(args) {
+    const project = readProject(requireArg(args, 'project_id'));
+    if (!project) throw new Error(`project not found: ${args.project_id}`);
+    return project;
+  },
+
+  async pm_get_tasks(args) {
+    const id = requireArg(args, 'project_id');
+    let tasks = (readTasks(id).tasks || []).slice();
+    if (args.status) tasks = tasks.filter((t) => t.status === args.status);
+    if (args.phase_id) tasks = tasks.filter((t) => t.phase_id === args.phase_id || t.phase === args.phase_id);
+    if (args.parent_id) tasks = tasks.filter((t) => t.parent_id === args.parent_id);
+    if (args.limit) tasks = tasks.slice(0, args.limit);
+    return { project_id: id, count: tasks.length, tasks };
+  },
+
+  async pm_get_task(args) {
+    const id = requireArg(args, 'project_id');
+    const taskId = requireArg(args, 'task_id');
+    const task = findTask(readTasks(id), taskId);
+    if (!task) throw new Error(`task not found: ${taskId}`);
+    return task;
+  },
+
+  async pm_next_task(args) {
+    const id = requireArg(args, 'project_id');
+    const focus = {
+      phase_id: args.focus_phase_id,
+      epic_id: args.focus_epic_id,
+      story_id: args.focus_story_id,
+    };
+    const hasFocus = Object.values(focus).some(Boolean);
+    const task = nextTask(readTasks(id), hasFocus ? { focus } : {});
+    return { task };
+  },
+
+  async pm_unblocked_tasks(args) {
+    const id = requireArg(args, 'project_id');
+    const ready = unblockedTasks(readTasks(id));
+    return { count: ready.length, tasks: ready };
+  },
+
+  async pm_update_task_status(args) {
+    const id = requireArg(args, 'project_id');
+    const taskId = requireArg(args, 'task_id');
+    const status = requireArg(args, 'status');
+    const result = await mutateTasks(id, (tasks) => {
+      const task = (tasks.tasks || []).find((t) => t.id === taskId);
+      if (!task) throw new Error(`task not found: ${taskId}`);
+      task.status = status;
+      if (status === 'BLOCKED') {
+        if (!args.blocked_reason) throw new Error('blocked_reason is required when status=BLOCKED');
+        task.blocked_reason = args.blocked_reason;
+      } else if (task.blocked_reason && status !== 'BLOCKED') {
+        task.blocked_reason = null;
+      }
+      if (status === 'COMPLETE') {
+        task.completed_at = new Date().toISOString();
+        if (args.actual_minutes !== undefined) task.actual_minutes = args.actual_minutes;
+      }
+      if (args.execution_notes) {
+        task.execution_notes = task.execution_notes
+          ? `${task.execution_notes}\n${args.execution_notes}`
+          : args.execution_notes;
+      }
+      return tasks;
+    });
+    return { updated: taskId, status, tasks_count: (result?.tasks || []).length };
+  },
+
+  async pm_add_task(args) {
+    const id = requireArg(args, 'project_id');
+    const newTask = requireArg(args, 'task');
+    if (typeof newTask !== 'object' || Array.isArray(newTask)) throw new Error('task must be an object');
+    await mutateTasks(id, (tasks) => {
+      const arr = tasks.tasks || [];
+      const taskId = newTask.id || autoTaskId(arr);
+      if (arr.some((t) => t.id === taskId)) throw new Error(`task id already exists: ${taskId}`);
+      const filled = {
+        id: taskId,
+        title: newTask.title || 'Untitled task',
+        description: newTask.description || '',
+        level: newTask.level || 'task',
+        status: newTask.status || 'PENDING',
+        priority: newTask.priority || 'MEDIUM',
+        dependencies: newTask.dependencies || [],
+        completion_criteria: newTask.completion_criteria || [],
+        created_at: newTask.created_at || new Date().toISOString(),
+        ...newTask,
+      };
+      arr.push(filled);
+      tasks.tasks = arr;
+      return tasks;
+    });
+    return { added: newTask.id || 'auto' };
+  },
+
+  async pm_complete_task(args) {
+    return HANDLERS.pm_update_task_status({
+      project_id: args.project_id,
+      task_id: args.task_id,
+      status: 'COMPLETE',
+      actual_minutes: args.actual_minutes,
+      execution_notes: args.execution_notes,
+    });
+  },
+
+  async pm_block_task(args) {
+    return HANDLERS.pm_update_task_status({
+      project_id: args.project_id,
+      task_id: args.task_id,
+      status: 'BLOCKED',
+      blocked_reason: requireArg(args, 'reason'),
+    });
+  },
+
+  async pm_checkpoint(args) {
+    const id = requireArg(args, 'project_id');
+    const file = writeCheckpoint(id);
+    if (!file) throw new Error(`project not found: ${id}`);
+    return { checkpoint: file };
+  },
+
+  async pm_get_research(args) {
+    const id = requireArg(args, 'project_id');
+    const taskId = requireArg(args, 'task_id');
+    const file = join(projectDir(id), 'research', `${taskId}.md`);
+    if (!existsSync(file)) return { project_id: id, task_id: taskId, found: false };
+    return { project_id: id, task_id: taskId, found: true, markdown: readFileSync(file, 'utf8') };
+  },
+
+  async pm_put_research(args) {
+    const id = requireArg(args, 'project_id');
+    const taskId = requireArg(args, 'task_id');
+    const markdown = requireArg(args, 'markdown');
+    const dir = join(projectDir(id), 'research');
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, `${taskId}.md`);
+    writeFileSync(file, markdown);
+    await mutateTasks(id, (tasks) => {
+      const task = (tasks.tasks || []).find((t) => t.id === taskId);
+      if (task) task.research_file = `research/${taskId}.md`;
+      return tasks;
+    }).catch(() => null); // not fatal if task doesn't exist yet
+    return { file };
+  },
+
+  async pm_validate(args) {
+    const id = requireArg(args, 'project_id');
+    const project = readProject(id);
+    const tasks = readTasks(id);
+    const project_errors = project ? validateProject(project) : ['project.json missing'];
+    const tasks_errors = validateTasks(tasks);
+    return { project_errors, tasks_errors };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// JSON-RPC dispatch
+// ---------------------------------------------------------------------------
+
+async function handleRequest(request) {
+  const { method, params, id } = request;
+
+  if (method === 'initialize') {
+    return {
+      jsonrpc: '2.0', id,
+      result: {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: SERVER_INFO,
+      },
+    };
+  }
+
+  if (method === 'tools/list') {
+    return { jsonrpc: '2.0', id, result: { tools: TOOLS } };
+  }
+
+  if (method === 'tools/call') {
+    const { name, arguments: args = {} } = params || {};
+    const handler = HANDLERS[name];
+    if (!handler) {
+      return {
+        jsonrpc: '2.0', id,
+        error: { code: -32601, message: `unknown tool: ${name}` },
+      };
+    }
+    try {
+      const result = await handler(args);
+      return {
+        jsonrpc: '2.0', id,
+        result: {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        },
+      };
+    } catch (err) {
+      return {
+        jsonrpc: '2.0', id,
+        error: { code: -32000, message: err.message || String(err) },
+      };
+    }
+  }
+
+  return {
+    jsonrpc: '2.0', id,
+    error: { code: -32601, message: `unknown method: ${method}` },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// stdio transport
+// ---------------------------------------------------------------------------
+
+async function main() {
+  await loadValidators();
+  const rl = createInterface({ input: process.stdin, terminal: false });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let request;
+    try {
+      request = JSON.parse(trimmed);
+    } catch {
+      process.stdout.write(JSON.stringify({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: 'parse error' },
+      }) + '\n');
+      continue;
+    }
+    const response = await handleRequest(request);
+    process.stdout.write(JSON.stringify(response) + '\n');
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`pm-mcp fatal: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/plugins/project-management-plugin/mcp/pm-server.mjs
+++ b/plugins/project-management-plugin/mcp/pm-server.mjs
@@ -24,8 +24,16 @@ import {
   validateProject,
   validateTasks,
 } from '../lib/pm-state.mjs';
+import {
+  activeContextSummary,
+  readAnchor, setAnchor, clearAnchor, formatAnchorReminder,
+  readScope, setScope, addScopePatterns, removeScopePatterns, recordOverride, isInScope,
+  readDoneWhen, setDoneWhen, markCriterionMet, unmetCriteria,
+  recordBreadcrumb, readBreadcrumbs, analyzeDrift,
+  detectOverengineering,
+} from '../lib/pm-guardrails.mjs';
 
-const SERVER_INFO = { name: 'pm-mcp', version: '1.0.0' };
+const SERVER_INFO = { name: 'pm-mcp', version: '1.2.0' };
 const PROTOCOL_VERSION = '2024-11-05';
 
 // ---------------------------------------------------------------------------
@@ -205,6 +213,165 @@ const TOOLS = [
       required: ['project_id'],
       properties: { project_id: { type: 'string' } },
     },
+  },
+
+  // --- Guardrails: focus anchor ----------------------------------------------
+  {
+    name: 'pm_anchor_set',
+    description: 'Set the active focus anchor ("DO X, DON\'T Y"). Every new user turn will have this reminder injected so Claude cannot drift from it.',
+    inputSchema: {
+      type: 'object',
+      required: ['do'],
+      properties: {
+        do: { type: 'string', minLength: 3, description: 'One sentence: what Claude is committing to finish.' },
+        dont: { type: 'string', description: 'One sentence: what Claude must not touch.' },
+        task_id: { type: 'string', pattern: '^T-[0-9]+$', description: 'Optional — bind the anchor to a specific task id.' },
+      },
+    },
+  },
+  {
+    name: 'pm_anchor_get',
+    description: 'Return the current focus anchor, or null if none is active.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'pm_anchor_clear',
+    description: 'Deactivate the focus anchor (e.g. after the task is complete).',
+    inputSchema: { type: 'object', properties: {} },
+  },
+
+  // --- Guardrails: scope lock ------------------------------------------------
+  {
+    name: 'pm_scope_set',
+    description: 'Replace the scope allowlist with a new set of glob patterns (e.g. ["src/auth/**","tests/auth/**"]).',
+    inputSchema: {
+      type: 'object',
+      required: ['patterns'],
+      properties: {
+        patterns: { type: 'array', items: { type: 'string', minLength: 1 } },
+      },
+    },
+  },
+  {
+    name: 'pm_scope_add',
+    description: 'Append one or more glob patterns to the scope allowlist.',
+    inputSchema: {
+      type: 'object',
+      required: ['patterns'],
+      properties: { patterns: { type: 'array', items: { type: 'string' } } },
+    },
+  },
+  {
+    name: 'pm_scope_remove',
+    description: 'Remove glob patterns from the scope allowlist.',
+    inputSchema: {
+      type: 'object',
+      required: ['patterns'],
+      properties: { patterns: { type: 'array', items: { type: 'string' } } },
+    },
+  },
+  {
+    name: 'pm_scope_check',
+    description: 'Check whether a path is currently in scope. Returns {in_scope, matched_pattern, active}.',
+    inputSchema: {
+      type: 'object',
+      required: ['path'],
+      properties: { path: { type: 'string' } },
+    },
+  },
+  {
+    name: 'pm_scope_override',
+    description: 'Record a justified override for an out-of-scope edit. The override is appended to the drift ledger — scope stays unchanged.',
+    inputSchema: {
+      type: 'object',
+      required: ['path', 'reason'],
+      properties: {
+        path: { type: 'string' },
+        reason: { type: 'string', minLength: 3 },
+      },
+    },
+  },
+  {
+    name: 'pm_scope_status',
+    description: 'Return the current scope record (allowlist + override ledger).',
+    inputSchema: { type: 'object', properties: {} },
+  },
+
+  // --- Guardrails: done-when contract ----------------------------------------
+  {
+    name: 'pm_done_when_set',
+    description: 'Declare the list of binary-testable completion criteria that must have evidence before Claude may declare the session done.',
+    inputSchema: {
+      type: 'object',
+      required: ['criteria'],
+      properties: {
+        criteria: { type: 'array', items: { type: 'string', minLength: 5 }, minItems: 1 },
+        task_id: { type: 'string', pattern: '^T-[0-9]+$' },
+      },
+    },
+  },
+  {
+    name: 'pm_done_when_met',
+    description: 'Mark one criterion as met with an evidence line (e.g. a test command output). Refuses without evidence.',
+    inputSchema: {
+      type: 'object',
+      required: ['id', 'evidence'],
+      properties: {
+        id: { type: 'string', description: 'Criterion id (c1, c2, ...) or exact text.' },
+        evidence: { type: 'string', minLength: 3, description: 'Short proof line (command + exit code, URL + status, file path).' },
+      },
+    },
+  },
+  {
+    name: 'pm_done_when_status',
+    description: 'Return the current done-when record including which criteria are met and which are unmet.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+
+  // --- Guardrails: breadcrumbs + drift ---------------------------------------
+  {
+    name: 'pm_breadcrumb',
+    description: 'Append a breadcrumb entry to the drift trail. Normally called by hooks — rarely by hand.',
+    inputSchema: {
+      type: 'object',
+      required: ['tool'],
+      properties: {
+        turn: { type: 'integer' },
+        tool: { type: 'string' },
+        target: { type: 'string' },
+        task_id: { type: 'string' },
+        scope_ok: { type: 'boolean' },
+        criterion_hint: { type: 'string' },
+        overengineering_hits: { type: 'array', items: { type: 'string' } },
+      },
+    },
+  },
+  {
+    name: 'pm_drift_report',
+    description: 'Analyze the breadcrumb trail against the active anchor/scope/done-when and return a drift classification.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        since: { type: 'string', description: 'ISO timestamp — only consider breadcrumbs newer than this.' },
+      },
+    },
+  },
+  {
+    name: 'pm_overengineering_scan',
+    description: 'Scan a unified diff against the overengineering ruleset and return any hits.',
+    inputSchema: {
+      type: 'object',
+      required: ['diff'],
+      properties: {
+        diff: { type: 'string', minLength: 1 },
+        path: { type: 'string' },
+      },
+    },
+  },
+  {
+    name: 'pm_active_context',
+    description: 'Return {kind, id, dir} for the active guardrail context — either an IN_PROGRESS project or the ephemeral session directory.',
+    inputSchema: { type: 'object', properties: {} },
   },
 ];
 
@@ -405,6 +572,78 @@ const HANDLERS = {
     const project_errors = project ? validateProject(project) : ['project.json missing'];
     const tasks_errors = validateTasks(tasks);
     return { project_errors, tasks_errors };
+  },
+
+  // --- Guardrail handlers ---------------------------------------------------
+
+  async pm_active_context() { return activeContextSummary(); },
+
+  async pm_anchor_set(args) {
+    const rec = await setAnchor({ doItem: requireArg(args, 'do'), dontItem: args.dont, task_id: args.task_id || null });
+    return { set: true, anchor: rec, reminder: formatAnchorReminder(rec) };
+  },
+  async pm_anchor_get() {
+    const anchor = readAnchor();
+    return { anchor, reminder: formatAnchorReminder(anchor) };
+  },
+  async pm_anchor_clear() {
+    const cleared = await clearAnchor();
+    return { cleared: !!cleared, anchor: cleared };
+  },
+
+  async pm_scope_set(args) {
+    const rec = await setScope(requireArg(args, 'patterns'));
+    return { active: rec.active, allowlist: rec.allowlist };
+  },
+  async pm_scope_add(args) {
+    const rec = await addScopePatterns(requireArg(args, 'patterns'));
+    return { active: rec.active, allowlist: rec.allowlist };
+  },
+  async pm_scope_remove(args) {
+    const rec = await removeScopePatterns(requireArg(args, 'patterns'));
+    return { active: rec.active, allowlist: rec.allowlist };
+  },
+  async pm_scope_check(args) {
+    const scope = readScope();
+    if (!scope.active) return { in_scope: true, active: false };
+    const pathArg = requireArg(args, 'path');
+    const inScope = isInScope(pathArg, { allowlist: scope.allowlist });
+    const matched = inScope ? scope.allowlist.find((p) => isInScope(pathArg, { allowlist: [p] })) : null;
+    return { in_scope: inScope, matched_pattern: matched, active: true };
+  },
+  async pm_scope_override(args) {
+    await recordOverride({ path: requireArg(args, 'path'), reason: requireArg(args, 'reason') });
+    return { recorded: true };
+  },
+  async pm_scope_status() {
+    return readScope();
+  },
+
+  async pm_done_when_set(args) {
+    const rec = await setDoneWhen({ criteria: requireArg(args, 'criteria'), task_id: args.task_id || null });
+    return { set: true, criteria_count: rec.criteria.length };
+  },
+  async pm_done_when_met(args) {
+    const hit = await markCriterionMet({ id: requireArg(args, 'id'), evidence: requireArg(args, 'evidence') });
+    return { marked: true, criterion: hit };
+  },
+  async pm_done_when_status() {
+    const rec = readDoneWhen();
+    if (!rec) return { active: false };
+    const unmet = unmetCriteria(rec);
+    return { active: true, total: rec.criteria.length, met: rec.criteria.length - unmet.length, unmet };
+  },
+
+  async pm_breadcrumb(args) {
+    recordBreadcrumb(args || {});
+    return { logged: true };
+  },
+  async pm_drift_report(args) {
+    return analyzeDrift({ since: args && args.since ? args.since : null });
+  },
+  async pm_overengineering_scan(args) {
+    const hits = detectOverengineering({ diff: requireArg(args, 'diff'), path: args.path });
+    return { hits, count: hits.length };
   },
 };
 

--- a/plugins/project-management-plugin/schemas/project.schema.json
+++ b/plugins/project-management-plugin/schemas/project.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/markus41/claude/plugins/project-management-plugin/schemas/project.schema.json",
   "title": "Project",
-  "description": "Schema for a project-management-plugin project state file",
+  "description": "Schema for a project-management-plugin project state file (.claude/projects/{id}/project.json)",
   "type": "object",
   "required": [
     "id",
@@ -12,10 +12,9 @@
     "status",
     "phases",
     "created_at",
-    "updated_at",
-    "metadata"
+    "updated_at"
   ],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "id": {
       "type": "string",
@@ -39,7 +38,8 @@
         "software",
         "content",
         "research",
-        "business"
+        "business",
+        "auto"
       ]
     },
     "status": {
@@ -48,10 +48,24 @@
       "enum": [
         "INITIALIZING",
         "READY",
+        "PLANNED",
         "IN_PROGRESS",
         "PAUSED",
+        "BLOCKED",
         "COMPLETE",
         "CANCELLED"
+      ]
+    },
+    "depth": {
+      "type": "string",
+      "description": "Decomposition depth preset selected during initialization",
+      "enum": [
+        "quick",
+        "standard",
+        "thorough",
+        "shallow",
+        "deep",
+        "exhaustive"
       ]
     },
     "phases": {
@@ -62,23 +76,19 @@
         "required": [
           "id",
           "name",
-          "status",
-          "task_ids"
+          "status"
         ],
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "id": {
             "type": "string",
-            "description": "Phase identifier (e.g. 'phase-1')",
             "pattern": "^[a-z0-9-]+$"
           },
           "name": {
-            "type": "string",
-            "description": "Display name of the phase"
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "description": "What this phase accomplishes"
+            "type": "string"
           },
           "status": {
             "type": "string",
@@ -91,12 +101,121 @@
           },
           "task_ids": {
             "type": "array",
-            "description": "Ordered list of task IDs that belong to this phase",
             "items": {
               "type": "string",
               "pattern": "^T-[0-9]+$"
             }
           }
+        }
+      }
+    },
+    "tech_stack": {
+      "type": [
+        "object",
+        "array",
+        "null"
+      ],
+      "description": "Languages, frameworks, databases, and external services as captured by /pm:init"
+    },
+    "team": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "Team size, roles, and workflow notes from /pm:init"
+    },
+    "workflow": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "Git workflow, review process, and deployment model from /pm:init"
+    },
+    "security": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "compliance": {
+      "type": [
+        "object",
+        "array",
+        "null"
+      ]
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": [
+          "string",
+          "object"
+        ]
+      }
+    },
+    "known_unknowns": {
+      "type": "array",
+      "items": {
+        "type": [
+          "string",
+          "object"
+        ]
+      }
+    },
+    "focus_scope": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "Narrowed scope (phase/epic/story) set by /pm:focus"
+    },
+    "loop_stats": {
+      "type": "object",
+      "description": "Autonomous loop safety counters",
+      "properties": {
+        "total_loop_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "consecutive_zero_progress": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_loop_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
+    "task_counts": {
+      "type": "object",
+      "properties": {
+        "phases": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "epics": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stories": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tasks": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "micro_tasks": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     },
@@ -109,11 +228,10 @@
       "required": [
         "platform"
       ],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "platform": {
           "type": "string",
-          "description": "The PM platform this project is synced with",
           "enum": [
             "github",
             "linear",
@@ -123,6 +241,7 @@
             "clickup",
             "monday",
             "todoist",
+            "jira",
             "local"
           ]
         },
@@ -130,55 +249,86 @@
           "type": [
             "string",
             "null"
-          ],
-          "description": "The ID of the corresponding project/board/space in the external platform"
+          ]
         },
         "last_sync_at": {
           "type": [
             "string",
             "null"
           ],
-          "description": "ISO 8601 timestamp of the most recent successful sync",
           "format": "date-time"
         }
       }
     },
     "created_at": {
       "type": "string",
-      "description": "ISO 8601 timestamp when the project was created",
       "format": "date-time"
     },
     "updated_at": {
       "type": "string",
-      "description": "ISO 8601 timestamp when the project was last modified",
+      "format": "date-time"
+    },
+    "planned_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "completed_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "last_session_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "total_session_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "total_tasks_completed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "review_passed_at": {
+      "type": [
+        "string",
+        "null"
+      ],
       "format": "date-time"
     },
     "metadata": {
       "type": "object",
       "description": "Runtime and configuration metadata for the project",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "depth_preset": {
           "type": "string",
-          "description": "Decomposition depth preset selected during initialization",
           "enum": [
             "shallow",
             "standard",
             "deep",
-            "exhaustive"
+            "exhaustive",
+            "quick",
+            "thorough"
           ]
         },
         "loop_count": {
           "type": "integer",
-          "description": "Number of autonomous loop iterations completed",
           "minimum": 0
         },
         "last_checkpoint": {
           "type": [
             "string",
             "null"
-          ],
-          "description": "Relative path to the most recent checkpoint file within the project state directory"
+          ]
         }
       }
     }

--- a/plugins/project-management-plugin/schemas/task.schema.json
+++ b/plugins/project-management-plugin/schemas/task.schema.json
@@ -7,48 +7,74 @@
   "required": [
     "id",
     "title",
-    "description",
-    "phase",
     "level",
     "status",
     "priority",
-    "estimate_minutes",
     "dependencies",
-    "subtasks",
     "completion_criteria",
-    "tags",
     "created_at"
   ],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "id": {
       "type": "string",
-      "description": "Unique task identifier in T-{number} format",
+      "description": "Unique task identifier in T-{number} format (numbers may be zero-padded)",
       "pattern": "^T-[0-9]+$"
     },
     "title": {
       "type": "string",
-      "description": "Short, action-oriented task title",
       "minLength": 3
     },
     "description": {
-      "type": "string",
-      "description": "Detailed description of what the task must accomplish and any relevant context"
+      "type": "string"
     },
     "phase": {
-      "type": "string",
-      "description": "ID of the parent phase this task belongs to",
-      "pattern": "^[a-z0-9-]+$"
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "ID of the parent phase (kept for backwards compatibility)",
+      "pattern": "^[a-z0-9-]*$"
+    },
+    "phase_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-z0-9-]*$"
+    },
+    "epic_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^T-[0-9]+$"
+    },
+    "story_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^T-[0-9]+$"
+    },
+    "parent_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^T-[0-9]+$"
     },
     "level": {
       "type": "string",
-      "description": "Granularity level in the 5-level decomposition hierarchy",
+      "description": "Granularity level in the decomposition hierarchy",
       "enum": [
+        "phase",
         "epic",
         "story",
         "task",
         "subtask",
-        "micro"
+        "micro",
+        "micro-task"
       ]
     },
     "status": {
@@ -60,13 +86,16 @@
         "RESEARCHED",
         "IN_PROGRESS",
         "VALIDATING",
+        "PARENT",
         "COMPLETE",
-        "BLOCKED"
+        "BLOCKED",
+        "SKIPPED",
+        "FAILED",
+        "CANCELLED"
       ]
     },
     "priority": {
       "type": "string",
-      "description": "Relative importance used for autonomous loop scheduling",
       "enum": [
         "CRITICAL",
         "HIGH",
@@ -75,8 +104,10 @@
       ]
     },
     "estimate_minutes": {
-      "type": "integer",
-      "description": "Original time estimate in minutes (1–480 / up to 8 hours)",
+      "type": [
+        "integer",
+        "null"
+      ],
       "minimum": 1,
       "maximum": 480
     },
@@ -85,12 +116,10 @@
         "integer",
         "null"
       ],
-      "description": "Actual time taken in minutes; null until the task is COMPLETE",
       "minimum": 0
     },
     "dependencies": {
       "type": "array",
-      "description": "IDs of tasks that must reach COMPLETE before this task can begin",
       "items": {
         "type": "string",
         "pattern": "^T-[0-9]+$"
@@ -99,7 +128,6 @@
     },
     "subtasks": {
       "type": "array",
-      "description": "IDs of child tasks decomposed from this task",
       "items": {
         "type": "string",
         "pattern": "^T-[0-9]+$"
@@ -108,47 +136,91 @@
     },
     "completion_criteria": {
       "type": "array",
-      "description": "Unambiguous, binary-testable acceptance criteria; each item must be independently verifiable",
       "items": {
         "type": "string",
-        "minLength": 10
+        "minLength": 5
       },
-      "minItems": 1,
-      "maxItems": 7
+      "minItems": 0,
+      "maxItems": 12
     },
     "research_file": {
       "type": [
         "string",
         "null"
-      ],
-      "description": "Relative path to the research brief file (e.g. research/T-42.md) within the project state directory; null until research phase is complete"
+      ]
+    },
+    "research_cache_key": {
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "external_id": {
       "type": [
         "string",
         "null"
-      ],
-      "description": "The ID or key of the corresponding issue/card/item in the connected PM platform; null when no PM integration is active"
+      ]
     },
     "tags": {
       "type": "array",
-      "description": "Freeform labels for filtering and grouping (e.g. 'frontend', 'auth', 'breaking-change')",
       "items": {
         "type": "string",
         "minLength": 1
       },
       "uniqueItems": true
     },
+    "agent_assignment": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "risk_score": {
+      "type": [
+        "integer",
+        "number",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 10
+    },
+    "risk_breakdown": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "on_critical_path": {
+      "type": "boolean"
+    },
+    "requires_hitl": {
+      "type": "boolean"
+    },
+    "validation_results": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "validation_failure_count": {
+      "type": "integer",
+      "minimum": 0
+    },
     "blocked_reason": {
       "type": [
         "string",
         "null"
-      ],
-      "description": "Human-readable explanation of why the task is BLOCKED; null for all other statuses"
+      ]
+    },
+    "execution_notes": {
+      "type": [
+        "string",
+        "array",
+        "null"
+      ]
     },
     "created_at": {
       "type": "string",
-      "description": "ISO 8601 timestamp when this task was created",
       "format": "date-time"
     },
     "completed_at": {
@@ -156,7 +228,6 @@
         "string",
         "null"
       ],
-      "description": "ISO 8601 timestamp when the task reached COMPLETE status; null until then",
       "format": "date-time"
     }
   }

--- a/plugins/project-management-plugin/tests/fixtures/valid-project.json
+++ b/plugins/project-management-plugin/tests/fixtures/valid-project.json
@@ -1,0 +1,20 @@
+{
+  "id": "fixture-alpha",
+  "name": "Fixture Alpha",
+  "goal": "A minimal but valid project used for unit tests.",
+  "type": "software",
+  "status": "PLANNED",
+  "phases": [
+    {
+      "id": "phase-1",
+      "name": "Foundation",
+      "status": "PENDING",
+      "task_ids": [
+        "T-001",
+        "T-002"
+      ]
+    }
+  ],
+  "created_at": "2026-04-23T00:00:00Z",
+  "updated_at": "2026-04-23T00:00:00Z"
+}

--- a/plugins/project-management-plugin/tests/fixtures/valid-tasks.json
+++ b/plugins/project-management-plugin/tests/fixtures/valid-tasks.json
@@ -1,0 +1,57 @@
+{
+  "version": 1,
+  "project_id": "fixture-alpha",
+  "tasks": [
+    {
+      "id": "T-001",
+      "title": "Set up repo scaffolding",
+      "description": "Create the initial project structure.",
+      "level": "task",
+      "status": "COMPLETE",
+      "priority": "HIGH",
+      "estimate_minutes": 15,
+      "dependencies": [],
+      "completion_criteria": [
+        "repository has package.json and README"
+      ],
+      "on_critical_path": true,
+      "requires_hitl": false,
+      "created_at": "2026-04-23T00:00:00Z",
+      "completed_at": "2026-04-23T00:15:00Z"
+    },
+    {
+      "id": "T-002",
+      "title": "Wire up first route",
+      "description": "Serve a hello-world endpoint.",
+      "level": "task",
+      "status": "PENDING",
+      "priority": "CRITICAL",
+      "estimate_minutes": 20,
+      "dependencies": [
+        "T-001"
+      ],
+      "completion_criteria": [
+        "GET /hello returns 200 with body 'ok'"
+      ],
+      "on_critical_path": true,
+      "requires_hitl": false,
+      "created_at": "2026-04-23T00:10:00Z"
+    },
+    {
+      "id": "T-003",
+      "title": "Docs stub",
+      "description": "Scaffold docs.",
+      "level": "task",
+      "status": "PENDING",
+      "priority": "LOW",
+      "estimate_minutes": 10,
+      "dependencies": [],
+      "completion_criteria": [
+        "docs/index.md exists"
+      ],
+      "on_critical_path": false,
+      "requires_hitl": false,
+      "created_at": "2026-04-23T00:11:00Z"
+    }
+  ]
+}

--- a/plugins/project-management-plugin/tests/pm-guardrails-mcp.test.mjs
+++ b/plugins/project-management-plugin/tests/pm-guardrails-mcp.test.mjs
@@ -1,0 +1,241 @@
+// Integration tests for the guardrail tools on the pm-mcp stdio server.
+// Spawns pm-server.mjs and drives it end-to-end.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const SERVER = join(HERE, '..', 'mcp', 'pm-server.mjs');
+
+function setupTemp() { return mkdtempSync(join(tmpdir(), 'pm-guard-mcp-')); }
+
+function startServer(tmp) {
+  const child = spawn('node', [SERVER], {
+    env: { ...process.env, CLAUDE_PROJECT_DIR: tmp },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let buffer = '';
+  const responses = [];
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk.toString('utf8');
+    let nl;
+    while ((nl = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      if (line) { try { responses.push(JSON.parse(line)); } catch {} }
+    }
+  });
+  const call = async (method, params = {}, id) => {
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    for (let i = 0; i < 400; i++) {
+      const hit = responses.find((r) => r.id === id);
+      if (hit) return hit;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    throw new Error(`timeout waiting for response id=${id}`);
+  };
+  return { child, call };
+}
+
+const textToJSON = (r) => JSON.parse(r.result.content[0].text);
+
+test('pm_anchor_set + pm_anchor_get round-trip through MCP', async () => {
+  const tmp = setupTemp();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    const set = await srv.call('tools/call', {
+      name: 'pm_anchor_set',
+      arguments: { do: 'ship /pm:anchor', dont: 'touch UI' },
+    }, 2);
+    assert.equal(set.error, undefined);
+    const got = await srv.call('tools/call', { name: 'pm_anchor_get', arguments: {} }, 3);
+    const payload = textToJSON(got);
+    assert.equal(payload.anchor.do, 'ship /pm:anchor');
+    assert.ok(payload.reminder.includes('DO: ship /pm:anchor'));
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm_scope_set + pm_scope_check blocks out-of-scope paths', async () => {
+  const tmp = setupTemp();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    await srv.call('tools/call', {
+      name: 'pm_scope_set',
+      arguments: { patterns: ['src/auth/**', 'tests/auth/**'] },
+    }, 2);
+    const inScope = textToJSON(await srv.call('tools/call', {
+      name: 'pm_scope_check',
+      arguments: { path: join(tmp, 'src/auth/refresh.ts') },
+    }, 3));
+    assert.equal(inScope.in_scope, true);
+    assert.equal(inScope.matched_pattern, 'src/auth/**');
+
+    const outOfScope = textToJSON(await srv.call('tools/call', {
+      name: 'pm_scope_check',
+      arguments: { path: join(tmp, 'src/ui/Login.tsx') },
+    }, 4));
+    assert.equal(outOfScope.in_scope, false);
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm_scope_override appends to drift ledger, leaves allowlist intact', async () => {
+  const tmp = setupTemp();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    await srv.call('tools/call', { name: 'pm_scope_set', arguments: { patterns: ['src/auth/**'] } }, 2);
+    await srv.call('tools/call', {
+      name: 'pm_scope_override',
+      arguments: { path: 'src/ui/Login.tsx', reason: 'auth endpoint needs new login button' },
+    }, 3);
+    const status = textToJSON(await srv.call('tools/call', { name: 'pm_scope_status', arguments: {} }, 4));
+    assert.equal(status.overrides.length, 1);
+    assert.deepEqual(status.allowlist, ['src/auth/**']);
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm_done_when_set + pm_done_when_met updates the met count', async () => {
+  const tmp = setupTemp();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    await srv.call('tools/call', {
+      name: 'pm_done_when_set',
+      arguments: { criteria: ['tests pass', 'README updated'] },
+    }, 2);
+
+    const before = textToJSON(await srv.call('tools/call', { name: 'pm_done_when_status', arguments: {} }, 3));
+    assert.equal(before.met, 0);
+    assert.equal(before.unmet.length, 2);
+
+    await srv.call('tools/call', {
+      name: 'pm_done_when_met',
+      arguments: { id: 'c1', evidence: 'pnpm test -> exit 0' },
+    }, 4);
+
+    const after = textToJSON(await srv.call('tools/call', { name: 'pm_done_when_status', arguments: {} }, 5));
+    assert.equal(after.met, 1);
+    assert.equal(after.unmet.length, 1);
+    assert.equal(after.unmet[0].id, 'c2');
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm_done_when_met rejects blank evidence at the MCP boundary', async () => {
+  const tmp = setupTemp();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    await srv.call('tools/call', { name: 'pm_done_when_set', arguments: { criteria: ['x y z'] } }, 2);
+    const resp = await srv.call('tools/call', {
+      name: 'pm_done_when_met',
+      arguments: { id: 'c1', evidence: '' },
+    }, 3);
+    assert.ok(resp.error || /evidence/i.test(JSON.stringify(resp)));
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm_overengineering_scan flags the rule from a crafted diff', async () => {
+  const tmp = setupTemp();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    const diff = '+// line 1\n+// line 2\n+// line 3\n+const x=1;';
+    const resp = textToJSON(await srv.call('tools/call', {
+      name: 'pm_overengineering_scan',
+      arguments: { diff, path: 'src/a.ts' },
+    }, 2));
+    assert.ok(resp.count >= 1);
+    assert.equal(resp.hits[0].tag, 'multiline-comment');
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm_breadcrumb + pm_drift_report round-trip', async () => {
+  const tmp = setupTemp();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    await srv.call('tools/call', { name: 'pm_breadcrumb', arguments: { tool: 'Edit', target: 'src/a.ts' } }, 2);
+    await srv.call('tools/call', { name: 'pm_breadcrumb', arguments: { tool: 'Bash', target: 'pnpm test:pm-plugin' } }, 3);
+    const drift = textToJSON(await srv.call('tools/call', { name: 'pm_drift_report', arguments: {} }, 4));
+    assert.equal(drift.totals.turns, 2);
+    assert.ok(drift.totals.advancing_turns >= 1);
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm_active_context returns a session kind when no project is IN_PROGRESS', async () => {
+  const tmp = setupTemp();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    const ctx = textToJSON(await srv.call('tools/call', { name: 'pm_active_context', arguments: {} }, 2));
+    assert.equal(ctx.kind, 'session');
+    assert.ok(ctx.dir.includes('.claude/pm-session') || ctx.dir.includes('.claude\\pm-session'));
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+// ---------------------------------------------------------------------------
+// Hook-level end-to-end: scope-guard.sh must block out-of-scope writes
+// ---------------------------------------------------------------------------
+
+test('scope-guard.sh blocks out-of-scope writes and approves in-scope ones', async () => {
+  const tmp = setupTemp();
+  try {
+    // Arrange: write a scope file via the lib directly.
+    process.env.CLAUDE_PROJECT_DIR = tmp;
+    const { setScope } = await import('../lib/pm-guardrails.mjs');
+    await setScope(['src/auth/**']);
+
+    const SCRIPT = join(HERE, '..', 'hooks', 'scripts', 'scope-guard.sh');
+    const { execFileSync } = await import('node:child_process');
+
+    const runHook = (payload) => execFileSync('bash', [SCRIPT], {
+      input: JSON.stringify(payload),
+      env: { ...process.env, CLAUDE_PROJECT_DIR: tmp },
+      encoding: 'utf8',
+    }).trim();
+
+    const blocked = runHook({
+      tool_name: 'Edit',
+      tool_input: { file_path: join(tmp, 'src/ui/Login.tsx') },
+    });
+    const blockedParsed = JSON.parse(blocked);
+    assert.equal(blockedParsed.decision, 'block');
+    assert.ok(/outside the active.*scope/i.test(blockedParsed.reason || ''));
+
+    const approved = runHook({
+      tool_name: 'Edit',
+      tool_input: { file_path: join(tmp, 'src/auth/refresh.ts') },
+    });
+    const approvedParsed = JSON.parse(approved);
+    assert.equal(approvedParsed.decision, 'approve');
+  } finally { rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('done-gate.sh blocks Stop while criteria are unmet', async () => {
+  const tmp = setupTemp();
+  try {
+    process.env.CLAUDE_PROJECT_DIR = tmp;
+    const { setDoneWhen } = await import('../lib/pm-guardrails.mjs');
+    await setDoneWhen({ criteria: ['tests pass', 'docs updated'] });
+
+    const SCRIPT = join(HERE, '..', 'hooks', 'scripts', 'done-gate.sh');
+    const { execFileSync } = await import('node:child_process');
+    const out = execFileSync('bash', [SCRIPT], {
+      input: '{}',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: tmp },
+      encoding: 'utf8',
+    }).trim();
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.decision, 'block');
+    assert.ok(parsed.reason.includes('c1'));
+    assert.ok(parsed.reason.includes('c2'));
+  } finally { rmSync(tmp, { recursive: true, force: true }); }
+});

--- a/plugins/project-management-plugin/tests/pm-guardrails.test.mjs
+++ b/plugins/project-management-plugin/tests/pm-guardrails.test.mjs
@@ -1,0 +1,250 @@
+// Unit tests for the guardrail layer (anchor, scope, done-when,
+// breadcrumbs, over-engineering detector).
+//
+// Each test pins CLAUDE_PROJECT_DIR at an isolated tmp dir so the
+// guardrail state files never touch the developer's real tree.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  setAnchor, readAnchor, clearAnchor, formatAnchorReminder,
+  setScope, addScopePatterns, removeScopePatterns, readScope, isInScope, globMatch, recordOverride,
+  setDoneWhen, readDoneWhen, markCriterionMet, unmetCriteria,
+  recordBreadcrumb, readBreadcrumbs, analyzeDrift,
+  detectOverengineering,
+  activeContextSummary, sessionDir,
+} from '../lib/pm-guardrails.mjs';
+import { matchOverengineering, _OVERENG_RULES } from '../lib/overengineering-rules.mjs';
+
+function setupTemp() {
+  const tmp = mkdtempSync(join(tmpdir(), 'pm-guard-test-'));
+  process.env.CLAUDE_PROJECT_DIR = tmp;
+  return tmp;
+}
+
+function teardown(tmp) {
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+}
+
+// ---------------------------------------------------------------------------
+// globMatch / scope predicates
+// ---------------------------------------------------------------------------
+
+test('globMatch handles * and ** correctly', () => {
+  assert.equal(globMatch('src/**', 'src/auth/refresh.ts'), true);
+  assert.equal(globMatch('src/*.ts', 'src/index.ts'), true);
+  assert.equal(globMatch('src/*.ts', 'src/auth/refresh.ts'), false); // single * stops at /
+  assert.equal(globMatch('tests/**/*.test.mjs', 'tests/unit/a.test.mjs'), true);
+  assert.equal(globMatch('src/auth/**', 'src/ui/Login.tsx'), false);
+});
+
+test('isInScope rejects paths escaping the base dir', () => {
+  const base = '/home/tmp/proj';
+  assert.equal(isInScope('/etc/passwd', { allowlist: ['**'], baseDir: base }), false);
+  assert.equal(isInScope('/home/tmp/proj/src/a.ts', { allowlist: ['src/**'], baseDir: base }), true);
+});
+
+// ---------------------------------------------------------------------------
+// Anchor
+// ---------------------------------------------------------------------------
+
+test('setAnchor + readAnchor + formatAnchorReminder round-trip', async () => {
+  const tmp = setupTemp();
+  try {
+    const rec = await setAnchor({ doItem: 'Ship /pm:anchor', dontItem: 'Touch unrelated plugins' });
+    assert.equal(rec.active, true);
+    assert.equal(rec.do, 'Ship /pm:anchor');
+    const read = readAnchor();
+    assert.deepEqual(read, rec);
+    const reminder = formatAnchorReminder(rec);
+    assert.ok(reminder.includes('DO: Ship /pm:anchor'));
+    assert.ok(reminder.includes("DON'T: Touch unrelated plugins"));
+  } finally { teardown(tmp); }
+});
+
+test('clearAnchor sets active=false but retains history', async () => {
+  const tmp = setupTemp();
+  try {
+    await setAnchor({ doItem: 'x', dontItem: 'y' });
+    const cleared = await clearAnchor();
+    assert.equal(cleared.active, false);
+    assert.ok(cleared.cleared_at);
+    assert.equal(formatAnchorReminder(readAnchor()), null);
+  } finally { teardown(tmp); }
+});
+
+test('setAnchor rejects empty "do" argument', async () => {
+  const tmp = setupTemp();
+  try {
+    await assert.rejects(() => setAnchor({ doItem: '' }), /doItem is required/);
+  } finally { teardown(tmp); }
+});
+
+// ---------------------------------------------------------------------------
+// Scope
+// ---------------------------------------------------------------------------
+
+test('setScope + isInScope enforce the allowlist', async () => {
+  const tmp = setupTemp();
+  try {
+    await setScope(['src/auth/**', 'tests/auth/**']);
+    const scope = readScope();
+    assert.equal(scope.active, true);
+    assert.deepEqual(scope.allowlist.sort(), ['src/auth/**', 'tests/auth/**']);
+    assert.equal(isInScope(join(tmp, 'src/auth/refresh.ts'), { allowlist: scope.allowlist, baseDir: tmp }), true);
+    assert.equal(isInScope(join(tmp, 'src/ui/Login.tsx'), { allowlist: scope.allowlist, baseDir: tmp }), false);
+  } finally { teardown(tmp); }
+});
+
+test('addScopePatterns + removeScopePatterns mutate atomically', async () => {
+  const tmp = setupTemp();
+  try {
+    await setScope(['src/auth/**']);
+    await addScopePatterns(['tests/auth/**', 'src/auth/**']); // duplicate ignored
+    assert.equal(readScope().allowlist.length, 2);
+    await removeScopePatterns(['src/auth/**']);
+    assert.deepEqual(readScope().allowlist, ['tests/auth/**']);
+  } finally { teardown(tmp); }
+});
+
+test('recordOverride appends to drift ledger without widening scope', async () => {
+  const tmp = setupTemp();
+  try {
+    await setScope(['src/auth/**']);
+    await recordOverride({ path: 'src/ui/Login.tsx', reason: 'auth requires button wiring' });
+    const scope = readScope();
+    assert.equal(scope.overrides.length, 1);
+    assert.equal(scope.overrides[0].reason, 'auth requires button wiring');
+    assert.deepEqual(scope.allowlist, ['src/auth/**']); // unchanged
+  } finally { teardown(tmp); }
+});
+
+// ---------------------------------------------------------------------------
+// Done-when
+// ---------------------------------------------------------------------------
+
+test('setDoneWhen assigns ids c1..cN', async () => {
+  const tmp = setupTemp();
+  try {
+    const rec = await setDoneWhen({ criteria: ['a passes', 'b returns 200', 'c exists'] });
+    assert.deepEqual(rec.criteria.map((c) => c.id), ['c1', 'c2', 'c3']);
+    assert.equal(rec.criteria[0].met_at, null);
+  } finally { teardown(tmp); }
+});
+
+test('markCriterionMet requires non-empty evidence', async () => {
+  const tmp = setupTemp();
+  try {
+    await setDoneWhen({ criteria: ['tests pass'] });
+    await assert.rejects(() => markCriterionMet({ id: 'c1', evidence: '' }), /evidence is required/);
+    await markCriterionMet({ id: 'c1', evidence: 'pnpm test -> 0' });
+    const rec = readDoneWhen();
+    assert.ok(rec.criteria[0].met_at);
+    assert.equal(rec.criteria[0].evidence, 'pnpm test -> 0');
+  } finally { teardown(tmp); }
+});
+
+test('unmetCriteria returns only the ones without evidence', async () => {
+  const tmp = setupTemp();
+  try {
+    await setDoneWhen({ criteria: ['a', 'b', 'c'] });
+    await markCriterionMet({ id: 'c1', evidence: 'proof' });
+    await markCriterionMet({ id: 'c3', evidence: 'proof' });
+    const unmet = unmetCriteria(readDoneWhen());
+    assert.deepEqual(unmet.map((c) => c.id), ['c2']);
+  } finally { teardown(tmp); }
+});
+
+// ---------------------------------------------------------------------------
+// Breadcrumbs + drift
+// ---------------------------------------------------------------------------
+
+test('recordBreadcrumb + readBreadcrumbs round-trip', () => {
+  const tmp = setupTemp();
+  try {
+    recordBreadcrumb({ tool: 'Edit', target: 'src/a.ts' });
+    recordBreadcrumb({ tool: 'Bash', target: 'pnpm test' });
+    const crumbs = readBreadcrumbs();
+    assert.equal(crumbs.length, 2);
+    assert.equal(crumbs[0].tool, 'Edit');
+    assert.equal(crumbs[1].target, 'pnpm test');
+    assert.ok(crumbs[0].ts);
+  } finally { teardown(tmp); }
+});
+
+test('analyzeDrift counts advancing vs drift turns', async () => {
+  const tmp = setupTemp();
+  try {
+    await setDoneWhen({ criteria: ['tests pass'] });
+    recordBreadcrumb({ tool: 'Edit', target: 'src/a.ts', scope_ok: true });
+    recordBreadcrumb({ tool: 'Edit', target: 'src/b.ts', scope_ok: false });
+    recordBreadcrumb({ tool: 'Bash', target: 'pnpm test:unit' });
+    const report = analyzeDrift();
+    assert.equal(report.totals.turns, 3);
+    // Bash pnpm test counts as advancing a criterion via heuristic.
+    assert.ok(report.totals.advancing_turns >= 1);
+  } finally { teardown(tmp); }
+});
+
+// ---------------------------------------------------------------------------
+// Overengineering detector
+// ---------------------------------------------------------------------------
+
+test('matchOverengineering flags multi-line comment blocks', () => {
+  const diff = [
+    '+// line 1 of a long comment block',
+    '+// line 2',
+    '+// line 3',
+    '+const x = 1;',
+  ].join('\n');
+  const hits = matchOverengineering({ diff, path: 'src/a.ts' });
+  assert.ok(hits.find((h) => h.tag === 'multiline-comment'));
+});
+
+test('matchOverengineering flags added feature flags', () => {
+  const diff = '+if (featureFlag.isEnabled("foo")) { doThing(); }';
+  const hits = matchOverengineering({ diff });
+  assert.ok(hits.find((h) => h.tag === 'added-feature-flag'));
+});
+
+test('matchOverengineering is quiet on a clean diff', () => {
+  const diff = [
+    '+function rotateRefreshToken(token) {',
+    '+  return verify(token);',
+    '+}',
+  ].join('\n');
+  const hits = matchOverengineering({ diff, path: 'src/auth.ts' });
+  assert.deepEqual(hits, []);
+});
+
+test('matchOverengineering flags backcompat "// removed" comments', () => {
+  const diff = '+// removed — kept for backwards compat\n+export { oldThing };';
+  const hits = matchOverengineering({ diff });
+  assert.ok(hits.find((h) => h.tag === 'backcompat-shim'));
+});
+
+test('every registered rule has a non-empty quote and unique tag', () => {
+  const tags = new Set();
+  for (const r of _OVERENG_RULES) {
+    assert.ok(r.tag && r.rule && typeof r.test === 'function', `bad rule: ${JSON.stringify(r)}`);
+    assert.equal(tags.has(r.tag), false, `duplicate tag: ${r.tag}`);
+    tags.add(r.tag);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Active context resolution
+// ---------------------------------------------------------------------------
+
+test('activeContextSummary falls back to session dir when no IN_PROGRESS project', () => {
+  const tmp = setupTemp();
+  try {
+    const summary = activeContextSummary();
+    assert.equal(summary.kind, 'session');
+    assert.equal(summary.dir, sessionDir());
+  } finally { teardown(tmp); }
+});

--- a/plugins/project-management-plugin/tests/pm-mcp.test.mjs
+++ b/plugins/project-management-plugin/tests/pm-mcp.test.mjs
@@ -1,0 +1,149 @@
+// Integration tests for the pm-mcp stdio JSON-RPC server.
+// Spawns the server as a subprocess and exercises a handful of tools end-to-end.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const SERVER = join(HERE, '..', 'mcp', 'pm-server.mjs');
+const FIXTURES = new URL('./fixtures/', import.meta.url);
+const validProject = JSON.parse(readFileSync(new URL('valid-project.json', FIXTURES), 'utf8'));
+const validTasks = JSON.parse(readFileSync(new URL('valid-tasks.json', FIXTURES), 'utf8'));
+
+function setupTempProject() {
+  const tmp = mkdtempSync(join(tmpdir(), 'pm-mcp-test-'));
+  const projectDir = join(tmp, '.claude', 'projects', validProject.id);
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(join(projectDir, 'project.json'), JSON.stringify(validProject, null, 2));
+  writeFileSync(join(projectDir, 'tasks.json'), JSON.stringify(validTasks, null, 2));
+  return { tmp, projectId: validProject.id };
+}
+
+function startServer(tmp) {
+  const child = spawn('node', [SERVER], {
+    env: { ...process.env, CLAUDE_PROJECT_DIR: tmp },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let buffer = '';
+  const responses = [];
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk.toString('utf8');
+    let nl;
+    while ((nl = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      if (line) { try { responses.push(JSON.parse(line)); } catch {} }
+    }
+  });
+  const call = async (method, params = {}, id) => {
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    for (let i = 0; i < 400; i++) {
+      const hit = responses.find((r) => r.id === id);
+      if (hit) return hit;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    throw new Error(`timeout waiting for response id=${id}`);
+  };
+  return { child, call };
+}
+
+function textToJSON(response) {
+  return JSON.parse(response.result.content[0].text);
+}
+
+test('pm-mcp initialize + tools/list', async () => {
+  const { tmp } = setupTempProject();
+  const srv = startServer(tmp);
+  try {
+    const init = await srv.call('initialize', {}, 1);
+    assert.equal(init.result.serverInfo.name, 'pm-mcp');
+    const list = await srv.call('tools/list', {}, 2);
+    const names = list.result.tools.map((t) => t.name);
+    assert.ok(names.includes('pm_list_projects'));
+    assert.ok(names.includes('pm_next_task'));
+    assert.ok(names.includes('pm_update_task_status'));
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm-mcp pm_list_projects returns the fixture', async () => {
+  const { tmp, projectId } = setupTempProject();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    const resp = await srv.call('tools/call', { name: 'pm_list_projects', arguments: {} }, 2);
+    const payload = textToJSON(resp);
+    assert.equal(payload.length, 1);
+    assert.equal(payload[0].id, projectId);
+    assert.equal(payload[0].counts.total, 3);
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm-mcp pm_next_task returns T-002 (critical + unblocked)', async () => {
+  const { tmp, projectId } = setupTempProject();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    const resp = await srv.call('tools/call', { name: 'pm_next_task', arguments: { project_id: projectId } }, 2);
+    const payload = textToJSON(resp);
+    assert.equal(payload.task.id, 'T-002');
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm-mcp pm_complete_task flips status + writes completed_at', async () => {
+  const { tmp, projectId } = setupTempProject();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    const resp = await srv.call('tools/call', {
+      name: 'pm_complete_task',
+      arguments: { project_id: projectId, task_id: 'T-002', actual_minutes: 18 },
+    }, 2);
+    assert.equal(resp.error, undefined, `expected success, got ${JSON.stringify(resp.error)}`);
+    // Re-read from disk
+    const disk = JSON.parse(readFileSync(join(tmp, '.claude', 'projects', projectId, 'tasks.json'), 'utf8'));
+    const t = disk.tasks.find((x) => x.id === 'T-002');
+    assert.equal(t.status, 'COMPLETE');
+    assert.equal(t.actual_minutes, 18);
+    assert.ok(t.completed_at, 'completed_at should be set');
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm-mcp pm_block_task requires a reason and writes it', async () => {
+  const { tmp, projectId } = setupTempProject();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    const resp = await srv.call('tools/call', {
+      name: 'pm_block_task',
+      arguments: { project_id: projectId, task_id: 'T-003', reason: 'Waiting on spike T-9' },
+    }, 2);
+    assert.equal(resp.error, undefined);
+    const disk = JSON.parse(readFileSync(join(tmp, '.claude', 'projects', projectId, 'tasks.json'), 'utf8'));
+    const t = disk.tasks.find((x) => x.id === 'T-003');
+    assert.equal(t.status, 'BLOCKED');
+    assert.equal(t.blocked_reason, 'Waiting on spike T-9');
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm-mcp rejects unknown status enum at the MCP boundary', async () => {
+  const { tmp, projectId } = setupTempProject();
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    const resp = await srv.call('tools/call', {
+      name: 'pm_update_task_status',
+      arguments: { project_id: projectId, task_id: 'T-002', status: 'WAT' },
+    }, 2);
+    // Either the MCP layer or the lib validator should produce an error.
+    // We accept either — but there must be some error path.
+    if (!resp.error) {
+      const payload = textToJSON(resp);
+      assert.notEqual(payload.status, 'WAT', 'server must not persist a WAT status');
+    }
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});

--- a/plugins/project-management-plugin/tests/pm-round3.test.mjs
+++ b/plugins/project-management-plugin/tests/pm-round3.test.mjs
@@ -1,0 +1,282 @@
+// Round-3 guardrails: turn budget, user-prompt archive, compaction handoff.
+// Uses node:test. Each test isolates CLAUDE_PROJECT_DIR to a fresh tmp dir.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawn } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  setBudget, readBudget, clearBudget, budgetStatus,
+  recordBreadcrumb,
+  recordUserPrompt, readUserPrompts, lastUserPrompt,
+  writeHandoff, readHandoff,
+  setAnchor, setScope, setDoneWhen, markCriterionMet,
+} from '../lib/pm-guardrails.mjs';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const SERVER = join(HERE, '..', 'mcp', 'pm-server.mjs');
+
+function setupTemp() {
+  const tmp = mkdtempSync(join(tmpdir(), 'pm-round3-'));
+  process.env.CLAUDE_PROJECT_DIR = tmp;
+  return tmp;
+}
+
+function teardown(tmp) {
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+test('setBudget stores max_turns and baseline crumb count', async () => {
+  const tmp = setupTemp();
+  try {
+    recordBreadcrumb({ tool: 'Read', target: 'preload' });
+    const rec = await setBudget({ max_turns: 20 });
+    assert.equal(rec.max_turns, 20);
+    assert.equal(rec.baseline_crumb_count, 1, 'baseline should equal crumb count at time of set');
+    assert.equal(rec.active, true);
+  } finally { teardown(tmp); }
+});
+
+test('budgetStatus transitions ok -> warn -> over based on consumption', async () => {
+  const tmp = setupTemp();
+  try {
+    await setBudget({ max_turns: 10 });
+    assert.equal(budgetStatus().status, 'ok');
+    for (let i = 0; i < 8; i++) recordBreadcrumb({ tool: 'Edit', target: `f${i}` });
+    assert.equal(budgetStatus().status, 'warn', '80% = warn');
+    for (let i = 0; i < 5; i++) recordBreadcrumb({ tool: 'Edit', target: `f${i}-extra` });
+    assert.equal(budgetStatus().status, 'over', '>=120% = over');
+  } finally { teardown(tmp); }
+});
+
+test('clearBudget retains history but sets active=false', async () => {
+  const tmp = setupTemp();
+  try {
+    await setBudget({ max_turns: 5 });
+    const cleared = await clearBudget();
+    assert.equal(cleared.active, false);
+    assert.ok(cleared.cleared_at);
+    assert.equal(budgetStatus().active, false);
+  } finally { teardown(tmp); }
+});
+
+test('setBudget rejects non-positive max_turns', async () => {
+  const tmp = setupTemp();
+  try {
+    await assert.rejects(() => setBudget({ max_turns: 0 }), /positive integer/i);
+    await assert.rejects(() => setBudget({ max_turns: 'ten' }), /positive integer/i);
+  } finally { teardown(tmp); }
+});
+
+// ---------------------------------------------------------------------------
+// User-prompt archive
+// ---------------------------------------------------------------------------
+
+test('recordUserPrompt + readUserPrompts round-trip and truncate', () => {
+  const tmp = setupTemp();
+  try {
+    recordUserPrompt('first message');
+    recordUserPrompt('second message');
+    recordUserPrompt('third message');
+    const recent = readUserPrompts({ limit: 2 });
+    assert.equal(recent.length, 2);
+    assert.equal(recent[0].text, 'second message');
+    assert.equal(recent[1].text, 'third message');
+    assert.equal(lastUserPrompt().text, 'third message');
+  } finally { teardown(tmp); }
+});
+
+test('recordUserPrompt ignores empty / whitespace / non-string input', () => {
+  const tmp = setupTemp();
+  try {
+    recordUserPrompt('');
+    recordUserPrompt('   ');
+    recordUserPrompt(null);
+    recordUserPrompt(42);
+    assert.equal(readUserPrompts().length, 0);
+  } finally { teardown(tmp); }
+});
+
+test('recordUserPrompt caps very long prompts at 4k chars', () => {
+  const tmp = setupTemp();
+  try {
+    const huge = 'x'.repeat(10_000);
+    recordUserPrompt(huge);
+    const stored = lastUserPrompt();
+    assert.equal(stored.text.length, 4000);
+  } finally { teardown(tmp); }
+});
+
+// ---------------------------------------------------------------------------
+// Handoff snapshot
+// ---------------------------------------------------------------------------
+
+test('writeHandoff produces a markdown file including anchor, scope, and done status', async () => {
+  const tmp = setupTemp();
+  try {
+    recordUserPrompt('implement refresh token rotation');
+    await setAnchor({ doItem: 'refresh-token rotation', dontItem: 'UI' });
+    await setScope(['src/auth/**']);
+    await setDoneWhen({ criteria: ['tests pass', 'endpoint returns 200'] });
+    await markCriterionMet({ id: 'c1', evidence: 'pnpm test -> exit 0' });
+    await setBudget({ max_turns: 30 });
+    recordBreadcrumb({ tool: 'Edit', target: 'src/auth/refresh.ts' });
+    recordBreadcrumb({ tool: 'Bash', target: 'pnpm test:auth' });
+
+    const file = writeHandoff();
+    assert.ok(existsSync(file), 'handoff file should exist');
+    const md = readFileSync(file, 'utf8');
+    assert.ok(md.includes('## Last user ask'));
+    assert.ok(md.includes('implement refresh token rotation'));
+    assert.ok(md.includes('## Focus anchor'));
+    assert.ok(md.includes('DO: refresh-token rotation'));
+    assert.ok(md.includes('## Scope allowlist'));
+    assert.ok(md.includes('`src/auth/**`'));
+    assert.ok(md.includes('## Done-when progress'));
+    assert.ok(md.includes('1/2 criteria met'));
+    assert.ok(md.includes('[x] **c1**'));
+    assert.ok(md.includes('[ ] **c2**'));
+    assert.ok(md.includes('## Turn budget'));
+    assert.ok(md.includes('## Recently touched files'));
+    assert.ok(md.includes('src/auth/refresh.ts'));
+    assert.ok(md.includes('## How to resume'));
+  } finally { teardown(tmp); }
+});
+
+test('readHandoff returns null when no snapshot exists', () => {
+  const tmp = setupTemp();
+  try {
+    assert.equal(readHandoff(), null);
+  } finally { teardown(tmp); }
+});
+
+test('writeHandoff is a no-op-safe: works with no state set', async () => {
+  const tmp = setupTemp();
+  try {
+    const file = writeHandoff();
+    assert.ok(existsSync(file));
+    const md = readFileSync(file, 'utf8');
+    // Minimal handoff still has the header + the resume section.
+    assert.ok(md.includes('# Task Handoff'));
+    assert.ok(md.includes('## How to resume'));
+  } finally { teardown(tmp); }
+});
+
+// ---------------------------------------------------------------------------
+// MCP end-to-end for the new tools
+// ---------------------------------------------------------------------------
+
+function startServer(tmp) {
+  const child = spawn('node', [SERVER], {
+    env: { ...process.env, CLAUDE_PROJECT_DIR: tmp },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let buffer = '';
+  const responses = [];
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk.toString('utf8');
+    let nl;
+    while ((nl = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      if (line) { try { responses.push(JSON.parse(line)); } catch {} }
+    }
+  });
+  const call = async (method, params = {}, id) => {
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    for (let i = 0; i < 400; i++) {
+      const hit = responses.find((r) => r.id === id);
+      if (hit) return hit;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    throw new Error(`timeout waiting for response id=${id}`);
+  };
+  return { child, call };
+}
+
+const textToJSON = (r) => JSON.parse(r.result.content[0].text);
+
+test('pm-mcp exposes the round-3 tools', async () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'pm-round3-mcp-'));
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    const list = await srv.call('tools/list', {}, 2);
+    const names = new Set(list.result.tools.map((t) => t.name));
+    for (const n of ['pm_budget_set', 'pm_budget_status', 'pm_budget_clear',
+      'pm_user_prompt_record', 'pm_user_prompts_recent',
+      'pm_handoff_write', 'pm_handoff_read']) {
+      assert.ok(names.has(n), `missing tool: ${n}`);
+    }
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm_budget_set + pm_budget_status via MCP', async () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'pm-round3-mcp-'));
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    await srv.call('tools/call', { name: 'pm_budget_set', arguments: { max_turns: 5 } }, 2);
+    const status = textToJSON(await srv.call('tools/call', { name: 'pm_budget_status', arguments: {} }, 3));
+    assert.equal(status.active, true);
+    assert.equal(status.max_turns, 5);
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('pm_handoff_write + pm_handoff_read produce a consistent markdown file', async () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'pm-round3-mcp-'));
+  const srv = startServer(tmp);
+  try {
+    await srv.call('initialize', {}, 1);
+    await srv.call('tools/call', { name: 'pm_anchor_set', arguments: { do: 'ship the handoff feature' } }, 2);
+    await srv.call('tools/call', { name: 'pm_user_prompt_record', arguments: { text: 'please build handoff' } }, 3);
+    const written = textToJSON(await srv.call('tools/call', { name: 'pm_handoff_write', arguments: {} }, 4));
+    assert.ok(written.file.endsWith('handoff.md'));
+    const read = textToJSON(await srv.call('tools/call', { name: 'pm_handoff_read', arguments: {} }, 5));
+    assert.equal(read.found, true);
+    assert.ok(read.markdown.includes('ship the handoff feature'));
+    assert.ok(read.markdown.includes('please build handoff'));
+  } finally { srv.child.kill(); rmSync(tmp, { recursive: true, force: true }); }
+});
+
+// ---------------------------------------------------------------------------
+// Hook-level: budget-warn.sh fires at warn/over thresholds only
+// ---------------------------------------------------------------------------
+
+test('budget-warn.sh emits notification at >=80% and is silent below', async () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'pm-round3-hook-'));
+  try {
+    process.env.CLAUDE_PROJECT_DIR = tmp;
+    await setBudget({ max_turns: 10 });
+    for (let i = 0; i < 5; i++) recordBreadcrumb({ tool: 'Edit', target: `f${i}` });
+    const SCRIPT = join(HERE, '..', 'hooks', 'scripts', 'budget-warn.sh');
+    const runHook = () => execFileSync('bash', [SCRIPT], {
+      input: '{}',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: tmp },
+      encoding: 'utf8',
+    }).trim();
+
+    // 50% — silent
+    const silent = JSON.parse(runHook());
+    assert.equal(silent.notification, undefined);
+
+    // 80% — warn
+    for (let i = 0; i < 3; i++) recordBreadcrumb({ tool: 'Edit', target: `warn${i}` });
+    const warn = JSON.parse(runHook());
+    assert.ok(warn.notification && warn.notification.toLowerCase().includes('budget'));
+
+    // 120% — over
+    for (let i = 0; i < 5; i++) recordBreadcrumb({ tool: 'Edit', target: `over${i}` });
+    const over = JSON.parse(runHook());
+    assert.ok(over.notification && over.notification.includes('OVER'));
+  } finally { rmSync(tmp, { recursive: true, force: true }); }
+});

--- a/plugins/project-management-plugin/tests/pm-state.test.mjs
+++ b/plugins/project-management-plugin/tests/pm-state.test.mjs
@@ -1,0 +1,173 @@
+// Unit tests for plugins/project-management-plugin/lib/pm-state.mjs.
+// Uses node:test + node:assert (no third-party deps).
+//
+// Each test points CLAUDE_PROJECT_DIR at an isolated temp dir so state
+// writes never touch the developer's real .claude/projects tree.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  projectsRoot,
+  listProjects,
+  readProject,
+  readTasks,
+  writeProject,
+  writeTasks,
+  mutateTasks,
+  nextTask,
+  unblockedTasks,
+  withLock,
+  loadValidators,
+  validateProject,
+  validateTasks,
+  writeCheckpoint,
+} from '../lib/pm-state.mjs';
+
+const FIXTURES = new URL('./fixtures/', import.meta.url);
+const validProject = JSON.parse(readFileSync(new URL('valid-project.json', FIXTURES), 'utf8'));
+const validTasks = JSON.parse(readFileSync(new URL('valid-tasks.json', FIXTURES), 'utf8'));
+
+function setupTempProject() {
+  const tmp = mkdtempSync(join(tmpdir(), 'pm-state-test-'));
+  process.env.CLAUDE_PROJECT_DIR = tmp;
+  const projectId = validProject.id;
+  const projectDir = join(tmp, '.claude', 'projects', projectId);
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(join(projectDir, 'project.json'), JSON.stringify(validProject, null, 2));
+  writeFileSync(join(projectDir, 'tasks.json'), JSON.stringify(validTasks, null, 2));
+  return { tmp, projectId, projectDir };
+}
+
+function teardown(tmp) {
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+}
+
+await loadValidators();
+
+test('projectsRoot() honors CLAUDE_PROJECT_DIR', () => {
+  process.env.CLAUDE_PROJECT_DIR = '/tmp/custom';
+  assert.equal(projectsRoot(), '/tmp/custom/.claude/projects');
+});
+
+test('listProjects + readProject + readTasks find the fixture', () => {
+  const { tmp, projectId } = setupTempProject();
+  try {
+    const all = listProjects();
+    assert.equal(all.length, 1);
+    assert.equal(all[0].id, projectId);
+    const project = readProject(projectId);
+    assert.equal(project.name, 'Fixture Alpha');
+    const tasks = readTasks(projectId);
+    assert.equal(tasks.tasks.length, 3);
+  } finally { teardown(tmp); }
+});
+
+test('readTasks() normalizes a bare-array legacy tasks.json', () => {
+  const { tmp, projectId, projectDir } = setupTempProject();
+  try {
+    writeFileSync(join(projectDir, 'tasks.json'), JSON.stringify(validTasks.tasks, null, 2));
+    const tasks = readTasks(projectId);
+    assert.equal(tasks.version, 1);
+    assert.equal(tasks.tasks.length, 3);
+  } finally { teardown(tmp); }
+});
+
+test('validateProject accepts fixture, rejects bad status', () => {
+  assert.deepEqual(validateProject(validProject), []);
+  const bad = { ...validProject, status: 'WAT' };
+  const errors = validateProject(bad);
+  assert.ok(errors.length > 0, 'should flag bad status enum');
+  assert.ok(errors.join('\n').toLowerCase().includes('status') || errors.join('\n').includes('enum'),
+    `expected status/enum error, got: ${errors.join('\n')}`);
+});
+
+test('validateTasks rejects task with missing required fields', () => {
+  const bad = { tasks: [{ id: 'T-999' }] };
+  const errors = validateTasks(bad);
+  assert.ok(errors.length > 0, 'should flag missing required fields');
+});
+
+test('writeProject writes + validates + reads back', async () => {
+  const { tmp, projectId } = setupTempProject();
+  try {
+    const updated = { ...validProject, name: 'Fixture Alpha v2' };
+    await writeProject(projectId, updated);
+    assert.equal(readProject(projectId).name, 'Fixture Alpha v2');
+  } finally { teardown(tmp); }
+});
+
+test('writeProject throws on schema-invalid input', async () => {
+  const { tmp, projectId } = setupTempProject();
+  try {
+    const bad = { ...validProject, status: 'NOT_A_STATUS' };
+    await assert.rejects(() => writeProject(projectId, bad), /validation/i);
+    // original file should be untouched
+    assert.equal(readProject(projectId).status, 'PLANNED');
+  } finally { teardown(tmp); }
+});
+
+test('mutateTasks applies a transform atomically', async () => {
+  const { tmp, projectId } = setupTempProject();
+  try {
+    await mutateTasks(projectId, (tasks) => {
+      const t = tasks.tasks.find((x) => x.id === 'T-002');
+      t.status = 'IN_PROGRESS';
+      return tasks;
+    });
+    assert.equal(readTasks(projectId).tasks.find((t) => t.id === 'T-002').status, 'IN_PROGRESS');
+  } finally { teardown(tmp); }
+});
+
+test('nextTask prefers CRITICAL on critical path', () => {
+  const pick = nextTask(validTasks);
+  // T-002 is CRITICAL + on_critical_path but depends on T-001 (COMPLETE),
+  // so it should be unblocked and picked over T-003 (LOW, off-path).
+  assert.equal(pick.id, 'T-002');
+});
+
+test('unblockedTasks excludes tasks whose deps are not COMPLETE', () => {
+  const ready = unblockedTasks(validTasks);
+  const ids = ready.map((t) => t.id).sort();
+  assert.deepEqual(ids, ['T-002', 'T-003']);
+});
+
+test('withLock serializes concurrent writers', async () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'pm-lock-test-'));
+  try {
+    const lockPath = join(tmp, '.lock');
+    let inFlight = 0;
+    let maxSeen = 0;
+    const work = async () => withLock(lockPath, async () => {
+      inFlight += 1;
+      maxSeen = Math.max(maxSeen, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight -= 1;
+    });
+    await Promise.all([work(), work(), work(), work()]);
+    assert.equal(maxSeen, 1, 'at most one critical section should run at a time');
+  } finally { rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('writeCheckpoint produces a snapshot file', () => {
+  const { tmp, projectId, projectDir } = setupTempProject();
+  try {
+    const file = writeCheckpoint(projectId);
+    assert.ok(file && existsSync(file), 'checkpoint file should exist');
+    const snap = JSON.parse(readFileSync(file, 'utf8'));
+    assert.equal(snap.project_snapshot.id, projectId);
+    assert.equal(snap.task_statuses.length, 3);
+  } finally { teardown(tmp); }
+});
+
+test('writeTasks rejects tasks.json with a disallowed status', async () => {
+  const { tmp, projectId } = setupTempProject();
+  try {
+    const bad = { ...validTasks };
+    bad.tasks = bad.tasks.map((t) => (t.id === 'T-002' ? { ...t, status: 'GOING_GREAT' } : t));
+    await assert.rejects(() => writeTasks(projectId, bad), /validation/i);
+  } finally { teardown(tmp); }
+});


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive guardrails system to keep Claude on task during long autonomous sessions. It adds four new commands (`/pm:anchor`, `/pm:scope`, `/pm:done-when`, `/pm:budget`) and five corresponding hooks that enforce focus, scope boundaries, completion criteria, and turn budgets. The system works with or without a formal project—ephemeral session state lives at `.claude/pm-session/` when no project is active.

## Key Changes

### New Libraries
- **`pm-guardrails.mjs`** (498 lines): Core guardrail state management with active-context resolution, anchor/scope/done-when/budget/breadcrumb persistence, and drift analysis
- **`pm-guardrails-cli.mjs`** (132 lines): Thin CLI wrapper for bash hooks to read/write guardrail state
- **`overengineering-rules.mjs`** (121 lines): Pattern-matching rules that flag over-engineering violations from CLAUDE.md (multiline comments, feature flags, premature optimization, etc.)

### MCP Server Enhancements
- **`pm-server.mjs`** (820 lines): Added 12 new tools for guardrail management:
  - `pm_anchor_set/get/clear` — focus receipt injection
  - `pm_scope_set/add/remove/check` — file/command allowlist with drift ledger
  - `pm_done_when_set/mark_met/show` — explicit completion criteria
  - `pm_budget_set/show/clear` — turn budget tracking
  - `pm_drift` — breadcrumb trail auditor
  - `pm_handoff_write/read` — compaction-safe task snapshots

### Hook Scripts (9 new/modified)
- **`anchor-inject.sh`** — Injects focus anchor on every user turn
- **`scope-guard.sh`** — PreToolUse blocker for out-of-scope edits
- **`done-gate.sh`** — Stop hook that blocks session end until criteria met
- **`budget-warn.sh`** — PostToolUse notifier at 80% and 120% consumption
- **`breadcrumb-logger.sh`** — Appends every tool call for drift auditing
- **`overengineering-detector.sh`** — Scans diffs against CLAUDE.md rules
- **`prompt-archive.sh`** — Archives user messages for context
- **`handoff-write.sh`** / **`handoff-read.sh`** — Compaction-safe snapshots
- Modified `session-resume.sh`, `auto-checkpoint.sh`, `risk-alert.sh`, `task-completion-capture.sh`

### Test Coverage
- **`pm-guardrails.test.mjs`** (250 lines): Unit tests for anchor, scope, done-when, breadcrumbs, overengineering detection
- **`pm-guardrails-mcp.test.mjs`** (241 lines): Integration tests for guardrail tools over MCP
- **`pm-round3.test.mjs`** (282 lines): Tests for budget, user-prompt archive, handoff
- **`pm-state.test.mjs`** (173 lines): Tests for core state library
- **`pm-mcp.test.mjs`** (149 lines): Integration tests for MCP server

### Documentation
- **`pm-anchor.md`** — Focus receipt command docs
- **`pm-scope.md`** — Scope lock command docs
- **`pm-done-when.md`** — Completion criteria command docs
- **`pm-budget.md`** — Turn budget command docs
- **`pm-drift.md`** — Drift auditor command docs
- **`pm-handoff.md`** — Compaction-safe handoff docs
- Updated `README.md` and `CLAUDE.md` with guardrails overview

### Schema Updates
- **`project.schema.json`**: Added `depth` field, relaxed `additionalProperties`, expanded status enum
- **`task.schema.json`**: Added `phase_id`, `

https://claude.ai/code/session_01MhXuZ1dkE88EWUxYZDvj9N