### PR TITLE
Claude 5 (Fable 5) support & Atlassian MCP HTTP migration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,8 +20,8 @@
     },
     {
       "name": "claude-code-expert",
-      "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 14 behavior-triggering skills, 11 single-intent commands, 18 role-scoped agents bridging engram and Obsidian.",
-      "version": "8.0.0",
+      "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 21 behavior-triggering skills, 12 single-intent commands, 18 role-scoped agents bridging engram and Obsidian. Tracks current Claude Code capabilities (Fable 5 + Opus 4.8, agent teams, Tool Search, web/remote).",
+      "version": "8.2.0",
       "author": {
         "name": "Markus Ahling"
       },
@@ -30,7 +30,7 @@
     {
       "name": "claude-code-templating",
       "description": "Universal templating and Harness expert plugin for Claude Code - enables fully autonomous project generation, pipeline creation, and deployment automation through a unified template interface. Supports Handlebars, Cookiecutter, Copier, Maven archetypes, and Harness pipelines. 5 commands, 6 agents, 3 skills.",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "author": {
         "name": "Markus Ahling",
         "url": "https://thelobbi.io"
@@ -40,7 +40,7 @@
     {
       "name": "cowork-marketplace",
       "description": "Browse, install, and manage cowork marketplace items backed by real plugin agents, skills, and commands",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "author": {
         "name": "Markus Ahling",
         "email": "markus@lobbi.co"
@@ -59,7 +59,7 @@
     {
       "name": "dotnet-blazor",
       "description": "Comprehensive .NET 10, Blazor, ASP.NET Core, C#, and Syncfusion expert plugin for building modern web apps, microservices, and cloud-native solutions",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "author": {
         "name": "Markus Ahling"
       },
@@ -78,7 +78,7 @@
     {
       "name": "exec-automator",
       "description": "Genesis (Forerunner) - AI-Powered Executive Director Automation Platform. Analyze organizational responsibilities, score automation potential with 6-factor algorithm, generate LangGraph workflows, and deploy 11 specialized agents for trade associations and nonprofits.",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "author": {
         "name": "Brookside BI",
         "email": "dev@brooksidebi.com"
@@ -125,8 +125,8 @@
     },
     {
       "name": "jira-orchestrator",
-      "description": "Enterprise Jira orchestration with 81 agents, 16 teams, 46 commands, 11 skills. Features Atlassian MCP OAuth, Harness integration, Neon PostgreSQL, Redis caching, Temporal workflows, and structured reasoning frameworks.",
-      "version": "8.0.0",
+      "description": "Enterprise Jira orchestration with 82 agents, 16 teams, 48 commands, 14 skills, 5 schema-validated workflows, and a read-only advisor. Features Atlassian MCP OAuth, Harness integration, Neon PostgreSQL, Redis caching, Temporal workflows, declarative workflow definitions, lifecycle telemetry hooks, and structured reasoning frameworks.",
+      "version": "8.2.0",
       "author": {
         "name": "Markus Ahling",
         "email": "markus@lobbi.io"
@@ -135,7 +135,7 @@
     },
     {
       "name": "linear-orchestrator",
-      "description": "Advanced Linear integration with two-way sync to Harness Code and Microsoft Planner. 24 commands, 10 skills, 12 agents covering Linear GraphQL, OAuth 2.0 + actor authorization, webhooks, attachments, agents (AIG), MCP, cycles, projects, initiatives, customer requests, SLA, triage, templates, diffs, plus deep Harness Git Experience, custom approvals, triggers, connectors-as-YAML, and Microsoft Graph delta sync.",
+      "description": "Advanced Linear integration with two-way sync to Harness Code and Microsoft Planner. Covers Linear GraphQL API, OAuth 2.0, webhooks, attachments, agents (AIG), MCP, cycles, projects, initiatives, customer requests, SLA, triage, templates, sub-issues, and diffs. 22 commands, 10 skills, 12 agents.",
       "version": "1.0.0",
       "author": {
         "name": "Markus Ahling",
@@ -264,8 +264,8 @@
     },
     {
       "name": "mui-expert",
-      "description": "Comprehensive Material UI (MUI) expert plugin \u2014 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
-      "version": "2.1.0",
+      "description": "Comprehensive Material UI (MUI) expert plugin — 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
+      "version": "2.1.1",
       "author": {
         "name": "Claude Code",
         "url": "https://github.com/markus41/claude"
@@ -275,7 +275,7 @@
     {
       "name": "project-management-plugin",
       "description": "Universal project manager with keep-Claude-on-task guardrails: focus anchor, scope lock, done-when contract, over-engineering detector, drift auditor, turn budget, user-prompt archive, and compaction-safe handoff. Plus interview-first init, micro-task decomposition, deep research, transactional state MCP, and 9 PM platform integrations.",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "author": {
         "name": "Markus Ahling",
         "email": "Markus@thelobbi.io"
@@ -285,7 +285,7 @@
     {
       "name": "react-animation-studio",
       "description": "Create beautiful, performant web animations for React and TypeScript applications. Includes background effects, text animations, 3D transforms, creative visual effects, Framer Motion, GSAP, and more.",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "author": {
         "name": "Brookside BI",
         "email": "plugins@brooksidebi.com",
@@ -333,8 +333,8 @@
     },
     {
       "name": "writing-plans-enhanced",
-      "description": "Enhanced fork of superpowers:writing-plans with pre-writing phase, task metadata, non-TDD templates, and automated plan linter with self-tests.",
-      "version": "1.0.0",
+      "description": "Enhanced writing-plans skill: 5-phase structure, task metadata (Type/Depends-on/Parallel-safe/Risk), non-TDD task templates, automated plan linter with self-tests. Standalone hub-hosted fork of superpowers:writing-plans.",
+      "version": "1.0.1",
       "author": {
         "name": "Markus Ahling",
         "email": "markus@thelobbi.io"
@@ -343,7 +343,7 @@
     },
     {
       "name": "work-automation",
-      "description": "Universal internal work-automation kit. ULTRA-mode constitution, Work Unit Protocol, Claude Code automation patterns, Harness pipeline ops.",
+      "description": "Universal internal work-automation kit. ULTRA-mode constitution, Work Unit Protocol, Claude Code automation patterns (hooks, skills, plugins, agents, schedules, MCP, SDK, headless, fullscreen), and Harness pipeline ops. Project-agnostic. Glues existing plugins (harness-platform, claude-code-expert, tenant-management-kit) with reusable workflows.",
       "version": "1.0.0",
       "author": {
         "name": "Markus Ahling",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,8 +1,8 @@
 # Project Instructions
 
 ## Overview
-Claude Code Plugin Marketplace — curated collection of 27 Claude Code plugins
-(21 in `plugins/`, 6 sub-plugins in `.claude/plugins/`) with marketplace-wide
+Claude Code Plugin Marketplace — curated collection of 41 Claude Code plugins
+(35 in `plugins/`, 6 sub-plugins in `.claude/plugins/`) with marketplace-wide
 validation and developer tooling. Pure marketplace repository; no application
 frontend.
 
@@ -28,7 +28,7 @@ EXPLORE → PLAN → CODE → TEST → FIX → DOCUMENT
 
 ## Key Paths
 - Marketplace manifest: `.claude-plugin/marketplace.json`
-- Installed plugins: `plugins/` (21 plugins)
+- Installed plugins: `plugins/` (35 plugins)
 - Sub-marketplace plugins: `.claude/plugins/` (6 plugins)
 - Rules: `.claude/rules/` (modular, path-scoped instructions)
 - Platform skills: `.claude/skills/`

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -93,6 +93,7 @@ unless the plugin includes a postinstall build hook.
 ## Models
 | Model | Use |
 |-------|-----|
+| fable | Hardest long-horizon autonomous runs, problems Opus failed on (Claude 5 tier above Opus) |
 | opus | Architecture, complex decisions, security review |
 | sonnet | Development, implementation, test writing |
 | haiku | Research, fast lookups, docs |

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -12,7 +12,7 @@
       "dependencies": {}
     },
     "claude-code-templating-plugin": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "path": "../plugins/claude-code-templating-plugin",
       "source": "local",
       "installedAt": "2026-01-08T00:00:00.000Z",
@@ -26,7 +26,7 @@
       "dependencies": {}
     },
     "exec-automator": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "path": "../plugins/exec-automator",
       "source": "local",
       "installedAt": "2026-01-01T00:00:00.000Z",
@@ -61,7 +61,7 @@
       "dependencies": {}
     },
     "jira-orchestrator": {
-      "version": "8.0.0",
+      "version": "8.2.0",
       "path": "../plugins/jira-orchestrator",
       "source": "local",
       "installedAt": "2026-01-01T00:00:00.000Z",
@@ -82,7 +82,7 @@
       "dependencies": {}
     },
     "react-animation-studio": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "path": "../plugins/react-animation-studio",
       "source": "local",
       "installedAt": "2026-01-01T00:00:00.000Z",
@@ -116,21 +116,21 @@
       "dependencies": {}
     },
     "claude-code-expert": {
-      "version": "7.9.0",
+      "version": "8.2.0",
       "path": "../plugins/claude-code-expert",
       "source": "local",
       "installedAt": "2026-04-17T00:00:00.000Z",
       "dependencies": {}
     },
     "cowork-marketplace": {
-      "version": "2.0.0",
+      "version": "2.1.1",
       "path": "../plugins/cowork-marketplace",
       "source": "local",
       "installedAt": "2026-02-23T00:00:00.000Z",
       "dependencies": {}
     },
     "mui-expert": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "path": "../plugins/mui-expert",
       "source": "local",
       "installedAt": "2026-03-28T00:00:00.000Z",
@@ -145,7 +145,7 @@
       "dependencies": {}
     },
     "dotnet-blazor": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "path": "../plugins/dotnet-blazor",
       "source": "local",
       "installedAt": "2026-03-29T00:00:00.000Z",
@@ -166,7 +166,7 @@
       "dependencies": {}
     },
     "project-management-plugin": {
-      "version": "1.0.0",
+      "version": "1.4.0",
       "path": "../plugins/project-management-plugin",
       "source": "local",
       "installedAt": "2026-04-21T00:00:00.000Z",

--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -49,7 +49,7 @@ paths:
 - Hooks read context from stdin as JSON — parse with `jq`, not string matching
 - Hook exit code 0 means the JSON response is authoritative; non-zero is treated as an error
 - Register hooks in `.claude/settings.json` under the `hooks` key with the correct event name
-- Valid hook events: `PreToolUse`, `PostToolUse`, `PreSubagentCreate`, `PostToolUseFailure`, `Notification`, `Stop`
+- Valid hook events: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `UserPromptSubmit`, `Notification`, `Stop`, `SessionStart`, `SessionEnd`, `PreCompact`, `SubagentStart`, `SubagentStop`, `TeammateIdle`, `PermissionRequest`, `Setup`
 
 ## Helm / Kubernetes
 

--- a/.claude/rules/lessons-learned.md
+++ b/.claude/rules/lessons-learned.md
@@ -866,3 +866,9 @@ Node.js v24.14.1
 - **Error:** Exit code 128
 fatal: option '--stat' must come before non-option arguments
 - **Status:** NEEDS_FIX - Claude should document the fix here after resolving
+
+### Error: Read failure (2026-06-10T21:36:17Z)
+- **Tool:** Read
+- **Input:** `/home/user/claude/plugins/jira-orchestrator/workflows`
+- **Error:** EISDIR: illegal operation on a directory, read '/home/user/claude/plugins/jira-orchestrator/workflows'
+- **Status:** NEEDS_FIX - Claude should document the fix here after resolving

--- a/.claude/rules/memory-preferences.md
+++ b/.claude/rules/memory-preferences.md
@@ -15,6 +15,7 @@
 
 | Model | Use Case |
 |-------|----------|
+| Fable | Long-horizon autonomous runs, overnight builds, hardest reasoning (tier above Opus — reserve for work above Opus's ceiling) |
 | Opus | Architecture decisions, complex refactoring, multi-file analysis |
 | Sonnet | Feature implementation, bug fixes, code generation |
 | Haiku | Research lookups, documentation queries, fast searches |

--- a/.claude/rules/memory-profile.md
+++ b/.claude/rules/memory-profile.md
@@ -9,7 +9,7 @@
 
 ## Scale
 
-- 19 domain plugins in `plugins/`
+- 35 domain plugins in `plugins/`
 - 54 skills across plugins and `.claude/skills/`
 - 37 agents across plugins and `.claude/agents/`
 - 7 MCP servers (5 custom + 2 external)

--- a/.claude/rules/memory-profile.md
+++ b/.claude/rules/memory-profile.md
@@ -10,8 +10,8 @@
 ## Scale
 
 - 35 domain plugins in `plugins/`
-- 54 skills across plugins and `.claude/skills/`
-- 37 agents across plugins and `.claude/agents/`
+- 54 platform skills in `.claude/skills/` (plugins ship their own — jira-orchestrator alone adds 14)
+- 9 platform agents in `.claude/agents/` (plugins ship their own — jira-orchestrator alone adds 82)
 - 7 MCP servers (5 custom + 2 external)
 
 ## Tech Stack

--- a/.github/workflows/jira-pr-sync.yml
+++ b/.github/workflows/jira-pr-sync.yml
@@ -21,6 +21,11 @@ jobs:
     # Skip if PR is from Dependabot or other bots (optional)
     if: github.actor != 'dependabot[bot]'
 
+    # "true" only when all three Jira secrets are configured; Jira steps
+    # skip cleanly (instead of failing the job) when they are absent.
+    env:
+      JIRA_CONFIGURED: ${{ secrets.JIRA_BASE_URL != '' && secrets.JIRA_USER_EMAIL != '' && secrets.JIRA_API_TOKEN != '' }}
+
     steps:
       # Step 1: Checkout repository to access commit history
       - name: Checkout code
@@ -28,9 +33,16 @@ jobs:
         with:
           fetch-depth: 0  # Full history to extract all commit messages
 
+      - name: Notice when Jira secrets are not configured
+        if: env.JIRA_CONFIGURED != 'true'
+        run: |
+          echo "::notice::Jira sync skipped — secrets not configured."
+          echo "::notice::To enable, add repo secrets: JIRA_BASE_URL, JIRA_USER_EMAIL, JIRA_API_TOKEN"
+
       # Step 2: Authenticate with Jira
       # Required secrets: JIRA_BASE_URL, JIRA_USER_EMAIL, JIRA_API_TOKEN
       - name: Login to Jira
+        if: env.JIRA_CONFIGURED == 'true'
         uses: atlassian/gajira-login@v3
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
@@ -41,6 +53,7 @@ jobs:
       # Looks for patterns like: PROJECT-123, TEAM-456
       # Branch examples: feature/PROJECT-123-description, bugfix/TEAM-456
       - name: Find Jira issue key
+        if: env.JIRA_CONFIGURED == 'true'
         id: find-issue
         uses: atlassian/gajira-find-issue-key@v3
         with:
@@ -128,7 +141,7 @@ jobs:
       # Step 9: Comment on all related issues
       # Links all Jira issues mentioned in commits to this PR
       - name: Link all related Jira issues
-        if: steps.extract-issues.outputs.issue_keys != ''
+        if: env.JIRA_CONFIGURED == 'true' && steps.extract-issues.outputs.issue_keys != ''
         run: |
           IFS=',' read -ra KEYS <<< "${{ steps.extract-issues.outputs.issue_keys }}"
           for KEY in "${KEYS[@]}"; do

--- a/plugins/claude-code-expert/.claude-plugin/plugin.json
+++ b/plugins/claude-code-expert/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://claude.local/schemas/plugin.schema.json",
   "name": "claude-code-expert",
-  "version": "8.1.0",
-  "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 21 behavior-triggering skills, 12 single-intent commands, 18 role-scoped agents bridging engram and Obsidian. Tracks current Claude Code capabilities (Opus 4.8, agent teams, Tool Search, web/remote).",
+  "version": "8.2.0",
+  "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 21 behavior-triggering skills, 12 single-intent commands, 18 role-scoped agents bridging engram and Obsidian. Tracks current Claude Code capabilities (Fable 5 + Opus 4.8, agent teams, Tool Search, web/remote).",
   "author": {
     "name": "Markus Ahling"
   },

--- a/plugins/claude-code-expert/CHANGELOG.md
+++ b/plugins/claude-code-expert/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v8.2.0 (2026-06-10) — Claude 5 Family (Fable 5 / Mythos 5)
+
+### Models
+
+- **Fable 5** (`claude-fable-5`) documented across the plugin as the new Mythos-class tier *above*
+  Opus: added to `docs/CC-CAPABILITIES-2026-06.md` (with a dedicated Fable/Mythos section — always-on
+  thinking, effort-only depth control, 1M default context, longer turns, dependable async delegation,
+  refusal classifiers, no fast mode), `model-routing` skill, `agent-teams` skill, `ultraplan` skill,
+  `/cc-orchestrate`, plugin `CLAUDE.md`, and `README.md`. **Mythos 5** (`claude-mythos-5`) noted as the
+  same model for approved orgs (Project Glasswing).
+- **Pricing corrections** in `model-routing` and the MCP `MODEL_DATA` table: Opus 4.8 is $5/$25 per
+  MTok (was wrongly listed at $15/$75), Haiku 4.5 is $1/$5; Fable 5 added at $10/$50. Relative-cost
+  guidance updated (Opus ≈ 1.7× Sonnet, Fable ≈ 3.3× plus ~30% tokenizer overhead).
+- MCP `cc_docs_model_recommend`: `fable` routing tier added (long-horizon/overnight/autonomous-run
+  patterns), budget fallback chain now Fable → Opus → Sonnet → Haiku; `fable`/`mythos` added to the
+  model topic matcher.
+
+### Orchestration
+
+- `/cc-orchestrate`: new **Model tiers** section (when to escalate the orchestrator to Fable 5) and a
+  **Coordination surface** section (concurrent spawns, `run_in_background`, `SendMessage` continuation,
+  final-message-only return, `AskUserQuestion` discipline).
+- `agent-teams`: guidance on Fable 5 coordinators for multi-hour teams and relaxing prior-model
+  anti-delegation guardrails.
+- `model-routing`: Fable upgrade triggers, cascading row for overnight runs, anti-pattern for
+  defaulting to Fable; removed dead `references/cost-table.md` link.
+
 ## v8.1.0 (2026-06-04) — Capability Refresh (June 2026)
 
 Brings every Claude Code reference in the plugin current with what the tool can do as of

--- a/plugins/claude-code-expert/CHANGELOG.md
+++ b/plugins/claude-code-expert/CHANGELOG.md
@@ -27,6 +27,13 @@
 - `model-routing`: Fable upgrade triggers, cascading row for overnight runs, anti-pattern for
   defaulting to Fable; removed dead `references/cost-table.md` link.
 
+### Consistency upgrades
+
+- **Pinned model IDs → aliases** across all 18 agents, the 5 topology kits, and the
+  `plugin-development` example, per the capability baseline's own policy ("prefer aliases so a
+  model refresh doesn't strand config"). Frontmatter now reads `model: opus|sonnet|haiku`.
+- Plugin `CLAUDE.md` architecture summary corrected: 12 commands (was 11).
+
 ## v8.1.0 (2026-06-04) — Capability Refresh (June 2026)
 
 Brings every Claude Code reference in the plugin current with what the tool can do as of

--- a/plugins/claude-code-expert/CLAUDE.md
+++ b/plugins/claude-code-expert/CLAUDE.md
@@ -54,7 +54,7 @@ Full reference in [`docs/MCP_TOOLS.md`](docs/MCP_TOOLS.md).
 ## Plugin architecture
 
 - `skills/` (21) — behavior-triggering, ≤ 500 lines each, `references/` for heavy content.
-- `commands/` (11) — single-intent, route to skills and MCP tools.
+- `commands/` (12) — single-intent, route to skills and MCP tools.
 - `agents/` (18) — role-scoped, model-deliberate, tool-restricted.
 - `memory/` — three-tier baseline rules + consolidator audit.
 - `mcp-server/` — 22-tool reference server (port via stdio).

--- a/plugins/claude-code-expert/CLAUDE.md
+++ b/plugins/claude-code-expert/CLAUDE.md
@@ -5,7 +5,8 @@ Modern second brain for Claude Code. Five-layer stack deploy + three-tier memory
 > **Capability baseline:** what current Claude Code can do (models, tools, hooks, agent teams,
 > permissions, web/remote, memory) is tracked in [`docs/CC-CAPABILITIES-2026-06.md`](docs/CC-CAPABILITIES-2026-06.md).
 > It is the source of truth — when a skill or command disagrees with it, fix the skill. Latest models:
-> Opus 4.8 (`claude-opus-4-8`), Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5-20251001`).
+> Fable 5 (`claude-fable-5`, new Mythos-class tier above Opus), Opus 4.8 (`claude-opus-4-8`),
+> Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5-20251001`).
 
 ## Fast routing
 

--- a/plugins/claude-code-expert/README.md
+++ b/plugins/claude-code-expert/README.md
@@ -9,10 +9,11 @@ capability snapshot lives in [`docs/CC-CAPABILITIES-2026-06.md`](docs/CC-CAPABIL
 (models, tools, hooks, agent teams, permissions, web/remote, memory) — when a skill disagrees with
 it, the skill gets fixed.
 
-**Current models:** Opus 4.8 (`claude-opus-4-8`) · Sonnet 4.6 (`claude-sonnet-4-6`) · Haiku 4.5
-(`claude-haiku-4-5-20251001`). Aliases `opus`/`sonnet`/`haiku` auto-resolve to the latest;
-`/fast` keeps Opus reasoning with faster output; `effort` (`low`→`max`, `xhigh` on Opus 4.7/4.8)
-scales thinking depth without changing model.
+**Current models:** Fable 5 (`claude-fable-5`, Mythos-class tier above Opus) · Opus 4.8
+(`claude-opus-4-8`) · Sonnet 4.6 (`claude-sonnet-4-6`) · Haiku 4.5 (`claude-haiku-4-5-20251001`).
+Aliases `fable`/`opus`/`sonnet`/`haiku` auto-resolve to the latest; `/fast` keeps Opus reasoning
+with faster output (not on Fable); `effort` (`low`→`max`, `xhigh` on Opus 4.7/4.8 and Fable 5)
+scales thinking depth without changing model — on Fable 5 it's the only depth control.
 
 ## The 5-layer extension stack
 

--- a/plugins/claude-code-expert/agents/audit-reviewer.md
+++ b/plugins/claude-code-expert/agents/audit-reviewer.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Second-round audit agent that reviews work produced by other agents. Finds gaps, missed edge cases, inconsistencies, and quality issues that first-pass agents missed. Uses Context7 to validate library usage against official docs.
-model: claude-opus-4-8
+model: opus
 tools:
   - Read
   - Glob

--- a/plugins/claude-code-expert/agents/autonomy-planner.md
+++ b/plugins/claude-code-expert/agents/autonomy-planner.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Decomposes any engineering task into a phased, risk-assessed plan with explicit verification steps and rollback paths. Invoked by /cc-autonomy plan "<task>". Writes the plan to .claude/active-task.md. Never implements — plan-only.
-model: claude-opus-4-8
+model: opus
 tools:
   - Read
   - Glob

--- a/plugins/claude-code-expert/agents/autonomy-reviewer.md
+++ b/plugins/claude-code-expert/agents/autonomy-reviewer.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Final review agent for autonomous work. Reads the plan from .claude/active-task.md, diffs changed files against the plan, reads each changed file, and issues BLOCK or APPROVE with specific findings. Invoked by /cc-autonomy review after the verifier passes. Never modifies files.
-model: claude-opus-4-8
+model: opus
 tools:
   - Read
   - Glob
@@ -123,7 +123,7 @@ Output the report to console only. Do not write to any file.
 === Autonomy Review ===
 Task:  <goal from active-task.md>
 Date:  <ISO timestamp>
-Reviewer: autonomy-reviewer (claude-opus-4-8)
+Reviewer: autonomy-reviewer (opus)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 BLOCK ✗  |  APPROVE ✓

--- a/plugins/claude-code-expert/agents/autonomy-verifier.md
+++ b/plugins/claude-code-expert/agents/autonomy-verifier.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Runs the verification suite after an implementation phase completes. Reads verification steps from .claude/active-task.md, detects project type, runs typecheck + lint + tests + diff check + secret scan, and produces a structured PASS or FAIL report. Never modifies files.
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Bash
   - Read

--- a/plugins/claude-code-expert/agents/debugger.md
+++ b/plugins/claude-code-expert/agents/debugger.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Scope — generic code-level bugs in the user's codebase. Systematic root-cause tracer using hypothesis-driven investigation; read-only by default, proposes fixes without applying them unless explicitly authorized. For Claude Code itself (MCP, hooks, plugin install), use the `claude-code-debugger` agent instead.
-model: claude-opus-4-8
+model: opus
 allowed-tools:
   - Read
   - Glob

--- a/plugins/claude-code-expert/agents/dependency-auditor.md
+++ b/plugins/claude-code-expert/agents/dependency-auditor.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Dependency health auditor — checks for security vulnerabilities, outdated packages, license issues, and bloat. Produces actionable upgrade reports. Read-only; does not modify package files.
-model: claude-haiku-4-5-20251001
+model: haiku
 allowed-tools:
   - Read
   - Bash

--- a/plugins/claude-code-expert/agents/evaluator-optimizer.md
+++ b/plugins/claude-code-expert/agents/evaluator-optimizer.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Implements the Evaluator-Optimizer loop pattern — generates an artifact, evaluates it against a rubric, and iteratively refines until quality threshold is met or max iterations reached. Use for code generation, config authoring, and any task where output quality must be verified before acceptance.
-model: claude-opus-4-8
+model: opus
 tools:
   - Read
   - Write

--- a/plugins/claude-code-expert/agents/implementer.md
+++ b/plugins/claude-code-expert/agents/implementer.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Focused implementation agent — writes code, edits files, runs builds. Restricted to write tools. Does not read broad context, only what's needed for the current task.
-model: claude-sonnet-4-6
+model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/plugins/claude-code-expert/agents/index.json
+++ b/plugins/claude-code-expert/agents/index.json
@@ -124,7 +124,7 @@
     },
     {
       "name": "claude-code-expert:memory-consolidator",
-      "intent": "Memory Consolidator",
+      "intent": "Consolidates working memory (engram) into durable knowledge (Obsidian vault) and baseline plugin rules, with strict read-only access to engram and user-curated notes.",
       "tags": [
         "claude-code-expert",
         "agent",

--- a/plugins/claude-code-expert/agents/memory-consolidator.md
+++ b/plugins/claude-code-expert/agents/memory-consolidator.md
@@ -2,7 +2,7 @@
 name: claude-code-expert:memory-consolidator
 intent: Consolidates working memory (engram) into durable knowledge (Obsidian vault) and baseline plugin rules, with strict read-only access to engram and user-curated notes.
 description: Bridges the three memory tiers — reads engram (tier 1, never writes), promotes reusable patterns and decisions into the Obsidian vault (tier 2) and plugin baseline rules (tier 3). Read-only on engram and on user-curated Obsidian notes; writes only auto-generated notes. Invoke for memory consolidation, vault sync, or promoting session learnings into durable storage.
-model: claude-opus-4-8
+model: opus
 tags:
   - claude-code-expert
   - agent

--- a/plugins/claude-code-expert/agents/memory-consolidator.md
+++ b/plugins/claude-code-expert/agents/memory-consolidator.md
@@ -1,8 +1,6 @@
 ---
 name: claude-code-expert:memory-consolidator
 intent: Consolidates working memory (engram) into durable knowledge (Obsidian vault) and baseline plugin rules, with strict read-only access to engram and user-curated notes.
-description: Bridges the three memory tiers — reads engram (tier 1, never writes), promotes reusable patterns and decisions into the Obsidian vault (tier 2) and plugin baseline rules (tier 3). Read-only on engram and on user-curated Obsidian notes; writes only auto-generated notes. Invoke for memory consolidation, vault sync, or promoting session learnings into durable storage.
-model: opus
 tags:
   - claude-code-expert
   - agent
@@ -10,6 +8,8 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Bridges the three memory tiers — reads engram (tier 1, never writes), promotes reusable patterns and decisions into the Obsidian vault (tier 2) and plugin baseline rules (tier 3). Read-only on engram and on user-curated Obsidian notes; writes only auto-generated notes. Invoke for memory consolidation, vault sync, or promoting session learnings into durable storage.
+model: opus
 ---
 
 # Memory Consolidator

--- a/plugins/claude-code-expert/agents/migration-lead.md
+++ b/plugins/claude-code-expert/agents/migration-lead.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Migration planning and execution specialist for database schema changes, API version migrations, dependency upgrades, and large-scale refactors. Emphasis on zero-downtime and rollback safety.
-model: claude-opus-4-8
+model: opus
 allowed-tools:
   - Read
   - Write

--- a/plugins/claude-code-expert/agents/pattern-router.md
+++ b/plugins/claude-code-expert/agents/pattern-router.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Analyzes incoming tasks and selects the optimal agentic design pattern (prompt chain, routing, parallelization, eval-optimizer, orchestrator-workers, reflection, or ReAct). Routes to the right pattern implementation to avoid over-engineering simple tasks or under-powering complex ones.
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Glob

--- a/plugins/claude-code-expert/agents/plugin-architect.md
+++ b/plugins/claude-code-expert/agents/plugin-architect.md
@@ -11,7 +11,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Plugin architecture specialist that designs plugin structures, scaffolds files, validates manifests, and advises on marketplace publishing readiness.
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Write

--- a/plugins/claude-code-expert/agents/principal-engineer-strategist.md
+++ b/plugins/claude-code-expert/agents/principal-engineer-strategist.md
@@ -15,7 +15,7 @@ inputs:
 risk: medium
 cost: high
 description: Principal-level engineering strategist for deep analysis, root-cause isolation, architecture review, and implementation pressure-testing.
-model: claude-opus-4-8
+model: opus
 tools:
   - Read
   - Glob

--- a/plugins/claude-code-expert/agents/release-coordinator.md
+++ b/plugins/claude-code-expert/agents/release-coordinator.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Release planning and execution coordinator. Generates changelogs, tags versions, validates release readiness, coordinates with CI/CD. Emphasizes checklist-driven, reversible releases.
-model: claude-sonnet-4-6
+model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/plugins/claude-code-expert/agents/research-orchestrator.md
+++ b/plugins/claude-code-expert/agents/research-orchestrator.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Routes research tasks to the optimal MCP tool chain — Perplexity for knowledge Q&A, Firecrawl for structured extraction, Context7 for library docs. Chains tools for comprehensive results.
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Agent
   - Read

--- a/plugins/claude-code-expert/agents/security-compliance-advisor.md
+++ b/plugins/claude-code-expert/agents/security-compliance-advisor.md
@@ -15,7 +15,7 @@ inputs:
 risk: low
 cost: medium
 description: Security and compliance specialist that audits Claude Code setups against enterprise security checklists and produces actionable compliance reports.
-model: claude-opus-4-8
+model: opus
 tools:
   - Read
   - Glob

--- a/plugins/claude-code-expert/agents/team-orchestrator.md
+++ b/plugins/claude-code-expert/agents/team-orchestrator.md
@@ -9,7 +9,7 @@ inputs: []
 risk: medium
 cost: medium
 description: Master orchestrator that prefers delegation over direct work. Manages agent teams, coordinates sub-agents, enforces audit loops, and maintains agent lifecycle health.
-model: claude-opus-4-8
+model: opus
 tools:
   - Agent
   - Read

--- a/plugins/claude-code-expert/commands/cc-orchestrate.md
+++ b/plugins/claude-code-expert/commands/cc-orchestrate.md
@@ -53,10 +53,23 @@ If `--pattern` isn't provided, runs `pattern-router` agent first. Router returns
 
 1. Pattern chosen (explicitly or via router).
 2. Topology chosen (from `--topology` or `cc_docs_team_topology_recommend`).
-3. `team-orchestrator` agent (Opus) launches specialists with correct tool restrictions and worktree isolation.
+3. `team-orchestrator` agent (Opus by default) launches specialists with correct tool restrictions and worktree isolation.
 4. **Between waves** (orchestrator-workers / blackboard): `verify-between-waves` skill runs as a gate — typecheck + lint + tests must pass before the next wave starts. See [`skills/verify-between-waves/SKILL.md`](../skills/verify-between-waves/SKILL.md).
 5. Coordinator gathers outputs and synthesizes.
 6. Returns: final artifact + decision log + cost actual vs estimate.
+
+## Model tiers
+
+Default split: Opus orchestrator + Sonnet workers + Haiku researchers (see [`skills/model-routing/SKILL.md`](../skills/model-routing/SKILL.md)).
+
+**Escalate the orchestrator to Fable 5** (`--model fable` on the lead, or `model: fable` on the spawn) when the run is long-horizon: overnight builds, end-to-end migrations, or 3+ waves where orchestrator drift is the failure mode. Fable sustains multi-hour coordination and long-lived async subagents that stall lesser models — but costs ~2× Opus per token (plus ~30% more tokens from its tokenizer), so workers stay on Sonnet. Don't escalate single-wave or routine runs.
+
+## Coordination surface
+
+- Spawn independent specialists **in one message** so they run concurrently; use `run_in_background: true` for workers the orchestrator shouldn't block on.
+- Give teammates a `name` and continue them via `SendMessage` — a fresh `Agent` call loses their context.
+- Only a teammate's **final message** returns to the orchestrator; have workers end with a structured summary.
+- Use `AskUserQuestion` only for genuine scope decisions mid-run — never for confirmations the budget/pattern already answers.
 
 **Resume**: If a multi-wave run was interrupted, `--resume` reads `.claude/active-task.md` (written by each wave) and restarts from the last completed wave. When using the Agent SDK programmatically, pass `resume: "<session-id>"` instead — session files are at `~/.claude/projects/<url-encoded-cwd>/<session-id>.jsonl`.
 

--- a/plugins/claude-code-expert/commands/index.json
+++ b/plugins/claude-code-expert/commands/index.json
@@ -136,7 +136,7 @@
     },
     {
       "name": "cc-skills",
-      "intent": "The claude-code-expert plugin ships ~54 skills. Reading CLAUDE.md and hunting for trigger keywords is not a good discovery UX. /cc-skills lists every skill in the plugin, grouped by category, with its trigger phrases and a one-line description so you can find the right one in",
+      "intent": "The claude-code-expert plugin ships 21 skills. Reading CLAUDE.md and hunting for trigger keywords is not a good discovery UX. /cc-skills lists every skill in the plugin, grouped by category, with its trigger phrases and a one-line description so you can find the right one in",
       "tags": [
         "claude-code-expert",
         "command",

--- a/plugins/claude-code-expert/docs/CC-CAPABILITIES-2026-06.md
+++ b/plugins/claude-code-expert/docs/CC-CAPABILITIES-2026-06.md
@@ -1,6 +1,6 @@
 # Claude Code Capability Baseline — June 2026
 
-Authoritative snapshot of what Claude Code can do as of **June 1, 2026**, used to keep this
+Authoritative snapshot of what Claude Code can do as of **June 10, 2026**, used to keep this
 plugin's skills, commands, and agents current. When a skill or command contradicts this file,
 this file wins — update the skill. Sourced from `code.claude.com/docs` plus the live runtime
 tool surface.
@@ -15,18 +15,43 @@ tool surface.
 
 | Alias | Latest ID | Use |
 |---|---|---|
+| `fable` | `claude-fable-5` | Hardest long-horizon agentic runs, overnight builds, deepest reasoning — the Claude 5 / Mythos-class tier above Opus |
 | `opus` | `claude-opus-4-8` | Architecture, hard debugging, security review, planning/review gates |
 | `sonnet` | `claude-sonnet-4-6` | Implementation, code review, refactoring, test writing |
 | `haiku` | `claude-haiku-4-5-20251001` | Retrieval, research, docs, bulk mechanical edits |
 
 Helper aliases: `best` (most capable available), `opusplan` (Opus reasoning → Sonnet execution),
 `opus[1m]` / `sonnet[1m]` (extended 1M-token context). `default` resolves per plan tier.
+The `Agent` tool's `model` override accepts `fable` alongside `sonnet`/`opus`/`haiku`.
+
+### Claude Fable 5 / Mythos 5 (new tier, June 2026)
+
+**Fable 5** (`claude-fable-5`) is the first Claude 5 model — a Mythos-class tier *above* Opus
+in capability, not an Opus replacement. **Mythos 5** (`claude-mythos-5`) is the same underlying
+model without Fable's additional dual-use safety measures, available only to approved
+organizations (Project Glasswing). See https://www.anthropic.com/news/claude-fable-5-mythos-5.
+
+What changes in practice when routing to Fable 5:
+
+- **1M context by default** (128K max output); `claude-fable-5[1m]` is the long-context ID form.
+- **Thinking is always on** — there is no thinking toggle; depth is controlled purely by
+  `effort` (`low` → `max`, including `xhigh`). Even `low` effort on Fable often beats `max` on
+  prior models for routine work.
+- **Longer turns** — single hard-task turns can run many minutes; plan for async check-ins and
+  background agents rather than blocking.
+- **Dependable parallel/async delegation** — sustains long-running subagents and teammate
+  messaging well; prior-model guardrails that suppressed delegation should be relaxed.
+- **~3.3× Sonnet pricing** ($10/$50 per MTok) vs Opus 4.8's ~1.7× ($5/$25) — reserve it for
+  work above what Opus handles, not as a blanket default.
+- Safety classifiers may refuse research-bio / most cybersecurity content (`refusal` stop
+  reason); requires 30-day data retention (not available under ZDR).
 
 - **Effort levels** (reasoning depth, independent of model): `low` · `medium` · `high` · `xhigh` · `max`.
-  Opus 4.7/4.8 add `xhigh`. Set with `/effort`, `--effort <level>`, or `effort:` in skill/agent frontmatter.
-  Bumping effort is cheaper than jumping a model tier when you only need deeper thinking.
+  Opus 4.7/4.8 and Fable 5 support `xhigh`. Set with `/effort`, `--effort <level>`, or `effort:` in
+  skill/agent frontmatter. Bumping effort is cheaper than jumping a model tier when you only need
+  deeper thinking.
 - **Fast mode** (`/fast`, `--fast`): keeps you on Opus (4.6/4.7/4.8) with faster output — it does
-  **not** downgrade to a smaller model.
+  **not** downgrade to a smaller model. Not available on Fable 5.
 
 ---
 

--- a/plugins/claude-code-expert/mcp-server/kb/topologies/architect-implementer-reviewer.json
+++ b/plugins/claude-code-expert/mcp-server/kb/topologies/architect-implementer-reviewer.json
@@ -3,9 +3,9 @@
   "summary": "3-agent trio with explicit design gate: Architect drafts the plan, Implementer executes, Reviewer gates the merge.",
   "when_to_use": "Medium-to-large features with non-trivial design choices where the team wants design review before code is written.",
   "composition": [
-    { "role": "architect", "model": "claude-opus-4-8", "tools": ["Read", "Grep", "Glob"], "writes": false },
-    { "role": "implementer", "model": "claude-sonnet-4-6", "tools": ["Read", "Edit", "Write", "Bash", "Grep", "Glob"], "writes": true },
-    { "role": "reviewer", "model": "claude-opus-4-8", "tools": ["Read", "Grep", "Glob", "Bash"], "writes": false }
+    { "role": "architect", "model": "opus", "tools": ["Read", "Grep", "Glob"], "writes": false },
+    { "role": "implementer", "model": "sonnet", "tools": ["Read", "Edit", "Write", "Bash", "Grep", "Glob"], "writes": true },
+    { "role": "reviewer", "model": "opus", "tools": ["Read", "Grep", "Glob", "Bash"], "writes": false }
   ],
   "file_ownership": {
     "architect": "writes only docs/design/*.md",

--- a/plugins/claude-code-expert/mcp-server/kb/topologies/competing-hypotheses-debug.json
+++ b/plugins/claude-code-expert/mcp-server/kb/topologies/competing-hypotheses-debug.json
@@ -3,10 +3,10 @@
   "summary": "3 parallel investigators pursue different root-cause hypotheses; an Opus synthesizer picks the winner.",
   "when_to_use": "Tricky bugs where the cause is genuinely unclear and multiple theories are plausible. Not for straightforward bugs.",
   "composition": [
-    { "role": "investigator-a", "model": "claude-sonnet-4-6", "tools": ["Read", "Grep", "Glob", "Bash"], "hypothesis": "primary suspicion (e.g. race condition)" },
-    { "role": "investigator-b", "model": "claude-sonnet-4-6", "tools": ["Read", "Grep", "Glob", "Bash"], "hypothesis": "secondary suspicion (e.g. cache staleness)" },
-    { "role": "investigator-c", "model": "claude-sonnet-4-6", "tools": ["Read", "Grep", "Glob", "Bash"], "hypothesis": "outside-the-box (e.g. env-config divergence)" },
-    { "role": "synthesizer", "model": "claude-opus-4-8", "tools": ["Read"], "writes": false }
+    { "role": "investigator-a", "model": "sonnet", "tools": ["Read", "Grep", "Glob", "Bash"], "hypothesis": "primary suspicion (e.g. race condition)" },
+    { "role": "investigator-b", "model": "sonnet", "tools": ["Read", "Grep", "Glob", "Bash"], "hypothesis": "secondary suspicion (e.g. cache staleness)" },
+    { "role": "investigator-c", "model": "sonnet", "tools": ["Read", "Grep", "Glob", "Bash"], "hypothesis": "outside-the-box (e.g. env-config divergence)" },
+    { "role": "synthesizer", "model": "opus", "tools": ["Read"], "writes": false }
   ],
   "file_ownership": {
     "investigators": "each writes to .claude/investigations/{role}.md — evidence table, ruled-in/ruled-out, proposed fix",

--- a/plugins/claude-code-expert/mcp-server/kb/topologies/docs-migration-sprint.json
+++ b/plugins/claude-code-expert/mcp-server/kb/topologies/docs-migration-sprint.json
@@ -3,10 +3,10 @@
   "summary": "3 Sonnet writers + 1 Opus editor. Bulk migration of docs (framework version bumps, brand renames, terminology changes).",
   "when_to_use": "Large doc-only migrations with clear find-replace pattern but requiring context-aware rewriting (not a pure sed pass).",
   "composition": [
-    { "role": "writer-a", "model": "claude-sonnet-4-6", "owns": "alphabetically first third of docs/" },
-    { "role": "writer-b", "model": "claude-sonnet-4-6", "owns": "middle third" },
-    { "role": "writer-c", "model": "claude-sonnet-4-6", "owns": "last third" },
-    { "role": "editor", "model": "claude-opus-4-8", "writes": "final touch-ups only" }
+    { "role": "writer-a", "model": "sonnet", "owns": "alphabetically first third of docs/" },
+    { "role": "writer-b", "model": "sonnet", "owns": "middle third" },
+    { "role": "writer-c", "model": "sonnet", "owns": "last third" },
+    { "role": "editor", "model": "opus", "writes": "final touch-ups only" }
   ],
   "file_ownership": "Sharded by alphabet to avoid collisions. No shared files. Each writer works in an isolated worktree.",
   "coordination": [

--- a/plugins/claude-code-expert/mcp-server/kb/topologies/frontend-backend-test-squad.json
+++ b/plugins/claude-code-expert/mcp-server/kb/topologies/frontend-backend-test-squad.json
@@ -3,10 +3,10 @@
   "summary": "3 parallel Sonnet workers (frontend, backend, test) + 1 Opus coordinator. Standard full-stack feature squad.",
   "when_to_use": "Features requiring coordinated changes across UI, API, and test layers with clear file-boundary ownership.",
   "composition": [
-    { "role": "frontend-agent", "model": "claude-sonnet-4-6", "owns": "src/components/**, src/pages/**, src/hooks/**" },
-    { "role": "backend-agent", "model": "claude-sonnet-4-6", "owns": "src/api/**, src/services/**, src/db/**" },
-    { "role": "test-agent", "model": "claude-sonnet-4-6", "owns": "**/*.test.*, **/*.spec.*, src/test/**" },
-    { "role": "coordinator", "model": "claude-opus-4-8", "writes": false, "note": "Runs in main context; decomposes, merges, resolves conflicts" }
+    { "role": "frontend-agent", "model": "sonnet", "owns": "src/components/**, src/pages/**, src/hooks/**" },
+    { "role": "backend-agent", "model": "sonnet", "owns": "src/api/**, src/services/**, src/db/**" },
+    { "role": "test-agent", "model": "sonnet", "owns": "**/*.test.*, **/*.spec.*, src/test/**" },
+    { "role": "coordinator", "model": "opus", "writes": false, "note": "Runs in main context; decomposes, merges, resolves conflicts" }
   ],
   "coordination": [
     "Phase 1 (parallel): frontend-agent + backend-agent implement their slices in separate worktrees.",

--- a/plugins/claude-code-expert/mcp-server/kb/topologies/security-performance-test-review-board.json
+++ b/plugins/claude-code-expert/mcp-server/kb/topologies/security-performance-test-review-board.json
@@ -3,11 +3,11 @@
   "summary": "4 parallel Sonnet specialists review the same diff from different angles, Opus synth produces the final verdict.",
   "when_to_use": "PR review where discipline specialists are cheaper per issue caught than a generalist reviewer.",
   "composition": [
-    { "role": "security-reviewer", "model": "claude-sonnet-4-6", "focus": "OWASP, auth, secrets, injection, authz, crypto misuse" },
-    { "role": "performance-reviewer", "model": "claude-sonnet-4-6", "focus": "N+1 queries, O(n²), cache invalidation, memory leaks, bundle size" },
-    { "role": "test-reviewer", "model": "claude-sonnet-4-6", "focus": "coverage gaps, flaky patterns, test quality, missing edge cases" },
-    { "role": "style-reviewer", "model": "claude-sonnet-4-6", "focus": "naming, dead code, comments, consistency with existing patterns" },
-    { "role": "synthesizer", "model": "claude-opus-4-8", "writes": false }
+    { "role": "security-reviewer", "model": "sonnet", "focus": "OWASP, auth, secrets, injection, authz, crypto misuse" },
+    { "role": "performance-reviewer", "model": "sonnet", "focus": "N+1 queries, O(n²), cache invalidation, memory leaks, bundle size" },
+    { "role": "test-reviewer", "model": "sonnet", "focus": "coverage gaps, flaky patterns, test quality, missing edge cases" },
+    { "role": "style-reviewer", "model": "sonnet", "focus": "naming, dead code, comments, consistency with existing patterns" },
+    { "role": "synthesizer", "model": "opus", "writes": false }
   ],
   "file_ownership": {
     "specialists": "each writes .claude/reviews/{role}.md — one section per finding (severity, location, suggested fix)",

--- a/plugins/claude-code-expert/mcp-server/src/index.js
+++ b/plugins/claude-code-expert/mcp-server/src/index.js
@@ -179,7 +179,7 @@ const TASK_HINTS = [
   },
   {
     kind: "model",
-    match: ["model", "cost", "budget", "routing", "expensive", "cheap", "haiku", "sonnet", "opus"],
+    match: ["model", "cost", "budget", "routing", "expensive", "cheap", "haiku", "sonnet", "opus", "fable", "mythos"],
     docs: ["model-routing", "cost-optimization", "cc-perf"],
   },
   {
@@ -300,12 +300,14 @@ function resolveTask(query) {
 
 // --- Model routing data for cc_docs_model_recommend ---
 const MODEL_DATA = {
-  "opus": { id: "claude-opus-4-8", inputCost: 15.00, outputCost: 75.00, cacheRead: 1.50, best: "architecture, complex debugging, security review" },
+  "fable": { id: "claude-fable-5", inputCost: 10.00, outputCost: 50.00, cacheRead: 1.00, best: "long-horizon autonomous runs, hardest reasoning above Opus's ceiling, multi-hour orchestration" },
+  "opus": { id: "claude-opus-4-8", inputCost: 5.00, outputCost: 25.00, cacheRead: 0.50, best: "architecture, complex debugging, security review" },
   "sonnet": { id: "claude-sonnet-4-6", inputCost: 3.00, outputCost: 15.00, cacheRead: 0.30, best: "implementation, code review, refactoring, test writing" },
-  "haiku": { id: "claude-haiku-4-5-20251001", inputCost: 0.80, outputCost: 4.00, cacheRead: 0.08, best: "lookups, research, docs, simple Q&A, commit messages" },
+  "haiku": { id: "claude-haiku-4-5-20251001", inputCost: 1.00, outputCost: 5.00, cacheRead: 0.10, best: "lookups, research, docs, simple Q&A, commit messages" },
 };
 
 const TASK_MODEL_MAP = [
+  { patterns: ["long-horizon", "overnight", "multi-day", "autonomous run", "end-to-end migration", "hardest"], model: "fable", reason: "Long-horizon autonomous work above Opus's ceiling — Fable 5 sustains multi-hour runs and async subagent fleets" },
   { patterns: ["architecture", "design", "complex", "security review", "audit"], model: "opus", reason: "Deep multi-step reasoning required" },
   { patterns: ["debug", "root cause", "hard bug", "race condition", "flaky"], model: "opus", reason: "Complex hypothesis evaluation" },
   { patterns: ["implement", "build", "create", "add feature", "refactor", "code review", "test"], model: "sonnet", reason: "Best cost/quality for code generation" },
@@ -329,7 +331,7 @@ function recommendModel(task, budget) {
   if (budget) {
     const budgetNum = parseFloat(budget.replace("$", ""));
     if (!isNaN(budgetNum) && estCost > budgetNum && rec.model !== "haiku") {
-      const fallback = rec.model === "opus" ? "sonnet" : "haiku";
+      const fallback = rec.model === "fable" ? "opus" : rec.model === "opus" ? "sonnet" : "haiku";
       const fbData = MODEL_DATA[fallback];
       const fbCost = (estInputTokens / 1e6) * fbData.inputCost + (estOutputTokens / 1e6) * fbData.outputCost;
       return {

--- a/plugins/claude-code-expert/skills/agent-teams/SKILL.md
+++ b/plugins/claude-code-expert/skills/agent-teams/SKILL.md
@@ -84,6 +84,13 @@ The agent's **final message is the only thing returned to the parent** — relay
 user doesn't see a teammate's transcript. Keep spawn prompts under ~400 words and prefer named
 specialists over generics (see `prompt-budget-preflight`).
 
+**Fable 5 for long-horizon coordinators.** When a team runs for hours (overnight builds, multi-wave
+migrations), put the coordinator on `model: fable` — Fable 5 reliably sustains ongoing messaging
+with long-running async subagents and doesn't drift across waves the way smaller orchestrators can.
+Workers stay on Sonnet; the tier premium (~2× Opus per token) only pays off on the coordinator
+role. Old "don't over-delegate" guardrails written for prior models should be relaxed on Fable —
+delegation is dependable there.
+
 ## Lifecycle management
 
 Long-running or idle agents waste tokens. `team-orchestrator` agent handles this:

--- a/plugins/claude-code-expert/skills/model-routing/SKILL.md
+++ b/plugins/claude-code-expert/skills/model-routing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-routing
-description: Pick the right Claude model (Opus, Sonnet, Haiku) for a task and manage cost — decision matrix, cost tables, budget planning, cascading strategy. Use this skill whenever choosing a model, setting a token budget, optimizing session cost, or deciding whether to upgrade/downgrade mid-task. Triggers on: "which model", "cost", "budget", "haiku vs sonnet", "opus for this", "save tokens", "model cascading", "/cc-budget".
+description: Pick the right Claude model (Fable, Opus, Sonnet, Haiku) for a task and manage cost — decision matrix, cost tables, budget planning, cascading strategy. Use this skill whenever choosing a model, setting a token budget, optimizing session cost, or deciding whether to upgrade/downgrade mid-task. Triggers on: "which model", "cost", "budget", "haiku vs sonnet", "opus for this", "fable for this", "save tokens", "model cascading", "/cc-budget".
 ---
 
 # Model Routing
@@ -11,6 +11,8 @@ Claude model choice is the biggest cost lever in Claude Code. Match the model to
 
 | Task type | Model | Why |
 |---|---|---|
+| Long-horizon autonomous run (overnight build, large migration end-to-end) | Fable | Sustains multi-hour agentic work and async subagent fleets that stall lesser models |
+| Hardest unsolved problem (Opus failed or would need many retries) | Fable | Highest reasoning ceiling; one Fable pass can beat several Opus retries |
 | Architecture decision | Opus | Multi-step reasoning; hidden-cost detection |
 | Root-cause debugging (hard) | Opus | Hypothesis trees, multi-source evidence |
 | Security review | Opus | Risk sensitivity; knowledge of OWASP/CWE |
@@ -26,17 +28,18 @@ Claude model choice is the biggest cost lever in Claude Code. Match the model to
 
 | Model | Alias / ID | Input $/M | Output $/M | Relative |
 |---|---|---|---|---|
-| Opus 4.8 | `opus` / `claude-opus-4-8` | ~$15 | ~$75 | 5× |
-| Sonnet 4.6 | `sonnet` / `claude-sonnet-4-6` | ~$3 | ~$15 | 1× |
-| Haiku 4.5 | `haiku` / `claude-haiku-4-5-20251001` | ~$0.80 | ~$4 | 0.3× |
+| Fable 5 | `fable` / `claude-fable-5` | $10 | $50 | 3.3× |
+| Opus 4.8 | `opus` / `claude-opus-4-8` | $5 | $25 | 1.7× |
+| Sonnet 4.6 | `sonnet` / `claude-sonnet-4-6` | $3 | $15 | 1× |
+| Haiku 4.5 | `haiku` / `claude-haiku-4-5-20251001` | $1 | $5 | 0.33× |
 
-Output tokens are the dominant cost in most Claude Code sessions. Opus is ~5× the cost but ~2× the capability on hard tasks — use it where the capability matters.
+Output tokens are the dominant cost in most Claude Code sessions. Two caveats on Fable 5: its new tokenizer produces ~30% more tokens for the same content (so the effective gap vs Opus is wider than the per-token price), and turns run longer. Use it where the capability ceiling matters, not as a default.
 
-**Aliases auto-resolve to the latest generation** — prefer `opus`/`sonnet`/`haiku` over pinned IDs so a model refresh doesn't strand your config. Use `opusplan` for Opus-reasoning + Sonnet-execution, or `best` for "most capable available". Extended 1M-token context: `opus[1m]` / `sonnet[1m]`.
+**Aliases auto-resolve to the latest generation** — prefer `fable`/`opus`/`sonnet`/`haiku` over pinned IDs so a model refresh doesn't strand your config. Use `opusplan` for Opus-reasoning + Sonnet-execution, or `best` for "most capable available". Extended 1M-token context: `opus[1m]` / `sonnet[1m]` (Fable 5 is 1M by default; `claude-fable-5[1m]` is the long-context ID form).
 
-**Fast mode** (`/fast` in-session, `--fast` at launch) keeps you on Opus (4.6/4.7/4.8) but optimizes for faster output — it does **not** downgrade to a smaller model. Toggle it when you want Opus-level reasoning without the usual latency.
+**Fast mode** (`/fast` in-session, `--fast` at launch) keeps you on Opus (4.6/4.7/4.8) but optimizes for faster output — it does **not** downgrade to a smaller model. Toggle it when you want Opus-level reasoning without the usual latency. Not available on Fable 5.
 
-**Effort levels** scale reasoning depth independently of model: `low` · `medium` · `high` · `xhigh` · `max` (Opus 4.7/4.8 add `xhigh`). Set via `/effort`, `--effort <level>`, or `effort:` in skill/agent frontmatter — cheaper than jumping a model tier when you just need deeper thinking.
+**Effort levels** scale reasoning depth independently of model: `low` · `medium` · `high` · `xhigh` · `max` (Opus 4.7/4.8 and Fable 5 support `xhigh`). Set via `/effort`, `--effort <level>`, or `effort:` in skill/agent frontmatter — cheaper than jumping a model tier when you just need deeper thinking. On Fable 5 thinking is always on and effort is the *only* depth control — and even `low` effort on Fable often matches or beats `max` on prior models, so sweep downward for routine work.
 
 ## Model cascading
 
@@ -44,13 +47,14 @@ The high-leverage pattern: start with a cheap model for planning, delegate imple
 
 | Phase | Model |
 |---|---|
-| Plan mode (Shift+Tab) | Opus |
+| Plan mode (Shift+Tab) | Opus (Fable for the hardest/longest-horizon plans) |
 | Implementation | Sonnet |
 | Subagent research | Haiku |
 | Code review gate | Opus |
 | Final sign-off | Opus |
+| Overnight / multi-hour autonomous run | Fable (orchestrator only; workers stay on Sonnet) |
 
-Net effect: most tokens are on Sonnet/Haiku; Opus tokens are where they matter most.
+Net effect: most tokens are on Sonnet/Haiku; Opus tokens are where they matter most; Fable tokens are reserved for the rare runs that justify the tier.
 
 ## Budget planning
 
@@ -77,6 +81,12 @@ Use `cc_docs_model_recommend(task, budget)` to get a specific recommendation wit
 - Stakeholder cost of error is ≥ days of engineer time.
 - You're designing something new (vs. implementing something known).
 
+**Upgrade to Fable when**:
+- Opus has failed (or would clearly need multiple retries) on the same problem.
+- The run is long-horizon and autonomous — overnight builds, end-to-end migrations, multi-wave orchestration where mid-run drift is the failure mode.
+- You're coordinating a fleet of long-lived async subagents and need the orchestrator to stay coherent for hours.
+- Don't route security-scanning/offensive-security analysis to Fable — its cyber safety classifiers can refuse (`refusal` stop reason); keep that on Opus.
+
 ## /plan mode
 
 `Shift+Tab` toggles plan mode — uses Opus to think deeper without producing code. Use for:
@@ -96,11 +106,8 @@ Don't use plan mode for: known patterns, mechanical work, small tweaks.
 
 ## Anti-patterns
 
-- Defaulting to Opus everywhere → 5× cost, rarely 5× value.
-- Haiku on hard tasks → gets it wrong, then you re-run on Opus = 6× cost.
+- Defaulting to Opus everywhere → ~1.7× cost, rarely 1.7× value on routine work.
+- Defaulting to Fable everywhere → 3.3× price *and* ~30% more tokens per task; the tier pays off only above Opus's ceiling.
+- Haiku on hard tasks → gets it wrong, then you re-run on Opus = wasted double cost.
 - Ignoring `/plan` on new work → code-first on unfamiliar problems wastes tokens.
 - Not estimating budget → costs creep; you notice on the monthly bill.
-
-## Reference
-
-- [cost-table.md](references/cost-table.md) — detailed cost breakdown by task type

--- a/plugins/claude-code-expert/skills/plugin-development/SKILL.md
+++ b/plugins/claude-code-expert/skills/plugin-development/SKILL.md
@@ -99,7 +99,7 @@ The command body is plain markdown executed as a prompt when the user runs `/plu
 ---
 name: agent-name
 description: When to invoke; ≥3 trigger phrases.
-model: claude-sonnet-4-6
+model: sonnet
 allowed-tools:
   - Read
   - Grep

--- a/plugins/claude-code-expert/skills/ultraplan/SKILL.md
+++ b/plugins/claude-code-expert/skills/ultraplan/SKILL.md
@@ -79,7 +79,7 @@ Claude detects the open PR for your current branch and enables auto-fix — watc
 
 ## Cost and Model
 
-Ultraplan uses Opus (`opus` → latest `claude-opus-4-8`) by default for the planning phase — the reasoning depth justifies the cost for complex migrations and architectural decisions. Pair it with a high `effort` level (`xhigh`/`max` on Opus 4.8) for the hardest plans. The execution phase uses the model appropriate to the task.
+Ultraplan uses Opus (`opus` → latest `claude-opus-4-8`) by default for the planning phase — the reasoning depth justifies the cost for complex migrations and architectural decisions. Pair it with a high `effort` level (`xhigh`/`max` on Opus 4.8) for the hardest plans. For plans above Opus's ceiling — multi-day migrations, problems Opus has already failed on — escalate planning to Fable 5 (`fable` → `claude-fable-5`); state the goal and constraints rather than enumerating steps, since over-prescriptive scaffolding reduces Fable output quality. The execution phase uses the model appropriate to the task.
 
 Estimated cost for a complex plan: ~$0.50–$2.00 depending on context volume. Simple plans use fewer tokens and run faster.
 

--- a/plugins/jira-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/jira-orchestrator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.local/schemas/plugin.schema.json",
   "name": "jira-orchestrator",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "description": "Enterprise Jira orchestration with 82 agents, 16 teams, 48 commands, 14 skills, 5 schema-validated workflows, and a read-only advisor. Features Atlassian MCP OAuth, Harness integration, Neon PostgreSQL, Redis caching, Temporal workflows, declarative workflow definitions, lifecycle telemetry hooks, and structured reasoning frameworks.",
   "author": {
     "name": "Markus Ahling",

--- a/plugins/jira-orchestrator/.mcp.json
+++ b/plugins/jira-orchestrator/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "atlassian": {
-      "type": "sse",
-      "url": "https://mcp.atlassian.com/v1/sse"
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
     }
   }
 }

--- a/plugins/jira-orchestrator/CHANGELOG.md
+++ b/plugins/jira-orchestrator/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## v8.2.0 (2026-06-10) — Atlassian MCP HTTP migration, Fable 5 tier, effort-based reasoning
+
+### Atlassian MCP: SSE → streamable HTTP (action required before 2026-06-30)
+
+- Atlassian retires `https://mcp.atlassian.com/v1/sse` on **June 30, 2026**. Migrated `.mcp.json`
+  to `{"type": "http", "url": "https://mcp.atlassian.com/v1/mcp/authv2"}` and updated every live
+  install path: `INSTALLATION.md`, `README.md`, `INSTALL-CHECKLIST.md`, `commands/setup.md`,
+  `lib/atlassian-tool-mapping.md`, `scripts/{setup.sh,install.sh,oauth-auth.sh,README.md}`, and
+  `docs/CONFLUENCE-DOCUMENTATION.md`. Existing installs should re-run setup (or
+  `claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2`).
+  Historical `docs/archive/` left as-is.
+
+### Models
+
+- **Fable 5** (`claude-fable-5`, Claude 5 tier above Opus) added to `agents/agent-router.md`'s
+  Model Assignment Strategy (long-horizon orchestration, Opus-failed problems, large parallel
+  fleets; not for security-scanning analysis) and to `config/reasoning/reasoning-config.yaml`
+  escalation rules (`upgrade_to_fable`).
+
+### Reasoning config modernized (effort levels)
+
+- `config/reasoning/reasoning-config.yaml` v1.1.0: complexity tiers now map to **effort levels**
+  (`low`/`medium`/`high`/`xhigh`); per-agent `thinking_budget` and `temperature` replaced with
+  `effort` (temperature is rejected by Opus 4.7+/Fable 5; fixed thinking budgets are deprecated
+  under adaptive thinking). Legacy `budgets:` block retained for
+  `lib/self-reflection-engine.ts` internals only.
+- `agents/{learning-coordinator,pattern-analyzer}.md`: `--thinking-budget=N` example flags
+  replaced with `--effort=high|xhigh`.
+
+### Orchestration docs
+
+- `skills/agentic-patterns/SKILL.md`: new **Coordination Surface** section mapping the book
+  patterns onto the current Agent-tool primitives (`SendMessage` teammate continuation,
+  `run_in_background`, `isolation: "worktree"`, `mode: "plan"`, Fable 5 coordinators);
+  corrected "81-agent hierarchy" → 82.
+
 ## v8.1.1 (2026-06-04) — Complete the Claude Code modernization (June 2026)
 
 Follow-up to v8.1.0: closes the gaps that pass left open against current Claude Code.

--- a/plugins/jira-orchestrator/INSTALL-CHECKLIST.md
+++ b/plugins/jira-orchestrator/INSTALL-CHECKLIST.md
@@ -262,7 +262,7 @@ claude /jira:triage PROJECT-123
 **Solution:**
 ```bash
 # Try manual installation
-claude mcp add atlassian -- npx -y mcp-remote https://mcp.atlassian.com/v1/sse
+claude mcp add atlassian -- npx -y mcp-remote https://mcp.atlassian.com/v1/mcp/authv2
 
 # Verify
 claude mcp list

--- a/plugins/jira-orchestrator/INSTALLATION.md
+++ b/plugins/jira-orchestrator/INSTALLATION.md
@@ -134,7 +134,7 @@ The plugin automatically installs the Atlassian MCP server during setup.
 
 **What it does:**
 - Adds the `atlassian` MCP server to Claude Code
-- Configures it to use: `npx -y mcp-remote https://mcp.atlassian.com/v1/sse`
+- Configures it to use: `npx -y mcp-remote https://mcp.atlassian.com/v1/mcp/authv2`
 - Enables Jira tool access
 
 **Verify Installation:**
@@ -147,7 +147,7 @@ claude mcp list
 **Manual Installation (if auto-install fails):**
 
 ```bash
-claude mcp add atlassian -- npx -y mcp-remote https://mcp.atlassian.com/v1/sse
+claude mcp add atlassian -- npx -y mcp-remote https://mcp.atlassian.com/v1/mcp/authv2
 ```
 
 ### Environment Variables
@@ -294,7 +294,7 @@ claude /jira:triage PROJECT-123
 1. Check npm/npx available: `which npx`
 2. Try manual installation:
    ```bash
-   claude mcp add atlassian -- npx -y mcp-remote https://mcp.atlassian.com/v1/sse
+   claude mcp add atlassian -- npx -y mcp-remote https://mcp.atlassian.com/v1/mcp/authv2
    ```
 3. Check internet connection
 4. Review installation log: `cat logs/install-*.log`

--- a/plugins/jira-orchestrator/README.md
+++ b/plugins/jira-orchestrator/README.md
@@ -121,7 +121,7 @@ agent usage, reject rates, and recurring failures.
 ## MCP Integration
 
 ```bash
-claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse
+claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
 ```
 
 Tools: `mcp__atlassian__getJiraIssue`, `mcp__atlassian__createJiraIssue`,

--- a/plugins/jira-orchestrator/agents/agent-router.md
+++ b/plugins/jira-orchestrator/agents/agent-router.md
@@ -354,6 +354,13 @@ execution_order:
 
 ### Model Assignment Strategy
 
+**Fable (claude-fable-5) — Claude 5 tier above Opus:**
+- Long-horizon autonomous orchestration (multi-hour epic execution, overnight runs)
+- Problems Opus has already failed on or that would need multiple Opus retries
+- Coordinating large fleets of long-lived parallel sub-agents without drift
+- Rare and deliberate: ~2× Opus per token plus ~30% tokenizer overhead — workers stay on Sonnet
+- Avoid for security-scanning analysis (Fable's cyber classifiers can refuse; keep that on Opus)
+
 **Opus (claude-opus-4-8):**
 - Strategic planning (PLAN phase)
 - Complex architectural decisions
@@ -371,6 +378,8 @@ execution_order:
 - Simple validation tasks
 - Quick analysis and reporting
 - Cost optimization for simple tasks
+
+Prefer aliases (`fable`/`opus`/`sonnet`/`haiku`) in agent frontmatter so model refreshes don't strand config.
 
 ### Success Metrics
 

--- a/plugins/jira-orchestrator/agents/learning-coordinator.md
+++ b/plugins/jira-orchestrator/agents/learning-coordinator.md
@@ -121,7 +121,7 @@ When significant events occur (every 5-10 tasks or critical failures):
 claude-agent pattern-analyzer \
   --agent="code-reviewer" \
   --recent-tasks=10 \
-  --thinking-budget=8000
+  --effort=high
 ```
 
 #### Step 2.2: Review Extracted Patterns

--- a/plugins/jira-orchestrator/agents/pattern-analyzer.md
+++ b/plugins/jira-orchestrator/agents/pattern-analyzer.md
@@ -583,12 +583,12 @@ New Weakness Pattern:
 claude-agent pattern-analyzer \
   --agent="code-reviewer" \
   --recent-tasks=30 \
-  --thinking-budget=8000
+  --effort=high
 
 # Analyze all agents (consolidation)
 claude-agent pattern-analyzer \
   --mode=consolidate \
-  --thinking-budget=10000
+  --effort=xhigh
 ```
 
 ### Outputs to

--- a/plugins/jira-orchestrator/commands/index.json
+++ b/plugins/jira-orchestrator/commands/index.json
@@ -493,7 +493,7 @@
     },
     {
       "name": "jira:setup",
-      "intent": "Interactive setup wizard v7.5.0 - OAuth auth, Neon PostgreSQL, Redis, Temporal workflows",
+      "intent": "Interactive setup wizard - OAuth auth, Neon PostgreSQL, Redis, Temporal workflows",
       "tags": [
         "jira",
         "setup",

--- a/plugins/jira-orchestrator/commands/setup.md
+++ b/plugins/jira-orchestrator/commands/setup.md
@@ -1,6 +1,6 @@
 ---
 name: jira:setup
-intent: Interactive setup wizard v7.5.0 - OAuth auth, Neon PostgreSQL, Redis, Temporal workflows
+intent: Interactive setup wizard - OAuth auth, Neon PostgreSQL, Redis, Temporal workflows
 tags:
   - jira
   - setup
@@ -13,15 +13,15 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: Interactive setup wizard v7.5.0 - OAuth auth, Neon PostgreSQL, Redis, Temporal workflows
+description: Interactive setup wizard - OAuth auth, Neon PostgreSQL, Redis, Temporal workflows
 model: sonnet
 ---
 
-# Jira Orchestrator v7.5.0 - Interactive Setup Wizard
+# Jira Orchestrator - Interactive Setup Wizard
 
-You are the **Setup Wizard** for the Jira Orchestrator plugin v7.5.0.
+You are the **Setup Wizard** for the Jira Orchestrator plugin (see .claude-plugin/plugin.json for the current version).
 
-## What's New in v7.5.0
+## Features added in v7.5.0
 
 - **Neon PostgreSQL** - Serverless database for persistent orchestration state
 - **Redis Caching** - High-performance caching for improved response times
@@ -29,7 +29,7 @@ You are the **Setup Wizard** for the Jira Orchestrator plugin v7.5.0.
 
 ## Authentication Method
 
-**Official Atlassian MCP SSE with OAuth** - Secure browser-based authentication!
+**Official Atlassian MCP (HTTP transport) with OAuth** - Secure browser-based authentication!
 
 Uses Atlassian's official MCP server at `https://mcp.atlassian.com/v1/mcp/authv2` with OAuth flow for secure, token-free authentication.
 
@@ -51,7 +51,7 @@ Guide the user through setup and verification:
 
 ### Phase 1: Add Atlassian MCP Server
 
-**Step 1:** Add the official Atlassian MCP SSE server:
+**Step 1:** Add the official Atlassian MCP server (HTTP transport):
 
 ```bash
 claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
@@ -247,7 +247,7 @@ Display:
 +================================================================+
 
 Authentication:
-  * Method: Official Atlassian MCP SSE
+  * Method: Official Atlassian MCP (HTTP transport)
   * Type: OAuth (browser-based)
   * Status: Authenticated
   * Atlassian Sites: [list accessible resources]

--- a/plugins/jira-orchestrator/commands/setup.md
+++ b/plugins/jira-orchestrator/commands/setup.md
@@ -31,7 +31,7 @@ You are the **Setup Wizard** for the Jira Orchestrator plugin v7.5.0.
 
 **Official Atlassian MCP SSE with OAuth** - Secure browser-based authentication!
 
-Uses Atlassian's official MCP server at `https://mcp.atlassian.com/v1/sse` with OAuth flow for secure, token-free authentication.
+Uses Atlassian's official MCP server at `https://mcp.atlassian.com/v1/mcp/authv2` with OAuth flow for secure, token-free authentication.
 
 ---
 
@@ -54,7 +54,7 @@ Guide the user through setup and verification:
 **Step 1:** Add the official Atlassian MCP SSE server:
 
 ```bash
-claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse
+claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
 ```
 
 **Step 2:** Restart Claude Code or run:
@@ -298,7 +298,7 @@ claude mcp remove atlassian
 
 **Re-add if needed:**
 ```bash
-claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse
+claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
 ```
 
 ---

--- a/plugins/jira-orchestrator/config/reasoning/reasoning-config.yaml
+++ b/plugins/jira-orchestrator/config/reasoning/reasoning-config.yaml
@@ -35,7 +35,7 @@ sequential_thinking:
 
   # Reasoning depth by complexity, expressed as effort levels.
   # Current models (Sonnet 4.6 / Opus 4.8 / Fable 5) use adaptive thinking;
-  # fixed token budgets (budget_tokens) are deprecated and 400 on Opus 4.7+.
+  # fixed token budgets (budget_tokens) are deprecated and rejected with an HTTP 400 error on Opus 4.7+.
   effort_levels:
     simple: low
     moderate: medium

--- a/plugins/jira-orchestrator/config/reasoning/reasoning-config.yaml
+++ b/plugins/jira-orchestrator/config/reasoning/reasoning-config.yaml
@@ -1,7 +1,7 @@
 # Reasoning Framework Configuration
 # Configures how reasoning agents operate within jira-orchestrator
 
-version: "1.0.0"
+version: "1.1.0"
 description: "Configuration for reasoning and problem-solving capabilities"
 
 # Documentation-First Protocol
@@ -33,14 +33,24 @@ documentation_first:
 sequential_thinking:
   enabled: true
 
-  # Default thinking budgets by complexity
+  # Reasoning depth by complexity, expressed as effort levels.
+  # Current models (Sonnet 4.6 / Opus 4.8 / Fable 5) use adaptive thinking;
+  # fixed token budgets (budget_tokens) are deprecated and 400 on Opus 4.7+.
+  effort_levels:
+    simple: low
+    moderate: medium
+    complex: high
+    critical: xhigh
+
+  # Legacy token budgets — kept for backward compatibility with
+  # lib/self-reflection-engine.ts internals only. Do not pass to the API.
   budgets:
     simple: 2000
     moderate: 5000
     complex: 8000
     critical: 15000
 
-  # When to use extended thinking
+  # When to raise reasoning depth
   triggers:
     - keyword: "debug"
       budget: "complex"
@@ -91,12 +101,13 @@ memory:
     archive_after_days: 90
 
 # Reasoning Agents Configuration
+# Note: temperature is removed on Opus 4.7+ and Fable 5 (the API rejects it);
+# steer behavior through prompts and effort instead.
 agents:
   chain-of-thought-reasoner:
     enabled: true
     model: sonnet
-    temperature: 0.3
-    thinking_budget: 5000
+    effort: medium
     auto_doc_lookup: true
     use_cases:
       - sequential_problems
@@ -106,8 +117,7 @@ agents:
   tree-of-thought-reasoner:
     enabled: true
     model: sonnet
-    temperature: 0.5
-    thinking_budget: 8000
+    effort: high
     auto_doc_lookup: true
     use_cases:
       - multiple_alternatives
@@ -117,8 +127,7 @@ agents:
   hypothesis-debugger:
     enabled: true
     model: sonnet
-    temperature: 0.3
-    thinking_budget: 8000
+    effort: high
     auto_doc_lookup: true
     use_cases:
       - complex_bugs
@@ -128,8 +137,7 @@ agents:
   root-cause-analyzer:
     enabled: true
     model: opus
-    temperature: 0.4
-    thinking_budget: 10000
+    effort: xhigh
     auto_doc_lookup: true
     use_cases:
       - post_mortems
@@ -222,10 +230,18 @@ metrics:
 escalation:
   # When to escalate to more powerful model
   upgrade_to_opus:
-    - thinking_budget_exceeded: 10000
+    - effort_at_max_insufficient: true
     - complexity_score_above: 80
     - incident_severity: "critical"
     - multiple_hypotheses_failed: 3
+
+  # Fable 5 (claude-fable-5) is the tier above Opus — reserve for runs
+  # above Opus's ceiling. Not for security-scanning analysis (cyber
+  # classifiers can refuse).
+  upgrade_to_fable:
+    - opus_failed_attempts: 2
+    - run_horizon: "multi-hour"
+    - parallel_subagents_above: 8
 
   # When to request human review
   request_human:

--- a/plugins/jira-orchestrator/docs/CONFLUENCE-DOCUMENTATION.md
+++ b/plugins/jira-orchestrator/docs/CONFLUENCE-DOCUMENTATION.md
@@ -427,7 +427,7 @@ claude /jira:setup
 
 **Setup Atlassian MCP:**
 ```bash
-claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse
+claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
 ```
 
 **Available Tools:**

--- a/plugins/jira-orchestrator/lib/atlassian-tool-mapping.md
+++ b/plugins/jira-orchestrator/lib/atlassian-tool-mapping.md
@@ -4,7 +4,7 @@
 
 This plugin ONLY uses the official Atlassian MCP SSE connector:
 ```bash
-claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse
+claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
 ```
 
 ## Tool Reference

--- a/plugins/jira-orchestrator/lib/atlassian-tool-mapping.md
+++ b/plugins/jira-orchestrator/lib/atlassian-tool-mapping.md
@@ -1,8 +1,8 @@
-# Atlassian MCP SSE Tool Mapping
+# Atlassian MCP Tool Mapping (HTTP transport)
 
 ## Official Tools (mcp__atlassian__*)
 
-This plugin ONLY uses the official Atlassian MCP SSE connector:
+This plugin ONLY uses the official Atlassian MCP connector (HTTP transport):
 ```bash
 claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
 ```

--- a/plugins/jira-orchestrator/scripts/README.md
+++ b/plugins/jira-orchestrator/scripts/README.md
@@ -185,15 +185,15 @@ The plugin requires the Atlassian MCP server to interact with Jira.
 
 **MCP Server Details:**
 - Name: `atlassian`
-- URL: `https://mcp.atlassian.com/v1/sse`
-- Command: `npx -y mcp-remote https://mcp.atlassian.com/v1/sse`
+- URL: `https://mcp.atlassian.com/v1/mcp/authv2`
+- Command: `npx -y mcp-remote https://mcp.atlassian.com/v1/mcp/authv2`
 
 **Manual Installation:**
 
 If automatic installation fails, add manually:
 
 ```bash
-claude mcp add atlassian -- npx -y mcp-remote https://mcp.atlassian.com/v1/sse
+claude mcp add atlassian -- npx -y mcp-remote https://mcp.atlassian.com/v1/mcp/authv2
 ```
 
 **Verify Installation:**

--- a/plugins/jira-orchestrator/scripts/install.sh
+++ b/plugins/jira-orchestrator/scripts/install.sh
@@ -20,7 +20,7 @@ NC='\033[0m' # No Color
 PLUGIN_NAME="jira-orchestrator"
 PLUGIN_VERSION="7.1.0"
 MCP_SERVER_NAME="atlassian"
-MCP_SERVER_URL="https://mcp.atlassian.com/v1/sse"
+MCP_SERVER_URL="https://mcp.atlassian.com/v1/mcp/authv2"
 
 # Directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/plugins/jira-orchestrator/scripts/install.sh
+++ b/plugins/jira-orchestrator/scripts/install.sh
@@ -18,7 +18,7 @@ NC='\033[0m' # No Color
 
 # Plugin information
 PLUGIN_NAME="jira-orchestrator"
-PLUGIN_VERSION="7.1.0"
+PLUGIN_VERSION="8.2.0"
 MCP_SERVER_NAME="atlassian"
 MCP_SERVER_URL="https://mcp.atlassian.com/v1/mcp/authv2"
 

--- a/plugins/jira-orchestrator/scripts/oauth-auth.sh
+++ b/plugins/jira-orchestrator/scripts/oauth-auth.sh
@@ -65,7 +65,7 @@ echo ""
 echo -e "${CYAN}Step 2: Adding Atlassian MCP Server...${NC}"
 echo ""
 
-MCP_URL="https://mcp.atlassian.com/v1/sse"
+MCP_URL="https://mcp.atlassian.com/v1/mcp/authv2"
 
 if [ "$CLAUDE_CLI" = true ]; then
     echo -e "${BLUE}Adding Atlassian MCP server via Claude CLI...${NC}"
@@ -150,7 +150,7 @@ console.log('Starting Atlassian MCP connection test...');
 console.log('If a browser window opens, please authenticate.');
 console.log('');
 
-const proc = spawn('npx', ['-y', 'mcp-remote', 'https://mcp.atlassian.com/v1/sse'], {
+const proc = spawn('npx', ['-y', 'mcp-remote', 'https://mcp.atlassian.com/v1/mcp/authv2'], {
     stdio: 'inherit'
 });
 

--- a/plugins/jira-orchestrator/scripts/publish-docs-to-confluence.ts
+++ b/plugins/jira-orchestrator/scripts/publish-docs-to-confluence.ts
@@ -1,7 +1,7 @@
 /**
  * Publish Jira Orchestrator documentation to Confluence using MCP Atlassian tools.
  * 
- * This script uses the official Atlassian MCP SSE tools to:
+ * This script uses the official Atlassian MCP (HTTP transport) tools to:
  * 1. Get accessible Atlassian resources (to find cloud ID)
  * 2. Get Confluence spaces
  * 3. Create the documentation page

--- a/plugins/jira-orchestrator/scripts/setup.sh
+++ b/plugins/jira-orchestrator/scripts/setup.sh
@@ -73,7 +73,7 @@ This project uses the **jira-orchestrator** plugin for Atlassian integration.
 
 **Required:** Atlassian MCP SSE must be configured:
 ```bash
-claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse
+claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
 ```
 
 ## Available Tools
@@ -166,7 +166,7 @@ update_claude_md() {
 
 **MCP Required:**
 ```bash
-claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse
+claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
 ```
 
 **Issue Hierarchy:** Initiative -> Epic -> Story -> Task -> Subtask
@@ -193,7 +193,7 @@ verify_mcp() {
       log_success "Atlassian MCP is configured."
     else
       log_warn "Atlassian MCP not found. Run:"
-      echo "  claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse"
+      echo "  claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2"
     fi
   else
     log_warn "Claude CLI not found. Cannot verify MCP configuration."

--- a/plugins/jira-orchestrator/scripts/setup.sh
+++ b/plugins/jira-orchestrator/scripts/setup.sh
@@ -71,7 +71,7 @@ This project uses the **jira-orchestrator** plugin for Atlassian integration.
 
 ## MCP Configuration
 
-**Required:** Atlassian MCP SSE must be configured:
+**Required:** Atlassian MCP (HTTP transport) must be configured:
 ```bash
 claude mcp add --transport http atlassian https://mcp.atlassian.com/v1/mcp/authv2
 ```

--- a/plugins/jira-orchestrator/skills/agentic-patterns/SKILL.md
+++ b/plugins/jira-orchestrator/skills/agentic-patterns/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: agentic-patterns
-description: This skill should be used when the user asks about "agentic design patterns", "multi-agent orchestration patterns", "routing/planning/reflection patterns", "the blackboard pattern", "coordinator-of-coordinators", or "saga/circuit-breaker for agents", or needs to apply agentic design patterns to Jira workflow orchestration and the 81-agent hierarchy.
+description: This skill should be used when the user asks about "agentic design patterns", "multi-agent orchestration patterns", "routing/planning/reflection patterns", "the blackboard pattern", "coordinator-of-coordinators", or "saga/circuit-breaker for agents", or needs to apply agentic design patterns to Jira workflow orchestration and the 82-agent hierarchy.
 version: 1.0.0
 categories: ["agentic-patterns", "orchestration", "multi-agent", "architecture"]
 ---
 
 # Agentic Design Patterns — Jira Orchestrator
 
-> Patterns from "Agentic Design Patterns" (Gulli & Sauco, 2025) applied to enterprise Jira workflow orchestration, 81-agent hierarchy management, sprint planning, and issue lifecycle automation.
+> Patterns from "Agentic Design Patterns" (Gulli & Sauco, 2025) applied to enterprise Jira workflow orchestration, 82-agent hierarchy management, sprint planning, and issue lifecycle automation.
 
 ## Applied Patterns
 
@@ -22,7 +22,7 @@ categories: ["agentic-patterns", "orchestration", "multi-agent", "architecture"]
 **Enhancement**: Adopt ReAct-style planning with explicit Thought → Action → Observation cycles logged to Temporal workflow state. Each planning decision references the Jira issue it modifies, creating a full audit trail.
 
 ### 3. Multi-Agent
-**Relevance**: The 81-agent hierarchy — organized into 16 specialized teams — is the core architectural pattern. No single agent has sufficient context or authority to handle complex enterprise workflows alone.
+**Relevance**: The 82-agent hierarchy — organized into 16 specialized teams — is the core architectural pattern. No single agent has sufficient context or authority to handle complex enterprise workflows alone.
 **Current Implementation**: Teams include Code Team (6 agents), QA Team (6 agents), Security Team (4 agents), DevOps Team (5 agents), Analytics Team (4 agents), and 11 additional specialized teams. Each team has a coordinator agent.
 **Enhancement**: Implement a Coordinator-of-Coordinators (CoC) pattern where team coordinators report status to a central orchestrator via the blackboard. The CoC resolves cross-team conflicts (e.g., QA blocking DevOps deploy) and escalates to HITL when consensus is not reached.
 
@@ -119,6 +119,22 @@ Incoming Jira Request
 | Evaluation | `/jira:metrics`, `/jira:quality` | Sprint/agent scoring |
 | Prioritization | `/backlog-groom`, `/jira:intelligence` | Backlog ordering |
 | Goal Setting | `/jira:sprint`, `/jira:release` | Sprint/release goals |
+
+
+## Coordination Surface (current Claude Code Agent tool)
+
+Implementing these patterns today maps onto the runtime's native primitives:
+
+| Need | How |
+|---|---|
+| Spawn a specialist | `Agent` tool (the tool formerly named `Task`) with `subagent_type`, `model` (`fable`/`opus`/`sonnet`/`haiku` aliases), and a focused prompt |
+| Run teams concurrently | Issue independent spawns in one message; `run_in_background: true` for non-blocking workers |
+| Continue a teammate with its context intact | Give it a `name` at spawn, then `SendMessage` to that name — a fresh `Agent` call starts a new context |
+| Prevent file contention between parallel coders | `isolation: "worktree"` (auto-cleaned if unchanged) |
+| Force plan-first behavior | `mode: "plan"` on the spawn |
+| Long-horizon coordinator (multi-hour epics, overnight runs) | Put the coordinator on `model: fable` — Fable 5 sustains long-lived async sub-agent fleets without drift; keep workers on Sonnet |
+
+Only a teammate's **final message** returns to the coordinator — require workers to end with a structured summary (blackboard writes happen via files, not transcripts).
 
 ## References
 - Gulli, A. & Sauco, M. (2025). *Agentic Design Patterns*. O'Reilly Media.

--- a/plugins/project-management-plugin/.claude-plugin/plugin.json
+++ b/plugins/project-management-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-management-plugin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Universal project manager with keep-Claude-on-task guardrails: focus anchor, scope lock, done-when contract, over-engineering detector, drift auditor, turn budget, user-prompt archive, and compaction-safe handoff. Plus interview-first init, micro-task decomposition, deep research, transactional state MCP, and 9 PM platform integrations.",
   "author": {
     "name": "Markus Ahling",

--- a/plugins/project-management-plugin/CLAUDE.md
+++ b/plugins/project-management-plugin/CLAUDE.md
@@ -70,6 +70,7 @@ All project state is in `.claude/projects/{project-id}/`:
 - `temp/.write-{uuid}` — temporary files used during atomic rename
 
 ## Agent Routing
+- **Fable** (escalation only): project-orchestrator on multi-hour/overnight autonomous runs or after repeated Opus failures — Fable 5 (`claude-fable-5`) is the Claude 5 tier above Opus; workers stay on Sonnet
 - **Opus**: project-orchestrator, project-interviewer, scope-architect, council-reviewer, adaptive replanning
 - **Sonnet**: task-decomposer, dependency-resolver, deep-researcher, task-executor, quality-reviewer, risk-assessor, pm-integrator
 - **Haiku**: progress-monitor, context-guardian, pattern-recognizer, checkpoint-manager, project-reporter

--- a/plugins/project-management-plugin/agents/deep-researcher.md
+++ b/plugins/project-management-plugin/agents/deep-researcher.md
@@ -1,6 +1,6 @@
 ---
 name: project-management-plugin:deep-researcher
-intent: Deep Researcher
+intent: Produces a research brief before task execution via fixed 4-source protocol (codebase-first, then web, Context7, Firecrawl) to prevent re-implementation and surface existing patterns.
 tags:
   - project-management-plugin
   - agent
@@ -8,6 +8,8 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Produces a research brief before task execution via fixed 4-source protocol (codebase-first, then web, Context7, Firecrawl) to prevent re-implementation and surface existing patterns.
+model: sonnet
 ---
 
 # Deep Researcher

--- a/plugins/project-management-plugin/agents/index.json
+++ b/plugins/project-management-plugin/agents/index.json
@@ -45,7 +45,7 @@
     },
     {
       "name": "project-management-plugin:deep-researcher",
-      "intent": "Deep Researcher",
+      "intent": "Produces a research brief before task execution via fixed 4-source protocol (codebase-first, then web, Context7, Firecrawl) to prevent re-implementation and surface existing patterns.",
       "tags": [
         "project-management-plugin",
         "agent",

--- a/plugins/project-management-plugin/skills/pm-integrations/SKILL.md
+++ b/plugins/project-management-plugin/skills/pm-integrations/SKILL.md
@@ -1,4 +1,5 @@
 ---
+intent: "Connect and sync project state with external PM platforms (GitHub Projects, Linear, Notion, Asana, Trello, ClickUp, Monday.com, Todoist, Local)"
 description: "Connecting and syncing with GitHub Projects, Linear, Notion, Asana, Trello, ClickUp, Monday.com, Todoist, and Local"
 ---
 

--- a/plugins/project-management-plugin/skills/progress-visualization/SKILL.md
+++ b/plugins/project-management-plugin/skills/progress-visualization/SKILL.md
@@ -1,4 +1,5 @@
 ---
+intent: "Render ASCII progress dashboards with phase/epic/task breakdown and velocity metrics"
 description: "Rendering ASCII progress dashboards with phase/epic/task breakdown and velocity metrics"
 ---
 

--- a/plugins/project-management-plugin/skills/project-decomposition/SKILL.md
+++ b/plugins/project-management-plugin/skills/project-decomposition/SKILL.md
@@ -1,4 +1,5 @@
 ---
+intent: "Decompose projects into granular micro-tasks using a 5-level hierarchy and INVEST principles"
 description: "Decomposing projects into granular micro-tasks using 5-level hierarchy and INVEST principles"
 ---
 

--- a/plugins/project-management-plugin/skills/project-templates/SKILL.md
+++ b/plugins/project-management-plugin/skills/project-templates/SKILL.md
@@ -1,4 +1,5 @@
 ---
+intent: "Scaffold projects from templates (webapp, API, ML pipeline, mobile, infrastructure) and create new templates"
 description: "Using and creating project templates for webapp, API, ML pipeline, mobile, and infrastructure projects"
 ---
 

--- a/plugins/project-management-plugin/skills/quality-gates/SKILL.md
+++ b/plugins/project-management-plugin/skills/quality-gates/SKILL.md
@@ -1,4 +1,5 @@
 ---
+intent: "Validate task completion against acceptance criteria with per-type automated checks"
 description: "Validating task completion against acceptance criteria with per-type automated checks"
 ---
 

--- a/plugins/project-management-plugin/skills/research-protocol/SKILL.md
+++ b/plugins/project-management-plugin/skills/research-protocol/SKILL.md
@@ -1,4 +1,5 @@
 ---
+intent: "Run deep research before task execution using the 4-source protocol: codebase, Perplexity, Context7, Firecrawl"
 description: "Deep research before task execution using 4-source protocol: codebase→Perplexity→Context7→Firecrawl"
 ---
 

--- a/plugins/project-management-plugin/skills/task-state-management/SKILL.md
+++ b/plugins/project-management-plugin/skills/task-state-management/SKILL.md
@@ -1,4 +1,5 @@
 ---
+intent: "Manage project and task state in .claude/projects/{id}/ with atomic writes and session continuity"
 description: "Managing project and task state in .claude/projects/{id}/ with atomic writes and session continuity"
 ---
 


### PR DESCRIPTION
## Summary

Adds support for Claude 5 / Fable 5 tier and migrates Atlassian MCP from SSE to HTTP transport ahead of June 30, 2026 deprecation. Updates reasoning config to use effort-based depth control (replacing deprecated fixed thinking budgets and temperature parameters).

## Key Changes

### Models & Reasoning
- **Fable 5 support** (`claude-fable-5`): Added as Mythos-class tier above Opus across jira-orchestrator and claude-code-expert plugins
  - Long-horizon autonomous runs, overnight builds, multi-hour orchestration
  - Escalation rules in `reasoning-config.yaml` v1.1.0
  - Updated model routing guidance and pricing tables ($10/$50 per MTok, ~3.3× Sonnet)
  - Documented in capability baseline (`CC-CAPABILITIES-2026-06.md`)

- **Effort-based reasoning** (v1.1.0): Replaced per-agent `thinking_budget` and `temperature` with `effort` levels (`low`/`medium`/`high`/`xhigh`)
  - Temperature is rejected by Opus 4.7+/Fable 5; fixed thinking budgets deprecated under adaptive thinking
  - Legacy `budgets:` block retained for `lib/self-reflection-engine.ts` internals only
  - Updated agent configs: chain-of-thought-reasoner, tree-of-thought-reasoner, hypothesis-debugger, root-cause-analyzer
  - Updated example flags in learning-coordinator and pattern-analyzer agents

### Atlassian MCP Migration
- **Transport change**: SSE → HTTP (`https://mcp.atlassian.com/v1/sse` → `https://mcp.atlassian.com/v1/mcp/authv2`)
- Updated across all installation paths:
  - `.mcp.json` (type: "http")
  - `INSTALLATION.md`, `README.md`, `INSTALL-CHECKLIST.md`
  - `commands/setup.md`, `scripts/{setup.sh,install.sh,oauth-auth.sh}`
  - `lib/atlassian-tool-mapping.md`, `docs/CONFLUENCE-DOCUMENTATION.md`

### Documentation & Orchestration
- **Coordination Surface** section added to `agentic-patterns/SKILL.md` mapping book patterns to Agent-tool primitives
- `/cc-orchestrate` command: new Model tiers section (Fable 5 escalation guidance) and Coordination surface section
- `agent-teams` skill: guidance on Fable 5 coordinators for multi-hour teams
- `model-routing` skill: Fable upgrade triggers, cascading row for overnight runs, pricing corrections (Opus $5/$25, Haiku $1/$5)
- Pinned model IDs → aliases across 18 agents and 5 topology kits per capability baseline policy

### Version & Metadata Updates
- jira-orchestrator: v8.1.1 → v8.2.0
- claude-code-expert: v7.9.0 → v8.2.0
- Updated marketplace descriptions and plugin counts (27 → 41 plugins, 11 → 12 commands in claude-code-expert)
- CHANGELOG entries documenting Atlassian MCP migration deadline and Fable 5 tier

## Implementation Details

- Effort levels map to adaptive thinking on current models; no API-level thinking_budget parameter
- Fable 5 has 1M context by default; `claude-fable-5[1m]` is the long-context ID form
- Fable 5 thinking is always on; depth controlled purely by `effort`
- Safety classifiers may refuse research-bio/cybersecurity content on Fable 5 (requires 30-day data retention)
- Backward compatibility: legacy `budgets:` block in reasoning config retained for internal engine use only

https://claude.ai/code/session_01PLJQscJNVhMXuXWUeBPWAq