### PR TITLE
Add project-planner-plugin alias and regression test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -264,7 +264,7 @@
     },
     {
       "name": "mui-expert",
-      "description": "Comprehensive Material UI (MUI) expert plugin — 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
+      "description": "Comprehensive Material UI (MUI) expert plugin \u2014 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
       "version": "2.1.0",
       "author": {
         "name": "Claude Code",
@@ -274,6 +274,16 @@
     },
     {
       "name": "project-management-plugin",
+      "description": "Universal project manager: interview-first init, micro-task decomposition, deep research before execution, autonomous loop with 9 PM platform integrations.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "Markus@thelobbi.io"
+      },
+      "source": "./plugins/project-management-plugin"
+    },
+    {
+      "name": "project-planner-plugin",
       "description": "Universal project manager: interview-first init, micro-task decomposition, deep research before execution, autonomous loop with 9 PM platform integrations.",
       "version": "1.0.0",
       "author": {

--- a/tests/marketplace-project-planner.test.mjs
+++ b/tests/marketplace-project-planner.test.mjs
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const marketplace = JSON.parse(fs.readFileSync('.claude-plugin/marketplace.json', 'utf8'));
+
+test('marketplace exposes project-planner-plugin alias for project-management-plugin', () => {
+  const plugin = marketplace.plugins.find((p) => p.name === 'project-planner-plugin');
+  assert.ok(plugin, 'Expected project-planner-plugin entry in marketplace');
+  assert.equal(plugin.source, './plugins/project-management-plugin');
+});


### PR DESCRIPTION
### Motivation
- Users searching for or installing a “project planner” plugin could not find the project management plugin because the marketplace lacked a planner-named alias, causing the project planner naming to fail to resolve.

### Description
- Inserted a new alias entry `project-planner-plugin` in `.claude-plugin/marketplace.json` that points to `./plugins/project-management-plugin` to provide planner-name compatibility.
- Added a regression test `tests/marketplace-project-planner.test.mjs` which asserts the alias exists and its `source` equals `./plugins/project-management-plugin`.

### Testing
- Ran the project-management plugin unit suite with `npm run test:pm-plugin`, which completed successfully (62 tests, 0 failures).
- Ran the new marketplace regression test with `node --test tests/marketplace-project-planner.test.mjs`, which passed.
- Ran `npm run check:plugin-indexes` which failed due to an unrelated pre-existing frontmatter mismatch in `commands/cc-autonomy.md`; this was deferred and logged below.

Deferred TODOs (added to the PR report; not modified here):
- [ ] [HIGH] Fix frontmatter mismatch reported by `generate-plugin-indexes.mjs`
  - File: `commands/cc-autonomy.md`:1
  - Discovered: 2026-05-02 during marketplace alias fix
  - Description: `scripts/generate-plugin-indexes.mjs` reports `commands/cc-autonomy.md` frontmatter is missing or differs from expected shape, causing `check:plugin-indexes` to fail repository-wide checks.
  - Impact: Repository-wide index generation and CI checks fail until fixed, blocking marketplace index validation.
  - Proposed fix: Inspect and normalize the YAML frontmatter in `commands/cc-autonomy.md` to match the generated form or update the generator if the intended shape changed.
  - Blocked by: none

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f59c0f7f90832a86ee28a55722c128)