### PR TITLE
fix(ci): auto-provision GitHub Pages in deploy workflow

### DIFF
--- a/.claude/rules/lessons-learned.md
+++ b/.claude/rules/lessons-learned.md
@@ -918,3 +918,11 @@ grep: site/assets/styles.css: No such file or directory
 - **Status:** RESOLVED
 - **Fix:** Same persistent-cwd cause as the entry above (shell still in `site/`). Switched to the Grep tool with an absolute path, which is also the preferred tool for content search.
 - **Prevention:** Prefer the Grep/Glob tools over shell `grep`/`find`; when shelling out, use absolute paths because the Bash cwd persists between calls.
+
+### Error: mcp__github__actions_get failure (2026-06-23T17:50:31Z)
+- **Tool:** mcp__github__actions_get
+- **Input:** `N/A`
+- **Error:** missing required parameter: resource_id
+- **Status:** RESOLVED
+- **Fix:** `actions_get` requires both `method` and `resource_id` (not `run_id`). To read failing job logs, the simpler path is `mcp__github__get_job_logs` with `run_id` + `failed_only: true` to find the failed job id, then call it again with that `job_id` and `return_content: true` + `tail_lines`.
+- **Prevention:** For CI log triage use `get_job_logs` (run_id → failed_only, then job_id → return_content), not `actions_get`. Reserve `actions_get` for run/workflow metadata and always pass `method` + `resource_id`.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,11 @@ jobs:
           node scripts/check-site.mjs
 
       - name: Configure Pages
+        # enablement: true auto-provisions the Pages site on first run so no
+        # manual Settings → Pages toggle is required (needs pages: write).
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ npx serve site         # or: python3 -m http.server -d site 8080
 
 The `Deploy GitHub Pages` workflow (`.github/workflows/pages.yml`) rebuilds the data and
 publishes `site/` whenever the manifest, a plugin manifest, or the site changes on `main`.
-To go live the first time, set **Settings → Pages → Source → GitHub Actions** once.
+It self-provisions the Pages site via `actions/configure-pages` (`enablement: true`), so no
+manual Settings toggle is required — assuming GitHub Pages is permitted for the repository.
 
 ## Contributing
 


### PR DESCRIPTION
## Problem

After #145 merged, the **Deploy GitHub Pages** workflow failed on `main` (run #1). The `build-site` and `check-site` steps passed; the failure was at `actions/configure-pages@v5`:

```
##[error]Get Pages site failed. Please verify that the repository has Pages
enabled and configured to build using GitHub Actions, or consider exploring
the `enablement` parameter for this action. Error: Not Found
```

GitHub Pages had never been enabled for the repo, so there was no Pages site to configure.

## Fix

Add `enablement: true` to `actions/configure-pages`, which provisions the Pages site automatically on the first run. The workflow already grants `pages: write` / `id-token: write`, so no manual **Settings → Pages** toggle is needed.

```yaml
- name: Configure Pages
  uses: actions/configure-pages@v5
  with:
    enablement: true
```

README updated to reflect the self-provisioning behavior.

## Scope

- Only the other workflow failures on that commit were **pre-existing and unrelated** (`Jira Build Status`, `jira-config-example.yml`). `Marketplace CI` and the dependency guard were green.
- `enablement: true` still requires that GitHub Pages is permitted at the org/repo policy level; if a policy blocks it, the site must be enabled in Settings manually.

## Test plan
- [x] `pages.yml` parses as valid YAML; `enablement: true` present
- [ ] On merge to `main`, the `Deploy GitHub Pages` run reaches `deploy` and publishes https://markus41.github.io/claude/

---

<div align="center">

[[Markus Ahling](https://img.shields.io/badge/%E2%9A%A1-markus41-000000?style=for-the-badge&labelColor=FF4500&color=1a1a2e)](https://github.com/markus41) [[Marketplace](``https://img.shields.io/badge/plugin-marketplace-blueviolet?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/markus41/claude``) [[Status](https://img.shields.io/badge/status-shipped%20%F0%9F%9A%80-brightgreen?style=for-the-badge)](https://github.com/markus41/claude)

*architecture by humans, velocity by machines*

</div>

https://claude.ai/code/session_01FwLLTCmgsrGHn9Ua9SBiit

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwLLTCmgsrGHn9Ua9SBiit)_