### PR TITLE
fix(ci): Deploy GitHub Pages skips gracefully until Pages is enabled

### DIFF
--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -35,7 +35,7 @@ paths:
 - Use OIDC for cloud authentication (Azure, AWS) — never store long-lived cloud credentials as secrets
 - Set minimum required permissions with `permissions:` block
 - Use `concurrency` groups to prevent duplicate workflow runs
-- GitHub Pages: the workflow `GITHUB_TOKEN` with `pages: write` can *deploy* to Pages but cannot *create* the Pages site. `actions/configure-pages` with `enablement: true` fails with `Resource not accessible by integration` when Pages was never enabled. First-time enablement (Settings → Pages → Source: GitHub Actions) is a repo-admin/UI action the Actions token cannot perform — treat it as a manual prerequisite, not something `enablement: true` solves.
+- GitHub Pages: the workflow `GITHUB_TOKEN` with `pages: write` can *deploy* to Pages but cannot *create* the Pages site. `actions/configure-pages` with `enablement: true` fails with `Resource not accessible by integration` when Pages was never enabled. First-time enablement (Settings → Pages → Source: GitHub Actions) is a repo-admin/UI action the Actions token cannot perform. To avoid a red workflow before that one-time toggle, preflight `GET /repos/{owner}/{repo}/pages` (404 ⇒ not enabled) and gate `configure-pages`/`upload-pages-artifact`/the deploy job behind it — skip with an `::notice::` instead of failing.
 
 ## MCP Servers
 

--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -35,6 +35,7 @@ paths:
 - Use OIDC for cloud authentication (Azure, AWS) — never store long-lived cloud credentials as secrets
 - Set minimum required permissions with `permissions:` block
 - Use `concurrency` groups to prevent duplicate workflow runs
+- GitHub Pages: the workflow `GITHUB_TOKEN` with `pages: write` can *deploy* to Pages but cannot *create* the Pages site. `actions/configure-pages` with `enablement: true` fails with `Resource not accessible by integration` when Pages was never enabled. First-time enablement (Settings → Pages → Source: GitHub Actions) is a repo-admin/UI action the Actions token cannot perform — treat it as a manual prerequisite, not something `enablement: true` solves.
 
 ## MCP Servers
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,11 @@ name: Deploy GitHub Pages
 # Builds the marketplace catalog data from the manifest and publishes the
 # static site in site/ to GitHub Pages. Runs on pushes to the default branch
 # (so the catalog never drifts from marketplace.json) and on demand.
+#
+# First-time setup: enable Pages at Settings → Pages → Source: GitHub Actions.
+# The Actions GITHUB_TOKEN can deploy to Pages but cannot CREATE the Pages site
+# (that needs repo-admin), so until Pages is enabled this workflow detects the
+# missing site and skips the deploy with a notice instead of failing red.
 
 on:
   push:
@@ -28,6 +33,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      pages_enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,20 +49,36 @@ jobs:
           node scripts/build-site.mjs
           node scripts/check-site.mjs
 
