### PR TITLE
fix(security): pin Syncfusion Blazor MCP package version

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -76,7 +76,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@syncfusion/blazor-assistant@latest"
+        "@syncfusion/blazor-assistant@2.0.1"
       ],
       "env": {
         "SYNCFUSION_API_KEY": "${SYNCFUSION_API_KEY}"


### PR DESCRIPTION
### Motivation
- The `syncfusion-blazor` MCP server in `.mcp.json` used `npx ... @syncfusion/blazor-assistant@latest`, which allows unpinned runtime npm installs and creates a supply-chain arbitrary code execution risk. 

### Description
- Replace `@syncfusion/blazor-assistant@latest` with the pinned version `@syncfusion/blazor-assistant@2.0.1` in `.mcp.json` to remove runtime resolution of `@latest` while preserving the MCP config and behavior. 

### Testing
- Ran `npm view @syncfusion/blazor-assistant version` and `jq empty .mcp.json` and verified the file diff with `git diff -- .mcp.json`; all commands succeeded and the JSON remained valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69c8fe4e06bc832aac12b30e42aee9f4)