+      - name: Check whether Pages is enabled
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          code=$(curl -s -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pages" || echo "000")
+          if [ "$code" = "200" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub Pages is enabled — proceeding with deploy."
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=GitHub Pages not enabled::Enable it once at Settings → Pages → Source: GitHub Actions, then re-run this workflow to publish the site. (Pages API returned HTTP $code.)"
+          fi
+
       - name: Configure Pages
-        # enablement: true auto-provisions the Pages site on first run so no
-        # manual Settings → Pages toggle is required (needs pages: write).
+        if: steps.check.outputs.enabled == 'true'
         uses: actions/configure-pages@v5
-        with:
-          enablement: true
 
       - name: Upload site artifact
+        if: steps.check.outputs.enabled == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
 
   deploy:
     needs: build
+    if: needs.build.outputs.pages_enabled == 'true'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -115,8 +115,13 @@ npx serve site         # or: python3 -m http.server -d site 8080
 
 The `Deploy GitHub Pages` workflow (`.github/workflows/pages.yml`) rebuilds the data and
 publishes `site/` whenever the manifest, a plugin manifest, or the site changes on `main`.
-It self-provisions the Pages site via `actions/configure-pages` (`enablement: true`), so no
-manual Settings toggle is required — assuming GitHub Pages is permitted for the repository.
+
+**First-time setup (one-time, required):** enable Pages once at
+**Settings → Pages → Build and deployment → Source: _GitHub Actions_**. The workflow's
+`GITHUB_TOKEN` can _deploy_ to Pages (`pages: write`) but cannot _create_ the Pages site —
+that needs repo-admin, so the initial enablement must be done in the UI. (`configure-pages`
+runs with `enablement: true`, which becomes a harmless no-op once Pages is enabled.) After
+that, every push to `main` deploys automatically.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -116,12 +116,13 @@ npx serve site         # or: python3 -m http.server -d site 8080
 The `Deploy GitHub Pages` workflow (`.github/workflows/pages.yml`) rebuilds the data and
 publishes `site/` whenever the manifest, a plugin manifest, or the site changes on `main`.
 
-**First-time setup (one-time, required):** enable Pages once at
+**First-time setup (one-time):** enable Pages at
 **Settings → Pages → Build and deployment → Source: _GitHub Actions_**. The workflow's
 `GITHUB_TOKEN` can _deploy_ to Pages (`pages: write`) but cannot _create_ the Pages site —
-that needs repo-admin, so the initial enablement must be done in the UI. (`configure-pages`
-runs with `enablement: true`, which becomes a harmless no-op once Pages is enabled.) After
-that, every push to `main` deploys automatically.
+that needs repo-admin, so the initial enablement must be done in the UI. Until then the
+workflow detects the missing Pages site and **skips the deploy with a notice instead of
+failing**, so `main` stays green. Once Pages is enabled, every push to `main` deploys
+automatically (or re-run the workflow to publish immediately).
 
 ## Contributing
 


### PR DESCRIPTION
## Problem

The **Deploy GitHub Pages** workflow failed red on `main`:

```
Get Pages site failed. Error: Not Found
Create Pages site failed. Error: Resource not accessible by integration
```

The Actions `GITHUB_TOKEN` can **deploy** to Pages (`pages: write`) but cannot **create** the Pages site — that needs repo-admin. So on a repo where Pages was never enabled, the workflow had no way to succeed, and `enablement: true` (from #146) just changed the error message.

## Fix

Make the workflow **degrade gracefully** instead of failing:

1. Preflight `GET /repos/{owner}/{repo}/pages` with the `GITHUB_TOKEN`.
2. If it returns 200 → Pages is enabled → run `configure-pages`, upload the artifact, and deploy as normal.
3. If it 404s → emit a `::notice::` explaining the one-time Settings toggle and **skip** the configure/upload steps and the `deploy` job. Skipped jobs don't fail the run, so **`main` stays green**.

Also drops `enablement: true` (the token can't create the site, so it served no purpose).

Result:
- **Now:** the workflow is green; it just prints a notice that Pages isn't enabled yet.
- **After** a maintainer enables Pages once (**Settings → Pages → Source: GitHub Actions**): the same workflow deploys and publishes https://markus41.github.io/claude/ on every `main` push.

README + `.claude/rules/infra.md` updated to document the behavior and the one-time prerequisite.

## Test plan
- [x] `pages.yml` parses as valid YAML; preflight/gating wired (`pages_enabled` output, `if:` on deploy job)
- [x] Root cause confirmed from job logs
- [ ] Post-merge: `Deploy GitHub Pages` on `main` is green (deploy job skipped with notice until Pages is enabled)
- [ ] After manual enablement: deploy job runs and the site is live

---

<div align="center">

[[Markus Ahling](https://img.shields.io/badge/%E2%9A%A1-markus41-000000?style=for-the-badge&labelColor=FF4500&color=1a1a2e)](https://github.com/markus41) [[Marketplace](``https://img.shields.io/badge/plugin-marketplace-blueviolet?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/markus41/claude``) [[Status](https://img.shields.io/badge/status-shipped%20%F0%9F%9A%80-brightgreen?style=for-the-badge)](https://github.com/markus41/claude)

*architecture by humans, velocity by machines*

</div>

https://claude.ai/code/session_01FwLLTCmgsrGHn9Ua9SBiit