### PR TITLE
feat(plugins): registry sync, Claude 5-era model upgrades, and new microsoft-agents-expert plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "claude-code-expert",
       "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 21 behavior-triggering skills, 12 single-intent commands, 18 role-scoped agents bridging engram and Obsidian. Tracks current Claude Code capabilities (Fable 5 + Opus 4.8, agent teams, Tool Search, web/remote).",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "author": {
         "name": "Markus Ahling"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -263,6 +263,16 @@
       "source": "./plugins/marketplace-pro"
     },
     {
+      "name": "microsoft-agents-expert",
+      "description": "Comprehensive Microsoft agent-stack expert: Microsoft Agent Framework (the Semantic Kernel + AutoGen successor), Microsoft 365 Agents SDK, Teams AI Library, Copilot Studio, and Microsoft Foundry Agent Service. Stack selection, scaffolding, migration, review, and deployment. 6 skills, 5 agents, 5 commands.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "Markus@thelobbi.io"
+      },
+      "source": "./plugins/microsoft-agents-expert"
+    },
+    {
       "name": "mui-expert",
       "description": "Comprehensive Material UI (MUI) expert plugin — 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
       "version": "2.2.0",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "claude-code-expert",
       "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 21 behavior-triggering skills, 12 single-intent commands, 18 role-scoped agents bridging engram and Obsidian. Tracks current Claude Code capabilities (Fable 5 + Opus 4.8, agent teams, Tool Search, web/remote).",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "author": {
         "name": "Markus Ahling"
       },
@@ -59,7 +59,7 @@
     {
       "name": "dotnet-blazor",
       "description": "Comprehensive .NET 10, Blazor, ASP.NET Core, C#, and Syncfusion expert plugin for building modern web apps, microservices, and cloud-native solutions",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "author": {
         "name": "Markus Ahling"
       },
@@ -68,7 +68,7 @@
     {
       "name": "drawio-diagramming",
       "description": "Intelligent draw.io diagramming plugin with AI-powered diagram generation, multi-platform embedding (GitHub, Confluence, Azure DevOps, Notion, Teams, Harness), conditional formatting, live data binding, and MCP server integration for programmatic diagram creation and management.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": {
         "name": "Markus Ahling",
         "url": "https://github.com/markus41"
@@ -78,7 +78,7 @@
     {
       "name": "exec-automator",
       "description": "Genesis (Forerunner) - AI-Powered Executive Director Automation Platform. Analyze organizational responsibilities, score automation potential with 6-factor algorithm, generate LangGraph workflows, and deploy 11 specialized agents for trade associations and nonprofits.",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "author": {
         "name": "Brookside BI",
         "email": "dev@brooksidebi.com"
@@ -126,7 +126,7 @@
     {
       "name": "jira-orchestrator",
       "description": "Enterprise Jira orchestration with 82 agents, 16 teams, 48 commands, 14 skills, 5 schema-validated workflows, and a read-only advisor. Features Atlassian MCP OAuth, Harness integration, Neon PostgreSQL, Redis caching, Temporal workflows, declarative workflow definitions, lifecycle telemetry hooks, and structured reasoning frameworks.",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "author": {
         "name": "Markus Ahling",
         "email": "markus@lobbi.io"
@@ -265,7 +265,7 @@
     {
       "name": "mui-expert",
       "description": "Comprehensive Material UI (MUI) expert plugin — 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "author": {
         "name": "Claude Code",
         "url": "https://github.com/markus41/claude"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,7 +20,7 @@ EXPLORE → PLAN → CODE → TEST → FIX → DOCUMENT
 | Layer | Technology |
 |-------|-----------|
 | Runtime | Node.js 20+, ES modules |
-| Language | TypeScript 5.3 strict (for scripts only) |
+| Language | TypeScript 7.0 strict (for scripts only) |
 | Validation | Ajv + JSON Schema (Draft 7) |
 | Package Manager | pnpm |
 | CI | GitHub Actions (marketplace-ci runs scripts/validate-marketplace.mjs + tsc + archetype validation) |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,8 +1,8 @@
 # Project Instructions
 
 ## Overview
-Claude Code Plugin Marketplace — curated collection of 41 Claude Code plugins
-(35 in `plugins/`, 6 sub-plugins in `.claude/plugins/`) with marketplace-wide
+Claude Code Plugin Marketplace — curated collection of 42 Claude Code plugins
+(36 in `plugins/`, 6 sub-plugins in `.claude/plugins/`) with marketplace-wide
 validation and developer tooling. Pure marketplace repository; no application
 frontend.
 
@@ -28,7 +28,7 @@ EXPLORE → PLAN → CODE → TEST → FIX → DOCUMENT
 
 ## Key Paths
 - Marketplace manifest: `.claude-plugin/marketplace.json`
-- Installed plugins: `plugins/` (35 plugins)
+- Installed plugins: `plugins/` (36 plugins)
 - Sub-marketplace plugins: `.claude/plugins/` (6 plugins)
 - Rules: `.claude/rules/` (modular, path-scoped instructions)
 - Platform skills: `.claude/skills/`

--- a/.claude/agents/selenium-testing/auth-flow-tester.md
+++ b/.claude/agents/selenium-testing/auth-flow-tester.md
@@ -1,7 +1,7 @@
 ---
 name: Auth Flow Tester
 type: specialized-agent
-model: claude-sonnet-4-5
+model: claude-sonnet-5
 category: testing
 keywords:
   - authentication

--- a/.claude/agents/selenium-testing/member-journey-tester.md
+++ b/.claude/agents/selenium-testing/member-journey-tester.md
@@ -1,7 +1,7 @@
 ---
 name: Member Journey Tester
 type: specialized-agent
-model: claude-sonnet-4-5
+model: claude-sonnet-5
 category: testing
 keywords:
   - member testing

--- a/.claude/agents/selenium-testing/selenium-test-architect.md
+++ b/.claude/agents/selenium-testing/selenium-test-architect.md
@@ -1,7 +1,7 @@
 ---
 name: Selenium Test Architect
 type: specialized-agent
-model: claude-sonnet-4-5
+model: claude-sonnet-5
 category: testing
 keywords:
   - selenium

--- a/.claude/commands/cc-agent.md
+++ b/.claude/commands/cc-agent.md
@@ -57,7 +57,7 @@ tools:
   - Bash
   - Glob
   - Grep
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 # Agent Name

--- a/.claude/commands/cc-setup.md
+++ b/.claude/commands/cc-setup.md
@@ -331,7 +331,7 @@ frontmatter (always loaded) → body (on activation) → reference files (on dem
 ```markdown
 ---
 description: "{stack_name} operations — auto-invoke when working on {file_patterns}"
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 allowed-tools:
   - Bash
   - Read
@@ -650,7 +650,7 @@ Based on project characteristics, generate agents with deliberate model assignme
 ---
 name: {agent-name}
 description: {what it does}
-model: {claude-sonnet-4-6 or claude-opus-4-6}
+model: {claude-sonnet-5 or claude-opus-4-8}
 allowed-tools:
   - Read
   - Grep
@@ -839,7 +839,7 @@ echo '{"decision": "approve"}'
       "Bash(curl * | bash)"
     ]
   },
-  "model": "claude-sonnet-4-6",
+  "model": "claude-sonnet-5",
   "autoMemory": true,
   "autoCompact": true
 }
@@ -852,7 +852,7 @@ echo '{"decision": "approve"}'
   "permissions": {
     "allow": []
   },
-  "model": "claude-sonnet-4-6"
+  "model": "claude-sonnet-5"
 }
 ```
 

--- a/.claude/plugins/langgraph-architect/.claude-plugin/plugin.json
+++ b/.claude/plugins/langgraph-architect/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langgraph-architect",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Expert LangGraph/LangChain agent builder with MCP integration, workflow orchestration, and CLI accessibility. Creates production-ready AI agents that are reachable via command line and Claude Code.",
   "author": {
     "name": "Brookside BI"

--- a/.claude/plugins/langgraph-architect/CHANGELOG.md
+++ b/.claude/plugins/langgraph-architect/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to the langgraph-architect plugin are documented in this file.
+
+## [1.1.0] - 2026-07-11
+
+### Changed
+
+- Migrated all Claude model references to the current model generation:
+  - `claude-3-5-sonnet-20241022`, `claude-sonnet-4-5` / `claude-sonnet-4-5-20250929`, and `claude-sonnet-4` → `claude-sonnet-5` (commands, agent definitions, skills, MCP lib, templates, examples)
+  - `claude-opus-4-5` and `claude-3-opus-20240229` → `claude-opus-4-8` (orchestration-master agent, graph/orchestration pattern skills, research-assistant example docs)
+- Removed `temperature` arguments from `ChatAnthropic(...)` call sites and example model configs that now target `claude-sonnet-5` / `claude-opus-4-8` — sampling parameters are rejected (HTTP 400) on current-generation models.
+- Removed deprecated `budget_tokens` thinking-budget settings from agent definitions (node-specialist, tool-integrator, edge-designer, state-engineer) — fixed thinking budgets are replaced by adaptive thinking on current models.
+
+### Notes
+
+- Generic, provider-agnostic `temperature` plumbing (multi-provider CLI flags in cli-wrapper-specialist, the MCP server's optional config-override schema, and the model-less hello_world example config) was intentionally left in place, as it does not unconditionally target a Claude model.

--- a/.claude/plugins/langgraph-architect/agents/cli-wrapper-specialist.md
+++ b/.claude/plugins/langgraph-architect/agents/cli-wrapper-specialist.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Claude Code
 created: 2026-01-16
 updated: 2026-01-16
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-5
 color: lime
 status: active
 type: specialist
@@ -158,7 +158,7 @@ class ModelChoice(str, Enum):
     """Available models"""
     GPT4 = "gpt-4o"
     GPT4_MINI = "gpt-4o-mini"
-    CLAUDE = "claude-sonnet-4-5"
+    CLAUDE = "claude-sonnet-5"
 
 @app.command()
 def run(
@@ -979,7 +979,7 @@ Run the LangGraph agent with a query.
 ## Options
 
 - `--stream`: Stream output
-- `--model`: Choose model (gpt-4o, claude-sonnet-4-5)
+- `--model`: Choose model (gpt-4o, claude-sonnet-5)
 - `--save`: Save conversation
 
 ## Implementation

--- a/.claude/plugins/langgraph-architect/agents/context-engineer.md
+++ b/.claude/plugins/langgraph-architect/agents/context-engineer.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Claude Code
 created: 2026-01-16
 updated: 2026-01-16
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-5
 color: indigo
 status: active
 type: specialist

--- a/.claude/plugins/langgraph-architect/agents/deployment-specialist.md
+++ b/.claude/plugins/langgraph-architect/agents/deployment-specialist.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Claude Code
 created: 2026-01-16
 updated: 2026-01-16
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-5
 color: gray
 status: active
 type: specialist

--- a/.claude/plugins/langgraph-architect/agents/edge-designer.md
+++ b/.claude/plugins/langgraph-architect/agents/edge-designer.md
@@ -9,9 +9,8 @@ name: edge-designer
 ---
 name: edge-designer
 version: 1.0.0
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-5
 color: red
-budget_tokens: 50000
 description: Expert in designing edges and routing logic for LangGraph state machines
 expertise:
   - Normal edge configuration

--- a/.claude/plugins/langgraph-architect/agents/mcp-bridge-specialist.md
+++ b/.claude/plugins/langgraph-architect/agents/mcp-bridge-specialist.md
@@ -57,7 +57,7 @@ async def create_mcp_agent():
             all_tools = fs_tools + atlassian_tools
 
             # Create agent with all tools
-            model = ChatAnthropic(model="claude-sonnet-4")
+            model = ChatAnthropic(model="claude-sonnet-5")
             agent = create_react_agent(model, all_tools)
 
             # Run agent with MCP tools available
@@ -269,7 +269,7 @@ class OrchestrationAgent:
 
     async def build_graph(self):
         """Build LangGraph with external MCP tools"""
-        model = ChatAnthropic(model="claude-sonnet-4")
+        model = ChatAnthropic(model="claude-sonnet-5")
 
         # Create graph with external tools
         builder = StateGraph(AgentState)

--- a/.claude/plugins/langgraph-architect/agents/node-specialist.md
+++ b/.claude/plugins/langgraph-architect/agents/node-specialist.md
@@ -9,9 +9,8 @@ name: node-specialist
 ---
 name: node-specialist
 version: 1.0.0
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-5
 color: orange
-budget_tokens: 50000
 description: Expert in creating and optimizing LangGraph nodes with proper patterns
 expertise:
   - Function node implementation
@@ -106,7 +105,7 @@ def llm_node(state: State) -> State:
     - Invokes LLM with tools
     - Appends response to messages
     """
-    llm = ChatAnthropic(model="claude-sonnet-4-5-20250929")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     llm_with_tools = llm.bind_tools(tools)
 
     response = llm_with_tools.invoke(state["messages"])
@@ -116,7 +115,7 @@ def llm_node(state: State) -> State:
 # Streaming variant
 async def streaming_llm_node(state: State) -> State:
     """LLM node with streaming support"""
-    llm = ChatAnthropic(model="claude-sonnet-4-5-20250929", streaming=True)
+    llm = ChatAnthropic(model="claude-sonnet-5", streaming=True)
 
     chunks = []
     async for chunk in llm.astream(state["messages"]):

--- a/.claude/plugins/langgraph-architect/agents/orchestration-master.md
+++ b/.claude/plugins/langgraph-architect/agents/orchestration-master.md
@@ -173,7 +173,7 @@ def create_supervisor_graph():
     from langgraph_supervisor import create_supervisor_node
 
     supervisor_node = create_supervisor_node(
-        llm=ChatAnthropic(model="claude-opus-4-5"),
+        llm=ChatAnthropic(model="claude-opus-4-8"),
         prompt=supervisor_prompt,
         agents=list(agents.keys())
     )
@@ -229,7 +229,7 @@ def create_hierarchical_supervisor():
         team_results: dict
 
     master_supervisor = create_supervisor_node(
-        llm=ChatAnthropic(model="claude-opus-4-5"),
+        llm=ChatAnthropic(model="claude-opus-4-8"),
         prompt="You coordinate research_team and writing_team supervisors...",
         agents=["research_team", "writing_team"]
     )
@@ -301,7 +301,7 @@ def create_research_swarm_agent():
         3. Hand off to fact_checker for verification
         4. Hand off to writer when ready for content creation
         """,
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_writer, handoff_to_fact_checker]
     )
 
@@ -328,7 +328,7 @@ def create_writer_swarm_agent():
         2. Request more research if needed
         3. Hand off to reviewer for quality check
         """,
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_reviewer, handoff_to_research]
     )
 
@@ -350,7 +350,7 @@ def create_reviewer_swarm_agent():
         2. Provide feedback and request revisions
         3. Approve when quality standards met
         """,
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_writer]
     )
 
@@ -408,7 +408,7 @@ def create_adaptive_swarm_agent():
     agent = create_swarm_agent(
         name="adaptive_agent",
         instructions="Adapt behavior and handoffs based on task complexity...",
-        llm=ChatAnthropic(model="claude-opus-4-5"),
+        llm=ChatAnthropic(model="claude-opus-4-8"),
         handoffs=[
             create_contextual_handoff("expert_agent", should_escalate),
             create_contextual_handoff("parallel_coordinator", should_parallelize)
@@ -564,7 +564,7 @@ def create_dynamic_parallel_graph():
         query = state["query"]
 
         # LLM decides how to parallelize
-        llm = ChatAnthropic(model="claude-opus-4-5")
+        llm = ChatAnthropic(model="claude-opus-4-8")
         analysis = llm.invoke(f"""
         Analyze this query and determine optimal parallelization:
         Query: {query}
@@ -656,7 +656,7 @@ def create_handoff_agent(name: str, handoff_targets: list[str]):
         handoff_tools.append(tool)
 
     def agent_node(state: HandoffState):
-        llm = ChatAnthropic(model="claude-sonnet-4-5")
+        llm = ChatAnthropic(model="claude-sonnet-5")
         llm_with_tools = llm.bind_tools(handoff_tools)
 
         # Agent can invoke handoff tools
@@ -1034,7 +1034,7 @@ def create_dynamic_approval():
 
     def determine_approvers(state: HumanLoopState):
         """LLM determines who needs to approve"""
-        llm = ChatAnthropic(model="claude-opus-4-5")
+        llm = ChatAnthropic(model="claude-opus-4-8")
 
         analysis = llm.invoke(f"""
         Analyze this work and determine required approvers:
@@ -1103,7 +1103,7 @@ def create_hybrid_orchestration():
 
     def master_coordinator(state: HybridState):
         """Determine orchestration strategy"""
-        llm = ChatAnthropic(model="claude-opus-4-5")
+        llm = ChatAnthropic(model="claude-opus-4-8")
 
         strategy = llm.invoke("""
         Analyze task and choose orchestration:

--- a/.claude/plugins/langgraph-architect/agents/state-engineer.md
+++ b/.claude/plugins/langgraph-architect/agents/state-engineer.md
@@ -9,9 +9,8 @@ name: state-engineer
 ---
 name: state-engineer
 version: 1.0.0
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-5
 color: yellow
-budget_tokens: 50000
 description: Expert in designing and managing state schemas for LangGraph applications
 expertise:
   - TypedDict state definitions

--- a/.claude/plugins/langgraph-architect/agents/subgraph-composer.md
+++ b/.claude/plugins/langgraph-architect/agents/subgraph-composer.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Claude Code
 created: 2026-01-16
 updated: 2026-01-16
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-5
 color: pink
 status: active
 type: specialist

--- a/.claude/plugins/langgraph-architect/agents/tool-integrator.md
+++ b/.claude/plugins/langgraph-architect/agents/tool-integrator.md
@@ -9,9 +9,8 @@ name: tool-integrator
 ---
 name: tool-integrator
 version: 1.0.0
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-5
 color: teal
-budget_tokens: 50000
 description: Expert in integrating tools with LangGraph agents and workflows
 expertise:
   - Tool decorator usage
@@ -187,7 +186,7 @@ from langchain_anthropic import ChatAnthropic
 
 def agent_node(state: AgentState) -> dict:
     """Agent that decides which tools to call."""
-    llm = ChatAnthropic(model="claude-sonnet-4-5-20250929")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     llm_with_tools = llm.bind_tools(tools)
 
     response = llm_with_tools.invoke(state["messages"])
@@ -556,7 +555,7 @@ tools = [
 ]
 
 # Bind tools to LLM
-llm = ChatAnthropic(model="claude-sonnet-4-5-20250929")
+llm = ChatAnthropic(model="claude-sonnet-5")
 llm_with_tools = llm.bind_tools(tools)
 
 # LLM can now call tools
@@ -606,7 +605,7 @@ def composed_search_and_summarize(query: str) -> str:
     search_results = search_tool.invoke({"query": query})
 
     # Summarize with LLM
-    llm = ChatAnthropic(model="claude-sonnet-4-5-20250929")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     summary = llm.invoke([
         HumanMessage(content=f"Summarize these search results:\n{search_results}")
     ])

--- a/.claude/plugins/langgraph-architect/commands/agent.md
+++ b/.claude/plugins/langgraph-architect/commands/agent.md
@@ -27,7 +27,7 @@ flags:
   - name: llm
     description: LLM model to use
     type: string
-    default: "claude-3-5-sonnet-20241022"
+    default: "claude-sonnet-5"
   - name: tools
     description: Comma-separated list of tools
     type: string
@@ -162,7 +162,7 @@ Reasoning and Acting pattern with tool use.
 from langchain_anthropic import ChatAnthropic
 from langgraph.prebuilt import create_react_agent
 
-llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+llm = ChatAnthropic(model="claude-sonnet-5")
 agent = create_react_agent(
     llm,
     tools=tools,
@@ -177,7 +177,7 @@ Optimized for structured tool usage.
 from langchain_core.messages import SystemMessage
 
 def tool_agent(state: State):
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     llm_with_tools = llm.bind_tools(tools)
 
     messages = [
@@ -192,7 +192,7 @@ Simple conversation handler.
 
 ```python
 def conversational_agent(state: State):
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     response = llm.invoke(state["messages"])
     return {"messages": [response]}
 ```
@@ -204,7 +204,7 @@ Orchestrates other agents.
 from typing import Literal
 
 def supervisor_agent(state: State) -> Literal["researcher", "coder", "END"]:
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     system_prompt = """
     You are a supervisor managing these agents:
@@ -227,7 +227,7 @@ Specialized task executor in multi-agent system.
 
 ```python
 def worker_agent(state: State):
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     llm_with_tools = llm.bind_tools(worker_tools)
 
     system_prompt = f"You are {state['current_agent']}. {state['task']}"
@@ -248,7 +248,7 @@ from langchain_community.tools import DuckDuckGoSearchRun
 search = DuckDuckGoSearchRun()
 
 def researcher_agent(state: State):
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     llm_with_tools = llm.bind_tools([search, scrape_tool, summarize_tool])
 
     system_prompt = """
@@ -270,7 +270,7 @@ Code generation and modification.
 
 ```python
 def coder_agent(state: State):
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     llm_with_tools = llm.bind_tools([
         read_file_tool,
         write_file_tool,
@@ -298,7 +298,7 @@ Quality assurance and feedback.
 
 ```python
 def reviewer_agent(state: State):
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     llm_with_tools = llm.bind_tools([
         read_file_tool,
         lint_tool,
@@ -378,7 +378,7 @@ Output:
 ```
 Agent: researcher
 Type: researcher
-LLM: claude-3-5-sonnet-20241022
+LLM: claude-sonnet-5
 Tools: search, scrape, summarize
 Max Iterations: 10
 Streaming: enabled
@@ -431,7 +431,7 @@ def researcher_agent(state: ResearcherState):
     - scrape: Web scraping
     - summarize: Text summarization
     """
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     llm_with_tools = llm.bind_tools([search, scrape, summarize])
 
     system_prompt = """
@@ -508,7 +508,7 @@ for agent in agents:
 AGENTS = {
     "researcher": {
         "type": "researcher",
-        "llm": "claude-3-5-sonnet-20241022",
+        "llm": "claude-sonnet-5",
         "tools": ["search", "scrape", "summarize"],
         "system_prompt": "You are a research assistant...",
         "max_iterations": 10,

--- a/.claude/plugins/langgraph-architect/commands/edge.md
+++ b/.claude/plugins/langgraph-architect/commands/edge.md
@@ -216,7 +216,7 @@ from langchain_core.messages import SystemMessage
 
 def llm_router(state: State) -> str:
     """Use LLM to decide next step."""
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     routing_prompt = """
     Based on the conversation, decide the next step:
@@ -620,7 +620,7 @@ from typing import Literal
 
 def llm_router(state: State) -> Literal["researcher", "coder", "reviewer", "end"]:
     """Use LLM to route to next agent."""
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     system_prompt = """
     You are a supervisor managing these agents:

--- a/.claude/plugins/langgraph-architect/commands/mcp.md
+++ b/.claude/plugins/langgraph-architect/commands/mcp.md
@@ -347,7 +347,7 @@ from .tools.mcp_tools import get_mcp_tools
 mcp_tools = get_mcp_tools()
 
 # Create agent with MCP tools
-llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+llm = ChatAnthropic(model="claude-sonnet-5")
 agent = create_react_agent(llm, mcp_tools)
 ```
 

--- a/.claude/plugins/langgraph-architect/commands/node.md
+++ b/.claude/plugins/langgraph-architect/commands/node.md
@@ -166,7 +166,7 @@ from langchain_core.messages import SystemMessage
 
 def llm_node(state: State):
     """LLM processing node."""
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     system_prompt = "You are a helpful assistant."
     messages = [SystemMessage(content=system_prompt)] + state["messages"]
@@ -516,7 +516,7 @@ def summarizer_node(state: SummarizerState):
 
     Processes text and generates concise summary.
     """
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     system_prompt = """
     You are a summarization expert.

--- a/.claude/plugins/langgraph-architect/lib/examples/research-assistant/README.md
+++ b/.claude/plugins/langgraph-architect/lib/examples/research-assistant/README.md
@@ -237,8 +237,7 @@ Edit the model initialization in `main.py`:
 
 ```python
 model = ChatAnthropic(
-    model="claude-3-opus-20240229",  # Change model
-    temperature=0.7                   # Adjust temperature
+    model="claude-opus-4-8",  # Change model
 )
 ```
 

--- a/.claude/plugins/langgraph-architect/lib/examples/research-assistant/main.py
+++ b/.claude/plugins/langgraph-architect/lib/examples/research-assistant/main.py
@@ -215,8 +215,7 @@ async def research_planner_node(state: ResearchState) -> ResearchState:
 Use the available tools strategically to gather comprehensive information."""
 
     model = ChatAnthropic(
-        model="claude-3-5-sonnet-20241022",
-        temperature=0
+        model="claude-sonnet-5"
     ).bind_tools(research_tools)
 
     messages = [SystemMessage(content=system_prompt)] + list(state["messages"])
@@ -324,8 +323,7 @@ Provide a well-structured summary that:
 Format the summary in markdown with clear sections."""
 
     model = ChatAnthropic(
-        model="claude-3-5-sonnet-20241022",
-        temperature=0.3
+        model="claude-sonnet-5"
     )
 
     response = await model.ainvoke([HumanMessage(content=synthesis_prompt)])
@@ -373,8 +371,7 @@ Provide:
 - Recommendation (approve/revise)"""
 
     model = ChatAnthropic(
-        model="claude-3-5-sonnet-20241022",
-        temperature=0
+        model="claude-sonnet-5"
     )
 
     response = await model.ainvoke([HumanMessage(content=check_prompt)])

--- a/.claude/plugins/langgraph-architect/lib/mcp/README.md
+++ b/.claude/plugins/langgraph-architect/lib/mcp/README.md
@@ -162,7 +162,7 @@ registry.register_agent(
     description="Helps with research tasks and information gathering",
     module_path="/path/to/research_agent.py",
     agent_type="specialized",
-    model="claude-3-5-sonnet-20241022",
+    model="claude-sonnet-5",
     capabilities=["web_search", "document_analysis", "summarization"],
     tools=["tavily_search", "document_loader"]
 )
@@ -246,7 +246,7 @@ Optional configuration file for agents:
   "description": "AI agent for research and information gathering",
   "version": "1.0.0",
   "agent_type": "specialized",
-  "model": "claude-3-5-sonnet-20241022",
+  "model": "claude-sonnet-5",
   "capabilities": [
     "web_search",
     "document_analysis",
@@ -257,7 +257,6 @@ Optional configuration file for agents:
     "document_loader"
   ],
   "default_config": {
-    "temperature": 0.7,
     "max_tokens": 4096
   },
   "dependencies": [

--- a/.claude/plugins/langgraph-architect/lib/mcp/mcp_config.json
+++ b/.claude/plugins/langgraph-architect/lib/mcp/mcp_config.json
@@ -3,7 +3,6 @@
   "name": "langgraph-agents-mcp-config",
   "version": "1.0.0",
   "description": "Sample MCP configuration for LangGraph agents integration",
-
   "mcpServers": {
     "langgraph-agents": {
       "description": "MCP server exposing LangGraph agents as callable tools",
@@ -25,7 +24,6 @@
       }
     }
   },
-
   "installation": {
     "instructions": [
       "Step 1: Install required Python packages",
@@ -55,7 +53,6 @@
       }
     }
   },
-
   "configuration": {
     "agentRegistryPath": {
       "type": "string",
@@ -66,7 +63,12 @@
     "logLevel": {
       "type": "string",
       "description": "Logging level for the MCP server",
-      "enum": ["DEBUG", "INFO", "WARNING", "ERROR"],
+      "enum": [
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR"
+      ],
       "default": "INFO",
       "required": false
     },
@@ -89,7 +91,6 @@
       "required": false
     }
   },
-
   "capabilities": {
     "tools": {
       "enabled": true,
@@ -104,7 +105,6 @@
       "description": "Provides prompt templates for invoking agents"
     }
   },
-
   "examples": {
     "invoke_agent": {
       "description": "Invoke a LangGraph agent by name",
@@ -113,8 +113,7 @@
         "input": "Hello, what can you do?",
         "thread_id": "optional-thread-id",
         "config": {
-          "model": "claude-3-5-sonnet-20241022",
-          "temperature": 0.7
+          "model": "claude-sonnet-5"
         }
       }
     },
@@ -127,7 +126,6 @@
       "resource": "agent://hello_world"
     }
   },
-
   "troubleshooting": {
     "common_issues": [
       {
@@ -159,7 +157,6 @@
       }
     ]
   },
-
   "usage": {
     "claude_code": {
       "description": "Using LangGraph agents from Claude Code",
@@ -218,7 +215,6 @@
       }
     }
   },
-
   "advanced": {
     "custom_registry_path": {
       "description": "Use a custom agent registry location",
@@ -247,7 +243,6 @@
       ]
     }
   },
-
   "metadata": {
     "author": "Brookside BI",
     "license": "MIT",

--- a/.claude/plugins/langgraph-architect/lib/templates/cli-agent.py
+++ b/.claude/plugins/langgraph-architect/lib/templates/cli-agent.py
@@ -95,8 +95,7 @@ agent_tools = [search_web, get_current_time, calculate]
 async def agent_node(state: AgentState) -> AgentState:
     """Main agent node."""
     model = ChatAnthropic(
-        model="claude-3-5-sonnet-20241022",
-        temperature=0
+        model="claude-sonnet-5"
     ).bind_tools(agent_tools)
 
     response = await model.ainvoke(state["messages"])

--- a/.claude/plugins/langgraph-architect/lib/templates/mcp-server-agent.py
+++ b/.claude/plugins/langgraph-architect/lib/templates/mcp-server-agent.py
@@ -74,8 +74,7 @@ agent_tools = [research_web, analyze_data]
 async def agent_node(state: AgentState) -> AgentState:
     """Main agent node."""
     model = ChatAnthropic(
-        model="claude-3-5-sonnet-20241022",
-        temperature=0
+        model="claude-sonnet-5"
     ).bind_tools(agent_tools)
 
     response = await model.ainvoke(state["messages"])

--- a/.claude/plugins/langgraph-architect/lib/templates/react-agent.py
+++ b/.claude/plugins/langgraph-architect/lib/templates/react-agent.py
@@ -111,8 +111,7 @@ async def agent_node(state: AgentState) -> AgentState:
     try:
         # Initialize the model with tools
         model = ChatAnthropic(
-            model="claude-3-5-sonnet-20241022",
-            temperature=0
+            model="claude-sonnet-5"
         ).bind_tools(tools)
 
         # Get the conversation history

--- a/.claude/plugins/langgraph-architect/lib/templates/supervisor-multi-agent.py
+++ b/.claude/plugins/langgraph-architect/lib/templates/supervisor-multi-agent.py
@@ -147,8 +147,7 @@ Available agents: {', '.join(AGENTS)}"""
 
     # Create supervisor chain
     model = ChatAnthropic(
-        model="claude-3-5-sonnet-20241022",
-        temperature=0
+        model="claude-sonnet-5"
     )
 
     supervisor_chain = prompt | model.with_structured_output(RouteResponse)
@@ -208,8 +207,7 @@ async def researcher_node(state: SupervisorState) -> SupervisorState:
 and provide accurate, well-sourced answers. Use the search_web tool to find information."""
 
     model = ChatAnthropic(
-        model="claude-3-5-sonnet-20241022",
-        temperature=0
+        model="claude-sonnet-5"
     ).bind_tools([search_web])
 
     messages = [SystemMessage(content=system_prompt)] + list(state["messages"])
@@ -260,8 +258,7 @@ async def calculator_node(state: SupervisorState) -> SupervisorState:
 calculations and solve mathematical problems. Use the calculate tool for computations."""
 
     model = ChatAnthropic(
-        model="claude-3-5-sonnet-20241022",
-        temperature=0
+        model="claude-sonnet-5"
     ).bind_tools([calculate])
 
     messages = [SystemMessage(content=system_prompt)] + list(state["messages"])
@@ -309,8 +306,7 @@ async def writer_node(state: SupervisorState) -> SupervisorState:
 clear, and engaging content. Use the format_document tool to format your output."""
 
     model = ChatAnthropic(
-        model="claude-3-5-sonnet-20241022",
-        temperature=0.7
+        model="claude-sonnet-5"
     ).bind_tools([format_document])
 
     messages = [SystemMessage(content=system_prompt)] + list(state["messages"])

--- a/.claude/plugins/langgraph-architect/skills/graph-patterns.md
+++ b/.claude/plugins/langgraph-architect/skills/graph-patterns.md
@@ -169,7 +169,7 @@ Route tasks to appropriate agents. When done, return FINISH.
 """
 
 supervisor = create_supervisor_node(
-    llm=ChatAnthropic(model="claude-opus-4-5"),
+    llm=ChatAnthropic(model="claude-opus-4-8"),
     prompt=supervisor_prompt,
     agents=members
 )
@@ -271,7 +271,7 @@ class HierarchicalState(TypedDict):
     team_outputs: dict
 
 main_supervisor = create_supervisor_node(
-    llm=ChatAnthropic(model="claude-opus-4-5"),
+    llm=ChatAnthropic(model="claude-opus-4-8"),
     prompt="Coordinate research_team, dev_team, and qa_team...",
     agents=["research_team", "dev_team", "qa_team"]
 )
@@ -315,7 +315,7 @@ def create_team_subgraph(team_name: str, members: list[str], supervisor_prompt: 
 
     # Create team supervisor
     team_supervisor = create_supervisor_node(
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         prompt=supervisor_prompt,
         agents=members
     )
@@ -384,7 +384,7 @@ def create_research_agent():
     return create_swarm_agent(
         name="researcher",
         instructions="Research and gather information. Hand off to fact checker or writer.",
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_writer, handoff_to_fact_checker]
     )
 
@@ -401,7 +401,7 @@ def create_writer_agent():
     return create_swarm_agent(
         name="writer",
         instructions="Create content. Request more research or hand off to reviewer.",
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_reviewer, handoff_to_researcher]
     )
 
@@ -414,7 +414,7 @@ def create_reviewer_agent():
     return create_swarm_agent(
         name="reviewer",
         instructions="Review quality. Request revisions or approve.",
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_writer],
         can_approve=True  # Can end workflow
     )

--- a/.claude/plugins/langgraph-architect/skills/orchestration-patterns.md
+++ b/.claude/plugins/langgraph-architect/skills/orchestration-patterns.md
@@ -178,7 +178,7 @@ When all work is complete and synthesis is done, return FINISH.
 """
 
 supervisor = create_supervisor_node(
-    llm=ChatAnthropic(model="claude-opus-4-5"),
+    llm=ChatAnthropic(model="claude-opus-4-8"),
     prompt=supervisor_prompt,
     agents=members
 )
@@ -244,7 +244,7 @@ def create_smart_supervisor(agents: list[str], agent_capabilities: dict):
         current_context = analyze_context(state)
 
         # Get supervisor decision
-        llm = ChatAnthropic(model="claude-opus-4-5")
+        llm = ChatAnthropic(model="claude-opus-4-8")
         decision = llm.invoke([
             SystemMessage(content=supervisor_prompt),
             *state["messages"],
@@ -345,7 +345,7 @@ def create_research_swarm_agent():
 
         Collaborate with peers via handoffs.
         """,
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_analyst, handoff_to_fact_checker, handoff_to_writer]
     )
 
@@ -374,7 +374,7 @@ def create_analyst_swarm_agent():
 
         Collaborate with peers via handoffs.
         """,
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_researcher, handoff_to_writer]
     )
 
@@ -403,7 +403,7 @@ def create_fact_checker_swarm_agent():
 
         Collaborate with peers via handoffs.
         """,
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_researcher, handoff_to_writer]
     )
 
@@ -432,7 +432,7 @@ def create_writer_swarm_agent():
 
         You can complete the workflow or hand back for more work.
         """,
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         handoffs=[handoff_to_researcher, handoff_to_analyst],
         can_complete=True  # Can end the workflow
     )
@@ -492,7 +492,7 @@ def create_adaptive_swarm_agent(
     return create_swarm_agent(
         name=name,
         instructions=base_instructions,
-        llm=ChatAnthropic(model="claude-opus-4-5"),
+        llm=ChatAnthropic(model="claude-opus-4-8"),
         handoffs=adaptive_handoff_logic  # Dynamic handoffs
     )
 ```
@@ -550,7 +550,7 @@ def create_team_subgraph(
 
     # Create team supervisor
     team_supervisor = create_supervisor_node(
-        llm=ChatAnthropic(model="claude-sonnet-4-5"),
+        llm=ChatAnthropic(model="claude-sonnet-5"),
         prompt=supervisor_prompt,
         agents=members
     )
@@ -639,7 +639,7 @@ Return FINISH when project complete.
 """
 
 main_supervisor = create_supervisor_node(
-    llm=ChatAnthropic(model="claude-opus-4-5"),
+    llm=ChatAnthropic(model="claude-opus-4-8"),
     prompt=main_supervisor_prompt,
     agents=["research_team", "dev_team", "qa_team"]
 )

--- a/.claude/registry/mcps.index.json
+++ b/.claude/registry/mcps.index.json
@@ -835,9 +835,43 @@
   },
   "models": {
     "anthropic": {
+      "fable": {
+        "description": "Claude Fable 5 - Mythos-class tier above Opus for the hardest long-horizon autonomous work",
+        "modelId": "claude-fable-5",
+        "provider": "anthropic",
+        "strengths": [
+          "long-horizon",
+          "autonomous-runs",
+          "hardest-reasoning",
+          "multi-agent-orchestration"
+        ],
+        "pricing": {
+          "inputPer1M": 10,
+          "outputPer1M": 50,
+          "currency": "USD"
+        },
+        "performance": {
+          "latencyMs": 5000,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "qualityScore": 99
+        },
+        "features": {
+          "extendedThinking": true,
+          "vision": true,
+          "toolUse": true,
+          "streaming": true
+        },
+        "useCases": [
+          "overnight builds",
+          "long-horizon agentic runs",
+          "problems above Opus ceiling"
+        ],
+        "priority": "high"
+      },
       "opus": {
-        "description": "Claude Opus 4.5 - Most capable model for complex reasoning and architecture",
-        "modelId": "claude-opus-4-5-20251101",
+        "description": "Claude Opus 4.8 - Most capable Opus-tier model for complex reasoning and architecture",
+        "modelId": "claude-opus-4-8",
         "provider": "anthropic",
         "strengths": [
           "architecture",
@@ -847,15 +881,15 @@
           "creative"
         ],
         "pricing": {
-          "inputPer1M": 15.00,
-          "outputPer1M": 75.00,
+          "inputPer1M": 5,
+          "outputPer1M": 25,
           "currency": "USD"
         },
         "performance": {
           "latencyMs": 3000,
-          "contextWindow": 200000,
-          "maxOutputTokens": 16384,
-          "qualityScore": 95
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "qualityScore": 97
         },
         "features": {
           "extendedThinking": true,
@@ -872,8 +906,8 @@
         "priority": "high"
       },
       "sonnet": {
-        "description": "Claude Sonnet 4.5 - Balanced model for development and analysis",
-        "modelId": "claude-sonnet-4-5-20250929",
+        "description": "Claude Sonnet 5 - Balanced model for development and analysis, near-Opus on coding",
+        "modelId": "claude-sonnet-5",
         "provider": "anthropic",
         "strengths": [
           "code-generation",
@@ -883,15 +917,15 @@
           "refactoring"
         ],
         "pricing": {
-          "inputPer1M": 3.00,
-          "outputPer1M": 15.00,
+          "inputPer1M": 3,
+          "outputPer1M": 15,
           "currency": "USD"
         },
         "performance": {
           "latencyMs": 2000,
-          "contextWindow": 200000,
-          "maxOutputTokens": 16384,
-          "qualityScore": 90
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "qualityScore": 94
         },
         "features": {
           "extendedThinking": true,
@@ -908,8 +942,8 @@
         "priority": "high"
       },
       "haiku": {
-        "description": "Claude Haiku 4 - Fast and cost-effective for simple tasks",
-        "modelId": "claude-haiku-4-20250130",
+        "description": "Claude Haiku 4.5 - Fast and cost-effective for simple tasks",
+        "modelId": "claude-haiku-4-5-20251001",
         "provider": "anthropic",
         "strengths": [
           "simple-task",
@@ -918,15 +952,15 @@
           "testing"
         ],
         "pricing": {
-          "inputPer1M": 0.80,
-          "outputPer1M": 4.00,
+          "inputPer1M": 1,
+          "outputPer1M": 5,
           "currency": "USD"
         },
         "performance": {
           "latencyMs": 800,
           "contextWindow": 200000,
-          "maxOutputTokens": 8192,
-          "qualityScore": 80
+          "maxOutputTokens": 64000,
+          "qualityScore": 85
         },
         "features": {
           "extendedThinking": false,
@@ -955,8 +989,8 @@
           "analysis"
         ],
         "pricing": {
-          "inputPer1M": 10.00,
-          "outputPer1M": 30.00,
+          "inputPer1M": 10,
+          "outputPer1M": 30,
           "currency": "USD"
         },
         "performance": {
@@ -988,8 +1022,8 @@
           "factual"
         ],
         "pricing": {
-          "inputPer1M": 0.50,
-          "outputPer1M": 1.50,
+          "inputPer1M": 0.5,
+          "outputPer1M": 1.5,
           "currency": "USD"
         },
         "performance": {
@@ -1024,7 +1058,7 @@
         ],
         "pricing": {
           "inputPer1M": 1.25,
-          "outputPer1M": 5.00,
+          "outputPer1M": 5,
           "currency": "USD"
         },
         "performance": {
@@ -1057,7 +1091,7 @@
         ],
         "pricing": {
           "inputPer1M": 0.075,
-          "outputPer1M": 0.30,
+          "outputPer1M": 0.3,
           "currency": "USD"
         },
         "performance": {

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -420,7 +420,7 @@
     },
     "langgraph-architect": {
       "name": "langgraph-architect",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Expert LangGraph/LangChain agent builder with MCP integration, workflow orchestration, and CLI accessibility. Creates production-ready AI agents that are reachable via command line and Claude Code.",
       "keywords": [
         "langgraph",
@@ -1714,7 +1714,7 @@
     "ai-advanced": {
       "langgraph-architect": {
         "path": "../.claude/plugins/langgraph-architect/.claude-plugin/plugin.json",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "status": "active",
         "tier": "standard"
       },

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -262,6 +262,13 @@
       "source": "local",
       "installedAt": "2026-07-11T00:00:00.000Z",
       "dependencies": {}
+    },
+    "microsoft-agents-expert": {
+      "version": "1.0.0",
+      "path": "../plugins/microsoft-agents-expert",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
     }
   },
   "registry": {
@@ -1594,6 +1601,32 @@
       "categories": [
         "developer-tools"
       ]
+    },
+    "microsoft-agents-expert": {
+      "name": "microsoft-agents-expert",
+      "version": "1.0.0",
+      "description": "Comprehensive Microsoft agent-stack expert: Microsoft Agent Framework (the Semantic Kernel + AutoGen successor), Microsoft 365 Agents SDK, Teams AI Library, Copilot Studio, and Microsoft Foundry Agent Service. Stack selection, scaffolding, migration, review, and deployment. 6 skills, 5 agents, 5 commands.",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "Markus@thelobbi.io"
+      },
+      "keywords": [
+        "microsoft",
+        "agents",
+        "agent-framework",
+        "m365-agents-sdk",
+        "teams",
+        "copilot-studio",
+        "microsoft-foundry",
+        "azure-ai-foundry",
+        "semantic-kernel",
+        "autogen",
+        "mcp",
+        "multi-agent"
+      ],
+      "categories": [
+        "ai-advanced"
+      ]
     }
   },
   "plugins": {
@@ -1681,6 +1714,12 @@
     "ai-advanced": {
       "langgraph-architect": {
         "path": "../.claude/plugins/langgraph-architect/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "microsoft-agents-expert": {
+        "path": "../plugins/microsoft-agents-expert/.claude-plugin/plugin.json",
         "version": "1.0.0",
         "status": "active",
         "tier": "standard"
@@ -1923,17 +1962,17 @@
     "PM": "project-management-plugin"
   },
   "stats": {
-    "totalInstalled": 35,
-    "totalPlugins": 41,
+    "totalInstalled": 36,
+    "totalPlugins": 42,
     "totalAvailable": 6,
     "lastUpdated": "2026-07-11T00:00:00.000Z",
     "byTier": {
       "enterprise": 1,
-      "standard": 40,
+      "standard": 41,
       "premium": 1
     },
     "byLocation": {
-      "plugins/": 35,
+      "plugins/": 36,
       ".claude/plugins/": 6
     }
   }

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -26,7 +26,7 @@
       "dependencies": {}
     },
     "exec-automator": {
-      "version": "2.0.1",
+      "version": "2.1.0",
       "path": "../plugins/exec-automator",
       "source": "local",
       "installedAt": "2026-01-01T00:00:00.000Z",
@@ -61,7 +61,7 @@
       "dependencies": {}
     },
     "jira-orchestrator": {
-      "version": "8.2.0",
+      "version": "8.3.0",
       "path": "../plugins/jira-orchestrator",
       "source": "local",
       "installedAt": "2026-01-01T00:00:00.000Z",
@@ -109,14 +109,14 @@
       "dependencies": {}
     },
     "drawio-diagramming": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "path": "../plugins/drawio-diagramming",
       "source": "local",
       "installedAt": "2026-03-16T00:00:00.000Z",
       "dependencies": {}
     },
     "claude-code-expert": {
-      "version": "8.3.0",
+      "version": "8.4.0",
       "path": "../plugins/claude-code-expert",
       "source": "local",
       "installedAt": "2026-04-17T00:00:00.000Z",
@@ -130,7 +130,7 @@
       "dependencies": {}
     },
     "mui-expert": {
-      "version": "2.1.1",
+      "version": "2.2.0",
       "path": "../plugins/mui-expert",
       "source": "local",
       "installedAt": "2026-03-28T00:00:00.000Z",
@@ -145,7 +145,7 @@
       "dependencies": {}
     },
     "dotnet-blazor": {
-      "version": "2.0.1",
+      "version": "2.1.0",
       "path": "../plugins/dotnet-blazor",
       "source": "local",
       "installedAt": "2026-03-29T00:00:00.000Z",
@@ -267,7 +267,7 @@
   "registry": {
     "jira-orchestrator": {
       "name": "jira-orchestrator",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "description": "Enterprise Jira orchestration with 82 agents, 16 teams, 48 commands, 14 skills, 5 schema-validated workflows, and a read-only advisor. Features Atlassian MCP OAuth, Harness integration, Neon PostgreSQL, Redis caching, Temporal workflows, declarative workflow definitions, lifecycle telemetry hooks, and structured reasoning frameworks.",
       "author": {
         "name": "Markus Ahling",
@@ -662,7 +662,7 @@
     },
     "claude-code-expert": {
       "name": "claude-code-expert",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 21 behavior-triggering skills, 12 single-intent commands, 18 role-scoped agents bridging engram and Obsidian. Tracks current Claude Code capabilities (Fable 5 + Opus 4.8, agent teams, Tool Search, web/remote).",
       "author": {
         "name": "Markus Ahling"
@@ -702,7 +702,7 @@
     },
     "drawio-diagramming": {
       "name": "drawio-diagramming",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "description": "Intelligent draw.io diagramming plugin with AI-powered diagram generation, multi-platform embedding (GitHub, Confluence, Azure DevOps, Notion, Teams, Harness), conditional formatting, live data binding, and MCP server integration for programmatic diagram creation and management.",
       "author": {
         "name": "Markus Ahling",
@@ -765,7 +765,7 @@
     },
     "mui-expert": {
       "name": "mui-expert",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "description": "Comprehensive Material UI (MUI) expert plugin — 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
       "author": {
         "name": "Claude Code",
@@ -824,7 +824,7 @@
     },
     "dotnet-blazor": {
       "name": "dotnet-blazor",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "description": "Comprehensive .NET 10, Blazor, ASP.NET Core, C#, and Syncfusion expert plugin for building modern web apps, microservices, and cloud-native solutions",
       "author": {
         "name": "Markus Ahling"
@@ -961,7 +961,7 @@
     },
     "exec-automator": {
       "name": "exec-automator",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "description": "Genesis (Forerunner) - AI-Powered Executive Director Automation Platform. Analyze organizational responsibilities, score automation potential with 6-factor algorithm, generate LangGraph workflows, and deploy 11 specialized agents for trade associations and nonprofits.",
       "author": {
         "name": "Brookside BI",
@@ -1601,7 +1601,7 @@
       "jira-orchestrator": {
         "path": "../plugins/jira-orchestrator/.claude-plugin/plugin.json",
         "callsign": "Arbiter",
-        "version": "8.2.0",
+        "version": "8.3.0",
         "status": "active",
         "tier": "enterprise"
       },
@@ -1623,7 +1623,7 @@
       "mui-expert": {
         "path": "../plugins/mui-expert/.claude-plugin/plugin.json",
         "callsign": "Materializer",
-        "version": "2.1.1",
+        "version": "2.2.0",
         "status": "active",
         "tier": "premium",
         "platforms": [
@@ -1701,7 +1701,7 @@
       },
       "exec-automator": {
         "path": "../plugins/exec-automator/.claude-plugin/plugin.json",
-        "version": "2.0.1",
+        "version": "2.1.0",
         "status": "active",
         "tier": "standard"
       },
@@ -1714,7 +1714,7 @@
       "dotnet-blazor": {
         "path": "../plugins/dotnet-blazor/.claude-plugin/plugin.json",
         "callsign": "Blazor",
-        "version": "2.0.1",
+        "version": "2.1.0",
         "status": "active",
         "tier": "standard",
         "platforms": [
@@ -1803,7 +1803,7 @@
       "claude-code-expert": {
         "path": "../plugins/claude-code-expert/.claude-plugin/plugin.json",
         "callsign": "Expert",
-        "version": "8.3.0",
+        "version": "8.4.0",
         "status": "active",
         "tier": "standard"
       },
@@ -1852,7 +1852,7 @@
       "drawio-diagramming": {
         "path": "../plugins/drawio-diagramming/.claude-plugin/plugin.json",
         "callsign": "Cartographer",
-        "version": "2.0.0",
+        "version": "2.1.0",
         "status": "active",
         "tier": "standard"
       }

--- a/.claude/registry/plugins.index.json
+++ b/.claude/registry/plugins.index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/plugins.schema.json",
   "version": "3.0.0",
-  "lastUpdated": "2026-04-17T00:00:00Z",
+  "lastUpdated": "2026-07-11T00:00:00Z",
   "description": "Plugin registry for Claude Code orchestration plugins - upgraded with Agentic Design Patterns (Gulli & Sauco, 2025)",
   "installed": {
     "aws-eks-helm-keycloak": {
@@ -116,7 +116,7 @@
       "dependencies": {}
     },
     "claude-code-expert": {
-      "version": "8.2.0",
+      "version": "8.3.0",
       "path": "../plugins/claude-code-expert",
       "source": "local",
       "installedAt": "2026-04-17T00:00:00.000Z",
@@ -171,13 +171,104 @@
       "source": "local",
       "installedAt": "2026-04-21T00:00:00.000Z",
       "dependencies": {}
+    },
+    "linear-orchestrator": {
+      "version": "1.0.0",
+      "path": "../plugins/linear-orchestrator",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-bi-reports": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-bi-reports",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-compliance-guard": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-compliance-guard",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-data-migration": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-data-migration",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-document-intelligence": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-document-intelligence",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-engagement-toolkit": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-engagement-toolkit",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-insurance-domain": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-insurance-domain",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-m365-automator": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-m365-automator",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-mortgage-domain": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-mortgage-domain",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-system-integrator": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-system-integrator",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "lobbi-workflow-engine": {
+      "version": "1.0.0",
+      "path": "../plugins/lobbi-workflow-engine",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "work-automation": {
+      "version": "1.0.0",
+      "path": "../plugins/work-automation",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
+    },
+    "writing-plans-enhanced": {
+      "version": "1.0.1",
+      "path": "../plugins/writing-plans-enhanced",
+      "source": "local",
+      "installedAt": "2026-07-11T00:00:00.000Z",
+      "dependencies": {}
     }
   },
   "registry": {
     "jira-orchestrator": {
       "name": "jira-orchestrator",
-      "version": "8.0.0",
-      "description": "Enterprise Jira orchestration with agents, teams, commands, skills, and agentic design patterns",
+      "version": "8.2.0",
+      "description": "Enterprise Jira orchestration with 82 agents, 16 teams, 48 commands, 14 skills, 5 schema-validated workflows, and a read-only advisor. Features Atlassian MCP OAuth, Harness integration, Neon PostgreSQL, Redis caching, Temporal workflows, declarative workflow definitions, lifecycle telemetry hooks, and structured reasoning frameworks.",
       "author": {
         "name": "Markus Ahling",
         "email": "markus@lobbi.io"
@@ -187,7 +278,32 @@
         "orchestration",
         "atlassian",
         "harness",
-        "ci-cd"
+        "ci-cd",
+        "workflow",
+        "advisor",
+        "automation",
+        "agents",
+        "clean-architecture",
+        "solid",
+        "mcp",
+        "knowledge-graph",
+        "sequential-thinking",
+        "neon",
+        "postgresql",
+        "redis",
+        "temporal",
+        "agentic-design-patterns",
+        "routing",
+        "planning",
+        "multi-agent",
+        "memory-management",
+        "reflection",
+        "parallelization",
+        "exception-handling",
+        "human-in-the-loop",
+        "evaluation-monitoring",
+        "prioritization",
+        "goal-setting"
       ],
       "categories": [
         "integration",
@@ -198,57 +314,131 @@
     "frontend-design-system": {
       "name": "frontend-design-system",
       "version": "2.0.0",
-      "description": "Design styles with multi-tenant Keycloak theming",
+      "description": "263+ design styles with multi-tenant Keycloak theming for AI-powered frontend development",
       "keywords": [
         "frontend",
         "design-system",
         "keycloak",
-        "theming"
+        "theming",
+        "css",
+        "tailwind",
+        "ui-ux",
+        "multi-tenant",
+        "accessibility",
+        "agentic-patterns",
+        "prompt-chaining",
+        "routing",
+        "reflection",
+        "planning",
+        "tool-use",
+        "memory",
+        "parallelization",
+        "guardrails"
       ],
       "categories": [
         "frontend"
-      ]
+      ],
+      "author": {
+        "name": "Markus Ahling"
+      }
     },
     "aws-eks-helm-keycloak": {
       "name": "aws-eks-helm-keycloak",
       "version": "2.0.0",
-      "description": "AWS EKS deployments with Helm, Keycloak, and Harness CI/CD",
+      "description": "The Conduit-Artisan Hybrid - AWS EKS deployments with Helm, Keycloak authentication, and Harness CI/CD. Combines pipeline excellence with developer velocity.",
       "keywords": [
         "aws",
         "eks",
         "kubernetes",
         "helm",
-        "keycloak"
+        "keycloak",
+        "harness",
+        "harness-code",
+        "oidc",
+        "authentication",
+        "ci-cd",
+        "gitops",
+        "developer-experience",
+        "agentic-patterns",
+        "prompt-chaining",
+        "multi-agent",
+        "hitl",
+        "guardrails",
+        "exception-handling",
+        "resource-aware",
+        "evaluation"
       ],
       "categories": [
         "infrastructure"
-      ]
+      ],
+      "author": {
+        "name": "Golden Armada",
+        "email": "architect@goldenarmada.io"
+      }
     },
     "claude-code-templating": {
       "name": "claude-code-templating",
-      "version": "2.0.0",
-      "description": "Universal templating and Harness expert plugin",
+      "version": "2.0.1",
+      "description": "Universal templating and Harness expert plugin for Claude Code - enables fully autonomous project generation, pipeline creation, and deployment automation through a unified template interface. Supports Handlebars, Cookiecutter, Copier, Maven archetypes, and Harness pipelines. 5 commands, 6 agents, 3 skills.",
       "keywords": [
         "templating",
         "scaffolding",
-        "harness"
+        "harness",
+        "pipelines",
+        "cookiecutter",
+        "copier",
+        "maven-archetype",
+        "mcp",
+        "code-generation",
+        "devops",
+        "ci-cd",
+        "infrastructure",
+        "agentic-patterns",
+        "prompt-chaining",
+        "planning",
+        "tool-use",
+        "routing",
+        "reflection",
+        "multi-agent",
+        "memory",
+        "guardrails"
       ],
       "categories": [
         "templating"
-      ]
+      ],
+      "author": {
+        "name": "Markus Ahling",
+        "url": "https://thelobbi.io"
+      }
     },
     "langgraph-architect": {
       "name": "langgraph-architect",
       "version": "1.0.0",
-      "description": "LangGraph/LangChain agent builder with workflow orchestration",
+      "description": "Expert LangGraph/LangChain agent builder with MCP integration, workflow orchestration, and CLI accessibility. Creates production-ready AI agents that are reachable via command line and Claude Code.",
       "keywords": [
         "langgraph",
         "langchain",
-        "agent-builder"
+        "agent-builder",
+        "workflow-orchestration",
+        "state-machine",
+        "multi-agent",
+        "mcp",
+        "model-context-protocol",
+        "ai-agents",
+        "graph-builder",
+        "checkpointing",
+        "memory-management",
+        "tool-integration",
+        "subgraph",
+        "supervisor-pattern",
+        "cli-agents"
       ],
       "categories": [
         "agents"
-      ]
+      ],
+      "author": {
+        "name": "Brookside BI"
+      }
     },
     "infrastructure-template-generator": {
       "name": "infrastructure-template-generator",
@@ -267,120 +457,243 @@
     "api-integration-helper": {
       "name": "api-integration-helper",
       "version": "1.0.0",
-      "description": "Production-ready API integration specialist with typed clients, auth flows, and mock servers",
+      "description": "Connector - Production-ready API integration specialist. Orchestrates 10 agents to generate typed clients, auth flows, error handling, rate limiting, and mock servers from OpenAPI/GraphQL specs. Delivers enterprise-grade API integrations, not basic fetch wrappers.",
       "keywords": [
         "api",
         "openapi",
+        "swagger",
         "graphql",
         "rest",
         "client-generation",
-        "sdk-generation"
+        "typescript",
+        "authentication",
+        "oauth",
+        "api-key",
+        "jwt",
+        "rate-limiting",
+        "retry-logic",
+        "error-handling",
+        "mock-server",
+        "api-testing",
+        "request-validation",
+        "response-validation",
+        "stripe",
+        "api-integration"
       ],
       "categories": [
         "development",
         "integration"
-      ]
+      ],
+      "author": {
+        "name": "Brookside BI",
+        "email": "plugins@brooksidebi.com"
+      }
     },
     "code-quality-orchestrator": {
       "name": "code-quality-orchestrator",
       "version": "1.0.0",
-      "description": "Unified code quality gates - static analysis, test coverage, security scanning, complexity analysis",
+      "description": "Curator - Ancient guardian of code excellence. Orchestrates 5 quality gates (Static Analysis, Test Coverage, Security Scanning, Complexity Analysis, Dependency Health) in a unified flow. Ensures pristine code through Forerunner precision and automated enforcement.",
       "keywords": [
         "code-quality",
         "linting",
+        "eslint",
+        "prettier",
         "static-analysis",
         "test-coverage",
         "security-scanning",
-        "quality-gates"
+        "complexity",
+        "dependencies",
+        "pre-commit",
+        "ci-cd",
+        "quality-gates",
+        "orchestration",
+        "clean-code"
       ],
       "categories": [
         "quality",
         "development"
-      ]
+      ],
+      "author": {
+        "name": "Brookside BI",
+        "email": "plugins@brooksidebi.com"
+      }
     },
     "dev-environment-bootstrap": {
       "name": "dev-environment-bootstrap",
       "version": "1.0.0",
-      "description": "Developer onboarding accelerator - Docker configs, env templates, IDE setup, dependency detection",
+      "description": "Bootstrap - Developer onboarding accelerator. Analyzes project requirements, detects missing dependencies, generates Docker/docker-compose configs, creates .env templates, sets up pre-commit hooks, configures IDE settings (VSCode/Cursor), and troubleshoots 'it works on my machine' issues. Gets developers productive in minutes, not hours.",
       "keywords": [
         "setup",
         "environment",
+        "dependencies",
         "docker",
+        "docker-compose",
+        "dotenv",
+        "env-vars",
+        "pre-commit",
+        "hooks",
+        "ide",
+        "vscode",
+        "cursor",
         "onboarding",
         "bootstrap",
-        "dev-container"
+        "init",
+        "install",
+        "configure",
+        "troubleshoot",
+        "debug-setup",
+        "requirements"
       ],
       "categories": [
         "development",
         "devops"
-      ]
+      ],
+      "author": {
+        "name": "The Lobbi",
+        "email": "developers@thelobbi.io"
+      }
     },
     "migration-wizard": {
       "name": "migration-wizard",
       "version": "1.0.0",
-      "description": "Complex code migrations between frameworks, libraries, and API versions with codemods and rollback",
+      "description": "Migrator - The architect of transformation. Orchestrates complex code migrations between frameworks, libraries, and API versions with precision codemods, incremental strangler fig patterns, and automated transformation. Ensures zero-downtime migrations with comprehensive test coverage and rollback strategies.",
       "keywords": [
         "migration",
         "codemod",
         "refactor",
+        "transform",
         "modernize",
+        "react-hooks",
+        "vue2-vue3",
+        "express-fastify",
+        "angular-react",
+        "webpack-vite",
+        "jest-vitest",
+        "class-to-hooks",
         "strangler-fig",
-        "upgrade"
+        "ast",
+        "jscodeshift",
+        "babel",
+        "typescript",
+        "eslint-codemod",
+        "api-migration",
+        "breaking-changes"
       ],
       "categories": [
         "development",
         "migration"
-      ]
+      ],
+      "author": {
+        "name": "Brookside BI",
+        "email": "plugins@brooksidebi.com"
+      }
     },
     "testforge": {
       "name": "testforge",
       "version": "1.0.0",
-      "description": "Intelligent test generation - analyzes code behavior to auto-generate comprehensive tests",
+      "description": "TestForge - Master of quality assurance through intelligent test generation. Analyzes code behavior to auto-generate comprehensive tests that catch real bugs, not just boost coverage numbers. Supports Jest, Pytest, Vitest, and more.",
       "keywords": [
         "test-generation",
+        "auto-test",
         "unit-test",
         "integration-test",
         "jest",
         "pytest",
         "vitest",
-        "coverage"
+        "mocha",
+        "jasmine",
+        "mock-generation",
+        "stub",
+        "fixture",
+        "test-double",
+        "edge-cases",
+        "boundary-testing",
+        "mutation-testing",
+        "coverage",
+        "test-coverage",
+        "coverage-gap",
+        "tdd"
       ],
       "categories": [
         "testing",
         "quality"
-      ]
+      ],
+      "author": {
+        "name": "The Lobbi",
+        "email": "developers@thelobbi.io"
+      }
     },
     "marketplace-pro": {
       "name": "marketplace-pro",
       "version": "2.0.0",
-      "description": "Plugin marketplace with federation, composition engine, trust scoring, and dev studio",
+      "description": "Advanced plugin marketplace platform with intent-based composition, supply chain security, contextual intelligence, dev studio hot-reload, and federated registry protocol. Transforms the marketplace from a package manager into an enterprise orchestration platform.",
       "keywords": [
         "marketplace",
-        "federation",
-        "plugins",
+        "plugin-management",
         "composition",
-        "trust",
-        "dev-studio"
+        "security",
+        "trust-scoring",
+        "supply-chain",
+        "federated-registry",
+        "hot-reload",
+        "dev-studio",
+        "intelligence",
+        "fingerprinting",
+        "sandboxing",
+        "lockfile",
+        "policy-engine",
+        "agentic-design-patterns",
+        "a2a-communication",
+        "routing",
+        "guardrails",
+        "resource-optimization",
+        "exploration",
+        "memory-management",
+        "evaluation-monitoring"
       ],
       "categories": [
         "marketplace",
         "orchestration"
-      ]
+      ],
+      "author": {
+        "name": "Markus Ahling",
+        "email": "markus@lobbi.io"
+      }
     },
     "claude-code-expert": {
       "name": "claude-code-expert",
-      "version": "7.9.0",
-      "description": "High-intelligence Claude Code copilot with deep code reasoning, evidence-driven planning, orchestration-first execution, model routing, context budgeting, CI/CD integration, enterprise security, plugin development, prompt engineering, performance profiling, agent teams, channels, hook policy engine, layered memory deployment, role-based subagent packs, agent-team topology kits, autonomy operating mode, orchestration blackboard (shared multi-round state across parallel agents), prompt-budget preflight, specialist-first routing, verify-between-waves cadence, agent telemetry, and a queryable 19-tool MCP documentation server with 2 MCP resources. 22 commands, 56 skills, 26 agents, 9 hooks.",
+      "version": "8.3.0",
+      "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 21 behavior-triggering skills, 12 single-intent commands, 18 role-scoped agents bridging engram and Obsidian. Tracks current Claude Code capabilities (Fable 5 + Opus 4.8, agent teams, Tool Search, web/remote).",
       "author": {
         "name": "Markus Ahling"
       },
       "keywords": [
         "claude-code",
-        "expert",
-        "orchestration",
+        "second-brain",
+        "engram",
+        "obsidian",
+        "memory",
+        "configuration",
+        "hooks",
         "mcp",
-        "debugging",
-        "enterprise"
+        "orchestration",
+        "agentic-patterns",
+        "deep-code-intelligence",
+        "evidence-driven",
+        "autonomy",
+        "council",
+        "multi-agent",
+        "agent-teams",
+        "model-routing",
+        "context-budgeting",
+        "security-compliance",
+        "plugin-development",
+        "prompt-engineering",
+        "channels",
+        "webhooks",
+        "cicd",
+        "consolidation",
+        "knowledge-graph"
       ],
       "categories": [
         "developer-tools",
@@ -390,7 +703,7 @@
     "drawio-diagramming": {
       "name": "drawio-diagramming",
       "version": "2.0.0",
-      "description": "Intelligent draw.io diagramming with AI generation, multi-platform embedding, conditional formatting, live data binding, and MCP integration",
+      "description": "Intelligent draw.io diagramming plugin with AI-powered diagram generation, multi-platform embedding (GitHub, Confluence, Azure DevOps, Notion, Teams, Harness), conditional formatting, live data binding, and MCP server integration for programmatic diagram creation and management.",
       "author": {
         "name": "Markus Ahling",
         "url": "https://github.com/markus41"
@@ -399,6 +712,9 @@
         "drawio",
         "diagrams",
         "diagramming",
+        "draw.io",
+        "diagrams.net",
+        "mxgraph",
         "flowchart",
         "uml",
         "bpmn",
@@ -406,10 +722,40 @@
         "architecture",
         "network",
         "cloud",
+        "aws",
+        "azure",
+        "gcp",
         "kubernetes",
-        "wireframe",
+        "sequence-diagram",
+        "erd",
+        "mermaid",
+        "svg",
+        "xml",
+        "ai-diagrams",
+        "conditional-formatting",
+        "live-data",
+        "github-integration",
+        "confluence",
+        "jira",
+        "notion",
+        "teams",
+        "harness",
+        "azure-devops",
         "mcp",
-        "ai-diagrams"
+        "vibe-diagramming",
+        "desktop",
+        "electron",
+        "drawio-desktop",
+        "visual-editor",
+        "wsl",
+        "agentic-patterns",
+        "prompt-chaining",
+        "reflection",
+        "planning",
+        "tool-use",
+        "routing",
+        "parallelization",
+        "resource-aware"
       ],
       "categories": [
         "diagramming",
@@ -419,10 +765,11 @@
     },
     "mui-expert": {
       "name": "mui-expert",
-      "version": "2.1.0",
-      "description": "Comprehensive MUI expert â€” 26 skills, 14 commands, 7 agents. Theming, CSS variables, Pigment CSS, slots API, MUI X (DataGrid/Charts/TreeView/DatePickers), SSR/Next.js, white-label, entity-driven CRUD, 200+ dashboard widgets, ecosystem integrations.",
+      "version": "2.1.1",
+      "description": "Comprehensive Material UI (MUI) expert plugin — 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
       "author": {
-        "name": "Claude Code"
+        "name": "Claude Code",
+        "url": "https://github.com/markus41/claude"
       },
       "platforms": [
         "cli",
@@ -436,24 +783,38 @@
         "material-ui",
         "react",
         "theming",
-        "components",
+        "design-system",
         "data-grid",
-        "charts",
         "date-picker",
+        "charts",
         "tree-view",
+        "sx-prop",
+        "styled",
+        "emotion",
+        "pigment-css",
+        "css-variables",
         "accessibility",
+        "responsive",
+        "dark-mode",
+        "white-label",
+        "multi-tenant",
+        "ssr",
+        "next-js",
+        "slots-api",
+        "headless",
+        "joy-ui",
+        "virtualization",
+        "animations",
+        "i18n",
+        "rtl",
+        "testing",
         "performance",
         "migration",
-        "mcp",
-        "css-variables",
-        "pigment-css",
-        "slots-api",
-        "white-label",
         "entity-driven",
         "formengine",
+        "aspnet-core",
         "dashboard-widgets",
-        "ssr",
-        "next-js"
+        "creative-ui"
       ],
       "categories": [
         "frontend",
@@ -463,8 +824,8 @@
     },
     "dotnet-blazor": {
       "name": "dotnet-blazor",
-      "version": "2.0.0",
-      "description": "Full-stack .NET 10 expert — 19 skills, 8 commands, 6 agents. Blazor Web Apps, ASP.NET Core APIs, microservices with DDD/CQRS, Syncfusion UI, .NET Aspire, EF Core, gRPC, SignalR, .NET AI/MCP, Docker, worker services, cloud-native deployment.",
+      "version": "2.0.1",
+      "description": "Comprehensive .NET 10, Blazor, ASP.NET Core, C#, and Syncfusion expert plugin for building modern web apps, microservices, and cloud-native solutions",
       "author": {
         "name": "Markus Ahling"
       },
@@ -487,12 +848,7 @@
         "grpc",
         "signalr",
         "maui",
-        "cloud-native",
-        "ddd",
-        "cqrs",
-        "docker",
-        "ai",
-        "mcp"
+        "cloud-native"
       ],
       "categories": [
         "backend",
@@ -505,8 +861,7 @@
       "version": "1.0.0",
       "description": "Documentation intelligence engine, algorithm library, and codebase/agent drift detection system for Claude Code",
       "author": {
-        "name": "Markus Ahling",
-        "email": "Markus@thelobbi.io"
+        "name": "Markus Ahling"
       },
       "keywords": [
         "documentation",
@@ -526,8 +881,8 @@
     },
     "project-management-plugin": {
       "name": "project-management-plugin",
-      "version": "1.0.0",
-      "description": "Universal project manager: interview-first init, micro-task decomposition, deep research before execution, autonomous work loop, and 9 PM platform integrations.",
+      "version": "1.4.0",
+      "description": "Universal project manager with keep-Claude-on-task guardrails: focus anchor, scope lock, done-when contract, over-engineering detector, drift auditor, turn budget, user-prompt archive, and compaction-safe handoff. Plus interview-first init, micro-task decomposition, deep research, transactional state MCP, and 9 PM platform integrations.",
       "author": {
         "name": "Markus Ahling",
         "email": "Markus@thelobbi.io"
@@ -538,11 +893,705 @@
         "research-first",
         "micro-tasks",
         "autonomous",
-        "pm-integration"
+        "pm-integration",
+        "mcp"
       ],
       "categories": [
         "project-management",
         "orchestration",
+        "developer-tools"
+      ]
+    },
+    "cowork-marketplace": {
+      "name": "cowork-marketplace",
+      "version": "2.1.1",
+      "description": "Browse, install, and manage cowork marketplace items backed by real plugin agents, skills, and commands",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "markus@lobbi.co"
+      },
+      "keywords": [
+        "cowork",
+        "marketplace",
+        "plugins",
+        "agents",
+        "skills",
+        "templates",
+        "workflows",
+        "session-blueprints",
+        "agentic-design-patterns",
+        "routing",
+        "a2a",
+        "resource-aware",
+        "exploration",
+        "memory",
+        "guardrails",
+        "tool-use"
+      ],
+      "categories": [
+        "marketplace-ecosystem"
+      ]
+    },
+    "deployment-pipeline": {
+      "name": "deployment-pipeline",
+      "version": "2.0.0",
+      "description": "Harness CD integration pipeline with state-machine workflow orchestration",
+      "author": {
+        "name": "Markus Ahling"
+      },
+      "keywords": [
+        "workflow",
+        "automation",
+        "state-machine",
+        "orchestration",
+        "harness",
+        "ci-cd",
+        "deployment",
+        "pipeline",
+        "agentic-patterns",
+        "prompt-chaining",
+        "hitl",
+        "guardrails",
+        "multi-agent",
+        "exception-handling"
+      ],
+      "categories": [
+        "infrastructure"
+      ]
+    },
+    "exec-automator": {
+      "name": "exec-automator",
+      "version": "2.0.1",
+      "description": "Genesis (Forerunner) - AI-Powered Executive Director Automation Platform. Analyze organizational responsibilities, score automation potential with 6-factor algorithm, generate LangGraph workflows, and deploy 11 specialized agents for trade associations and nonprofits.",
+      "author": {
+        "name": "Brookside BI",
+        "email": "dev@brooksidebi.com"
+      },
+      "keywords": [
+        "executive-director",
+        "association-management",
+        "workflow-automation",
+        "langgraph",
+        "langchain",
+        "deep-agents",
+        "ai-automation",
+        "nonprofit",
+        "trade-association",
+        "process-automation",
+        "agentic-design-patterns",
+        "planning",
+        "multi-agent",
+        "routing",
+        "parallelization",
+        "memory",
+        "exception-handling",
+        "hitl",
+        "goal-setting"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "fastapi-backend": {
+      "name": "fastapi-backend",
+      "version": "1.0.0",
+      "description": "Comprehensive FastAPI backend development plugin with MongoDB/Beanie, Keycloak auth, Docker/K8s deployment, background tasks, caching, observability, and real-time features",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "markus@brooksidebi.com"
+      },
+      "keywords": [
+        "fastapi",
+        "mongodb",
+        "beanie",
+        "keycloak",
+        "kubernetes",
+        "docker",
+        "async",
+        "python",
+        "backend",
+        "api",
+        "websocket",
+        "redis",
+        "celery",
+        "arq",
+        "observability",
+        "agentic-patterns",
+        "prompt-chaining",
+        "tool-use",
+        "rag",
+        "guardrails",
+        "memory",
+        "parallelization",
+        "resource-aware"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "fullstack-iac": {
+      "name": "fullstack-iac",
+      "version": "2.0.0",
+      "description": "Zenith (Forerunner) - Complete full-stack development and infrastructure automation. FastAPI, React/Vite, Ansible, Terraform, Kubernetes with production-ready templates and CI/CD pipelines.",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "markus@brooksidebi.com"
+      },
+      "keywords": [
+        "fastapi",
+        "react",
+        "vite",
+        "ansible",
+        "terraform",
+        "kubernetes",
+        "docker",
+        "full-stack",
+        "infrastructure-as-code",
+        "ci-cd",
+        "templates",
+        "scaffolding",
+        "agentic-patterns",
+        "prompt-chaining",
+        "planning",
+        "tool-use",
+        "exception-handling",
+        "guardrails",
+        "hitl",
+        "multi-agent",
+        "evaluation"
+      ],
+      "categories": [
+        "infrastructure"
+      ]
+    },
+    "home-assistant-architect": {
+      "name": "home-assistant-architect",
+      "version": "3.0.0",
+      "description": "Complete Home Assistant platform with frontend design, energy management, cameras, sensors, local LLM integration, and Ubuntu server deployment",
+      "author": {
+        "name": "Brookside BI"
+      },
+      "keywords": [
+        "home-assistant",
+        "smart-home",
+        "automation",
+        "ollama",
+        "local-llm",
+        "mcp-server",
+        "ubuntu",
+        "iot",
+        "agentic-patterns",
+        "tool-use",
+        "routing",
+        "planning",
+        "exception-handling",
+        "memory",
+        "guardrails",
+        "hitl",
+        "parallelization",
+        "learning"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "linear-orchestrator": {
+      "name": "linear-orchestrator",
+      "version": "1.0.0",
+      "description": "Advanced Linear integration with two-way sync to Harness Code and Microsoft Planner. Covers Linear GraphQL API, OAuth 2.0, webhooks, attachments, agents (AIG), MCP, cycles, projects, initiatives, customer requests, SLA, triage, templates, sub-issues, and diffs. 22 commands, 10 skills, 12 agents.",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "markus@lobbi.io"
+      },
+      "keywords": [
+        "linear",
+        "linear-app",
+        "graphql",
+        "oauth",
+        "webhooks",
+        "agents",
+        "aig",
+        "harness",
+        "harness-code",
+        "microsoft-planner",
+        "ms-graph",
+        "two-way-sync",
+        "mcp",
+        "cycles",
+        "projects",
+        "initiatives",
+        "customer-requests",
+        "sla",
+        "triage",
+        "issue-tracking",
+        "orchestration",
+        "automation",
+        "agent-signals"
+      ],
+      "categories": [
+        "core"
+      ]
+    },
+    "lobbi-bi-reports": {
+      "name": "lobbi-bi-reports",
+      "version": "1.0.0",
+      "description": "Business intelligence and reporting for insurance and financial services. Power BI report building, KPI design, dashboard embedding, data model mapping, refresh scheduling, and report distribution. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "power-bi",
+        "kpi",
+        "dashboard",
+        "analytics",
+        "reporting",
+        "data-model",
+        "bi"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-compliance-guard": {
+      "name": "lobbi-compliance-guard",
+      "version": "1.0.0",
+      "description": "Regulatory compliance for insurance, mortgage, and financial services. Audit trail design, GDPR/CCPA review, SOX validation, data retention policies, and regulatory requirement mapping. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "compliance",
+        "audit",
+        "gdpr",
+        "sox",
+        "finra",
+        "insurance",
+        "mortgage",
+        "data-retention",
+        "regulatory"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-data-migration": {
+      "name": "lobbi-data-migration",
+      "version": "1.0.0",
+      "description": "Data migration planning and execution for insurance and financial services systems. Schema analysis, data profiling, migration planning, transform building, validation running, and rollback coordination. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "migration",
+        "etl",
+        "schema",
+        "data-profiling",
+        "transform",
+        "rollback",
+        "dataverse",
+        "sharepoint"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-document-intelligence": {
+      "name": "lobbi-document-intelligence",
+      "version": "1.0.0",
+      "description": "AI-powered document processing for insurance and financial services. PDF extraction, form classification, OCR pipelines, data validation, intelligent routing, and extraction auditing. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "document",
+        "ocr",
+        "extraction",
+        "classification",
+        "pdf",
+        "ai",
+        "rpa",
+        "forms"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-engagement-toolkit": {
+      "name": "lobbi-engagement-toolkit",
+      "version": "1.0.0",
+      "description": "Client engagement tools for fixed-scope, fixed-price automation projects. ROI calculation, scope definition, proposal generation, change order protection, delivery tracking, and post-launch review. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "engagement",
+        "roi",
+        "scope",
+        "proposal",
+        "project-management",
+        "fixed-price",
+        "delivery"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-insurance-domain": {
+      "name": "lobbi-insurance-domain",
+      "version": "1.0.0",
+      "description": "Insurance-specific automation for agencies and MGAs. Policy workflows, claims processing, producer portal design, E&O tracking, renewal automation, and compliance checking. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "insurance",
+        "claims",
+        "policy",
+        "producer",
+        "renewal",
+        "e-and-o",
+        "mga",
+        "agency"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-m365-automator": {
+      "name": "lobbi-m365-automator",
+      "version": "1.0.0",
+      "description": "Microsoft 365 automation for insurance and financial services firms. SharePoint site building, Teams provisioning, Power Automate flow generation, Exchange rules, M365 auditing, and OneDrive organization. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "m365",
+        "sharepoint",
+        "teams",
+        "power-automate",
+        "exchange",
+        "microsoft-365",
+        "onedrive"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-mortgage-domain": {
+      "name": "lobbi-mortgage-domain",
+      "version": "1.0.0",
+      "description": "Mortgage and lending automation for brokers and lenders. Loan pipeline tracking, disclosure generation, AUS integration, closing checklists, compliance scanning, and borrower portal design. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "mortgage",
+        "lending",
+        "loan",
+        "trid",
+        "hmda",
+        "aus",
+        "closing",
+        "respa"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-platform-manager": {
+      "name": "lobbi-platform-manager",
+      "version": "2.0.0",
+      "description": "Streamline development on the-lobbi/keycloak-alpha with Keycloak management, service orchestration, and test generation",
+      "author": {
+        "name": "Markus Ahling"
+      },
+      "keywords": [
+        "keycloak",
+        "multi-tenant",
+        "mern",
+        "microservices",
+        "docker",
+        "testing",
+        "devops",
+        "platform-management",
+        "agentic-patterns",
+        "multi-agent",
+        "tool-use",
+        "exception-handling",
+        "guardrails",
+        "memory",
+        "hitl",
+        "routing",
+        "planning",
+        "evaluation"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-system-integrator": {
+      "name": "lobbi-system-integrator",
+      "version": "1.0.0",
+      "description": "API and system integration for insurance, mortgage, and financial services platforms. Connector building, webhook orchestration, data mapping, error handling, rate limit management, and integration testing. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "api",
+        "integration",
+        "webhook",
+        "connector",
+        "data-mapping",
+        "middleware",
+        "crm",
+        "los",
+        "ams"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "lobbi-workflow-engine": {
+      "name": "lobbi-workflow-engine",
+      "version": "1.0.0",
+      "description": "Design and implement multi-step approval workflows, routing rules, escalation policies, and SLA tracking for insurance, mortgage, and financial services. 6 skills, 3 agents.",
+      "author": {
+        "name": "thelobbi.io",
+        "email": "developers@thelobbi.io"
+      },
+      "keywords": [
+        "workflow",
+        "approval",
+        "routing",
+        "escalation",
+        "sla",
+        "business-process",
+        "automation",
+        "insurance",
+        "mortgage",
+        "finserv"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "react-animation-studio": {
+      "name": "react-animation-studio",
+      "version": "2.0.1",
+      "description": "Create beautiful, performant web animations for React and TypeScript applications. Includes background effects, text animations, 3D transforms, creative visual effects, Framer Motion, GSAP, and more.",
+      "author": {
+        "name": "Brookside BI",
+        "email": "plugins@brooksidebi.com",
+        "url": "https://brooksidebi.com"
+      },
+      "keywords": [
+        "react",
+        "animation",
+        "framer-motion",
+        "gsap",
+        "css-animations",
+        "typescript",
+        "motion-design",
+        "spring-physics",
+        "micro-interactions",
+        "page-transitions",
+        "scroll-animations",
+        "creative-effects",
+        "background-animations",
+        "text-animations",
+        "3d-transforms",
+        "particles",
+        "aurora",
+        "typewriter",
+        "flip-card",
+        "parallax",
+        "agentic-patterns",
+        "prompt-chaining",
+        "parallelization",
+        "reflection",
+        "planning",
+        "tool-use",
+        "routing",
+        "resource-aware"
+      ],
+      "categories": [
+        "frontend"
+      ]
+    },
+    "team-accelerator": {
+      "name": "team-accelerator",
+      "version": "2.0.0",
+      "description": "Enterprise development toolkit for teams - DevOps, code quality, integrations, workflow automation, documentation, and performance optimization across multi-cloud and full-stack platforms",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "markus@example.com"
+      },
+      "keywords": [
+        "enterprise",
+        "devops",
+        "ci-cd",
+        "code-quality",
+        "testing",
+        "documentation",
+        "performance",
+        "multi-cloud",
+        "kubernetes",
+        "github-actions",
+        "harness",
+        "playwright",
+        "prometheus",
+        "agentic-patterns",
+        "multi-agent",
+        "parallelization",
+        "routing",
+        "resource-aware",
+        "learning"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "tvs-microsoft-deploy": {
+      "name": "tvs-microsoft-deploy",
+      "version": "2.0.0",
+      "description": "Consul - Enterprise Microsoft ecosystem orchestrator for TVS (Trusted Virtual Solutions) multi-entity multi-tenant deployment. 19 agents, 18 commands, 17 skills, 14 hooks, 5 workflows. MCP server for Graph API, Dataverse, Fabric, and Planner.",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "markus@lobbi.io"
+      },
+      "keywords": [
+        "microsoft",
+        "power-platform",
+        "dataverse",
+        "fabric",
+        "azure",
+        "entra",
+        "multi-tenant",
+        "tvs",
+        "tvs-holdings",
+        "fmo-sale",
+        "stripe",
+        "firebase",
+        "pac-cli",
+        "playwright",
+        "office-scripts",
+        "power-pages",
+        "copilot-studio",
+        "onelake",
+        "bicep",
+        "graph-api",
+        "power-bi-embedded",
+        "planner",
+        "m365-governance",
+        "dlp",
+        "excel-automation",
+        "solution-architect",
+        "pipeline-orchestration",
+        "agentic-patterns",
+        "prompt-chaining",
+        "planning",
+        "tool-use",
+        "exception-handling",
+        "guardrails",
+        "hitl",
+        "multi-agent",
+        "memory",
+        "a2a",
+        "routing",
+        "resource-aware"
+      ],
+      "categories": [
+        "domain"
+      ]
+    },
+    "upgrade-suggestion": {
+      "name": "upgrade-suggestion",
+      "version": "3.0.0",
+      "description": "AI-powered upgrade intelligence platform. Multi-agent council analyzes your codebase across 8 dimensions, produces confidence-scored suggestions with visual impact heatmaps, upgrade roadmaps, framework-specific deep dives, and before/after impact previews. Features innovation radar, tech debt forecasting, and coordinated upgrade bundles.",
+      "author": {
+        "name": "Markus Ahling"
+      },
+      "keywords": [
+        "upgrades",
+        "suggestions",
+        "improvements",
+        "spark",
+        "ai-suggestions",
+        "code-quality",
+        "dx",
+        "ux",
+        "performance",
+        "architecture",
+        "innovation-radar",
+        "upgrade-roadmap",
+        "tech-debt",
+        "council-review",
+        "fingerprinting",
+        "deep-analysis",
+        "impact-preview",
+        "heatmap",
+        "multi-agent",
+        "agentic-design-patterns",
+        "reflection",
+        "parallelization",
+        "reasoning",
+        "evaluation",
+        "planning",
+        "resource-aware"
+      ],
+      "categories": [
+        "developer-tools"
+      ]
+    },
+    "work-automation": {
+      "name": "work-automation",
+      "version": "1.0.0",
+      "description": "Universal internal work-automation kit. ULTRA-mode constitution, Work Unit Protocol, Claude Code automation patterns (hooks, skills, plugins, agents, schedules, MCP, SDK, headless, fullscreen), and Harness pipeline ops. Project-agnostic. Glues existing plugins (harness-platform, claude-code-expert, tenant-management-kit) with reusable workflows.",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "mahling@taia.us"
+      },
+      "keywords": [
+        "harness",
+        "claude-code",
+        "automation",
+        "work-unit",
+        "ultra",
+        "pipeline",
+        "ci-cd",
+        "hooks",
+        "skills",
+        "agents"
+      ],
+      "categories": [
+        "automation"
+      ]
+    },
+    "writing-plans-enhanced": {
+      "name": "writing-plans-enhanced",
+      "version": "1.0.1",
+      "description": "Enhanced writing-plans skill: 5-phase structure, task metadata (Type/Depends-on/Parallel-safe/Risk), non-TDD task templates, automated plan linter with self-tests. Standalone hub-hosted fork of superpowers:writing-plans.",
+      "author": {
+        "name": "Markus Ahling",
+        "email": "markus@thelobbi.io"
+      },
+      "keywords": [
+        "planning",
+        "tdd",
+        "writing-plans",
+        "plan-linter",
+        "superpowers"
+      ],
+      "categories": [
         "developer-tools"
       ]
     }
@@ -552,9 +1601,15 @@
       "jira-orchestrator": {
         "path": "../plugins/jira-orchestrator/.claude-plugin/plugin.json",
         "callsign": "Arbiter",
-        "version": "8.0.0",
+        "version": "8.2.0",
         "status": "active",
         "tier": "enterprise"
+      },
+      "linear-orchestrator": {
+        "path": "../plugins/linear-orchestrator/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
       }
     },
     "frontend": {
@@ -568,7 +1623,7 @@
       "mui-expert": {
         "path": "../plugins/mui-expert/.claude-plugin/plugin.json",
         "callsign": "Materializer",
-        "version": "2.1.0",
+        "version": "2.1.1",
         "status": "active",
         "tier": "premium",
         "platforms": [
@@ -581,7 +1636,7 @@
       },
       "react-animation-studio": {
         "path": "../plugins/react-animation-studio/.claude-plugin/plugin.json",
-        "version": "2.0.0",
+        "version": "2.0.1",
         "status": "active",
         "tier": "standard"
       }
@@ -618,7 +1673,7 @@
       "claude-code-templating": {
         "path": "../plugins/claude-code-templating-plugin/.claude-plugin/plugin.json",
         "callsign": "Architect",
-        "version": "2.0.0",
+        "version": "2.0.1",
         "status": "active",
         "tier": "standard"
       }
@@ -646,7 +1701,7 @@
       },
       "exec-automator": {
         "path": "../plugins/exec-automator/.claude-plugin/plugin.json",
-        "version": "2.0.0",
+        "version": "2.0.1",
         "status": "active",
         "tier": "standard"
       },
@@ -659,7 +1714,7 @@
       "dotnet-blazor": {
         "path": "../plugins/dotnet-blazor/.claude-plugin/plugin.json",
         "callsign": "Blazor",
-        "version": "2.0.0",
+        "version": "2.0.1",
         "status": "active",
         "tier": "standard",
         "platforms": [
@@ -675,13 +1730,80 @@
         "version": "2.0.0",
         "status": "active",
         "tier": "standard"
+      },
+      "lobbi-bi-reports": {
+        "path": "../plugins/lobbi-bi-reports/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "lobbi-compliance-guard": {
+        "path": "../plugins/lobbi-compliance-guard/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "lobbi-data-migration": {
+        "path": "../plugins/lobbi-data-migration/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "lobbi-document-intelligence": {
+        "path": "../plugins/lobbi-document-intelligence/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "lobbi-engagement-toolkit": {
+        "path": "../plugins/lobbi-engagement-toolkit/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "lobbi-insurance-domain": {
+        "path": "../plugins/lobbi-insurance-domain/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "lobbi-m365-automator": {
+        "path": "../plugins/lobbi-m365-automator/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "lobbi-mortgage-domain": {
+        "path": "../plugins/lobbi-mortgage-domain/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "lobbi-system-integrator": {
+        "path": "../plugins/lobbi-system-integrator/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "lobbi-workflow-engine": {
+        "path": "../plugins/lobbi-workflow-engine/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "tvs-microsoft-deploy": {
+        "path": "../plugins/tvs-microsoft-deploy/.claude-plugin/plugin.json",
+        "callsign": "Consul",
+        "version": "2.0.0",
+        "status": "active",
+        "tier": "standard"
       }
     },
     "developer-tools": {
       "claude-code-expert": {
         "path": "../plugins/claude-code-expert/.claude-plugin/plugin.json",
         "callsign": "Expert",
-        "version": "7.0.0",
+        "version": "8.3.0",
         "status": "active",
         "tier": "standard"
       },
@@ -695,7 +1817,19 @@
       "project-management-plugin": {
         "path": "../plugins/project-management-plugin/.claude-plugin/plugin.json",
         "callsign": "PM",
-        "version": "1.0.0",
+        "version": "1.4.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "upgrade-suggestion": {
+        "path": "../plugins/upgrade-suggestion/.claude-plugin/plugin.json",
+        "version": "3.0.0",
+        "status": "active",
+        "tier": "standard"
+      },
+      "writing-plans-enhanced": {
+        "path": "../plugins/writing-plans-enhanced/.claude-plugin/plugin.json",
+        "version": "1.0.1",
         "status": "active",
         "tier": "standard"
       }
@@ -703,7 +1837,7 @@
     "marketplace-ecosystem": {
       "cowork-marketplace": {
         "path": "../plugins/cowork-marketplace/.claude-plugin/plugin.json",
-        "version": "2.0.0",
+        "version": "2.1.1",
         "status": "active",
         "tier": "standard"
       },
@@ -759,6 +1893,14 @@
         "status": "available",
         "tier": "standard"
       }
+    },
+    "automation": {
+      "work-automation": {
+        "path": "../plugins/work-automation/.claude-plugin/plugin.json",
+        "version": "1.0.0",
+        "status": "active",
+        "tier": "standard"
+      }
     }
   },
   "callsignRegistry": {
@@ -781,16 +1923,17 @@
     "PM": "project-management-plugin"
   },
   "stats": {
-    "totalInstalled": 22,
-    "totalPlugins": 28,
+    "totalInstalled": 35,
+    "totalPlugins": 41,
     "totalAvailable": 6,
-    "lastUpdated": "2026-04-21T00:00:00.000Z",
+    "lastUpdated": "2026-07-11T00:00:00.000Z",
     "byTier": {
       "enterprise": 1,
-      "standard": 25
+      "standard": 40,
+      "premium": 1
     },
     "byLocation": {
-      "plugins/": 22,
+      "plugins/": 35,
       ".claude/plugins/": 6
     }
   }

--- a/.claude/rules/lessons-learned.md
+++ b/.claude/rules/lessons-learned.md
@@ -934,3 +934,11 @@ grep: site/assets/styles.css: No such file or directory
 - **Status:** RESOLVED
 - **Fix:** Reverted to js-yaml@^4.1.1 (default export restored, dump output matches committed frontmatter). Kept the other dep upgrades (typescript 7.0.2, tsx 4.23 → esbuild 0.28.1 clearing all audit vulnerabilities, ajv 8.20).
 - **Prevention:** js-yaml v5 is ESM-only (named exports) and changes dump formatting. Upgrading it requires (a) `import * as yaml` or named imports in scripts/*.mjs AND (b) regenerating frontmatter across all plugin command/agent files in the same commit (`pnpm generate:plugin-indexes`), accepting a ~300-file churn. Don't bump it casually.
+
+### Error: mcp__github__get_check_run failure (2026-07-11T20:06:25Z)
+- **Tool:** mcp__github__get_check_run
+- **Input:** `method: list_check_runs, ref: <sha>`
+- **Error:** owner, repo, and checkRunId are required
+- **Status:** RESOLVED
+- **Fix:** `get_check_run` fetches ONE check run by `checkRunId` — it has no list mode. To see CI status for a commit/branch, use `actions_list` with `method: "list_workflow_runs"` + `branch`, then parse the oversized saved payload with `node -e` (filter by `head_sha`, print name/status/conclusion).
+- **Prevention:** For "is CI green on this sha" questions, go straight to `actions_list` → saved-file parse. Reserve `get_check_run` for drilling into a single known check-run ID.

--- a/.claude/rules/lessons-learned.md
+++ b/.claude/rules/lessons-learned.md
@@ -926,3 +926,11 @@ grep: site/assets/styles.css: No such file or directory
 - **Status:** RESOLVED
 - **Fix:** `actions_get` requires both `method` and `resource_id` (not `run_id`). To read failing job logs, the simpler path is `mcp__github__get_job_logs` with `run_id` + `failed_only: true` to find the failed job id, then call it again with that `job_id` and `return_content: true` + `tail_lines`.
 - **Prevention:** For CI log triage use `get_job_logs` (run_id → failed_only, then job_id → return_content), not `actions_get`. Reserve `actions_get` for run/workflow metadata and always pass `method` + `resource_id`.
+
+### Error: js-yaml v5 upgrade broke ESM import and index check (2026-07-11T20:00:00Z)
+- **Tool:** Bash
+- **Input:** `pnpm add -D js-yaml@^5.2.1 && pnpm check:plugin-indexes`
+- **Error:** `SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'`; after switching to a namespace import, generate-plugin-indexes.mjs --check failed because js-yaml v5's `dump` serializes frontmatter differently than v4, mismatching every generated frontmatter block on disk.
+- **Status:** RESOLVED
+- **Fix:** Reverted to js-yaml@^4.1.1 (default export restored, dump output matches committed frontmatter). Kept the other dep upgrades (typescript 7.0.2, tsx 4.23 → esbuild 0.28.1 clearing all audit vulnerabilities, ajv 8.20).
+- **Prevention:** js-yaml v5 is ESM-only (named exports) and changes dump formatting. Upgrading it requires (a) `import * as yaml` or named imports in scripts/*.mjs AND (b) regenerating frontmatter across all plugin command/agent files in the same commit (`pnpm generate:plugin-indexes`), accepting a ~300-file churn. Don't bump it casually.

--- a/.claude/rules/memory-profile.md
+++ b/.claude/rules/memory-profile.md
@@ -9,7 +9,7 @@
 
 ## Scale
 
-- 35 domain plugins in `plugins/`
+- 36 domain plugins in `plugins/`
 - 54 platform skills in `.claude/skills/` (plugins ship their own — jira-orchestrator alone adds 14)
 - 9 platform agents in `.claude/agents/` (plugins ship their own — jira-orchestrator alone adds 82)
 - 7 MCP servers (5 custom + 2 external)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0",
     "MAX_THINKING_TOKENS": "31999"
   },
-  "model": "claude-sonnet-4-6",
+  "model": "claude-sonnet-5",
   "teammateMode": "auto",
   "enableAllProjectMcpServers": true,
   "respectGitignore": true,

--- a/.claude/skills/authentication/SKILL.md
+++ b/.claude/skills/authentication/SKILL.md
@@ -758,12 +758,10 @@ Provide specific findings with:
 """
 
 response = client.messages.create(
-    model="claude-opus-4-5-20250514",
+    model="claude-opus-4-8",
     max_tokens=32000,
-    thinking={
-        "type": "enabled",
-        "budget_tokens": 20000  # High budget for security analysis
-    },
+    thinking={"type": "adaptive"},
+    output_config={"effort": "high"},  # deep reasoning for security analysis
     messages=[{
         "role": "user",
         "content": security_review_prompt

--- a/.claude/skills/batch-processing/SKILL.md
+++ b/.claude/skills/batch-processing/SKILL.md
@@ -69,7 +69,7 @@ requests = [
     {
         "custom_id": "request-1",
         "params": {
-            "model": "claude-sonnet-4-20250514",
+            "model": "claude-sonnet-5",
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "Summarize: Document 1..."}]
         }
@@ -77,7 +77,7 @@ requests = [
     {
         "custom_id": "request-2",
         "params": {
-            "model": "claude-sonnet-4-20250514",
+            "model": "claude-sonnet-5",
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "Summarize: Document 2..."}]
         }
@@ -175,7 +175,7 @@ def run_batch_job(documents):
         requests.append({
             "custom_id": f"doc-{i}",
             "params": {
-                "model": "claude-sonnet-4-20250514",
+                "model": "claude-sonnet-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": f"Summarize: {doc}"}]
             }
@@ -264,12 +264,11 @@ def retry_failed(client, original_batch_id):
 {
     "custom_id": "unique-identifier",
     "params": {
-        "model": "claude-sonnet-4-20250514",
+        "model": "claude-sonnet-5",
         "max_tokens": 1024,
         "system": "Optional system prompt",
         "messages": [{"role": "user", "content": "..."}],
-        "tools": [],
-        "temperature": 0.7
+        "tools": []
     }
 }
 ```
@@ -306,7 +305,7 @@ documents = load_documents("data/*.txt")  # 10K files
 requests = [{
     "custom_id": doc.id,
     "params": {
-        "model": "claude-haiku-4-20250514",  # Cheapest for bulk
+        "model": "claude-haiku-4-5",  # Cheapest for bulk
         "max_tokens": 512,
         "system": "Extract key information as JSON.",
         "messages": [{"role": "user", "content": doc.content}]

--- a/.claude/skills/citations-retrieval/OUTLINE.md
+++ b/.claude/skills/citations-retrieval/OUTLINE.md
@@ -426,7 +426,7 @@ doc["citations"] = {"enabled": True}
 messages = [{"role": "user", "content": documents}]
 
 # Use supported model
-model="claude-sonnet-4-5"
+model="claude-sonnet-5"
 ```
 
 ### Issue: Wrong or hallucinated citations

--- a/.claude/skills/citations-retrieval/QUICK-REFERENCE.md
+++ b/.claude/skills/citations-retrieval/QUICK-REFERENCE.md
@@ -29,7 +29,7 @@ document = {
 
 # 3. Query with citations
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     messages=[
         {"role": "user", "content": [document]},
@@ -174,7 +174,7 @@ documents = [
 ]
 
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     messages=[
         {"role": "user", "content": documents},
@@ -186,7 +186,7 @@ response = client.messages.create(
 ### Combined with System Prompt
 ```python
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     system="You are a helpful assistant. Use citations to back up claims.",
     messages=[
@@ -200,7 +200,7 @@ response = client.messages.create(
 ```python
 # Only cite if supported by document
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     system="Only answer if supported by provided documents. Otherwise, say 'Not found in documents.'",
     messages=[
@@ -284,7 +284,7 @@ Use citations to back up your answer.
 
 ### Check Model Support
 ```python
-MODELS_WITH_CITATIONS = ["claude-sonnet-4-5", "claude-3-5-haiku-20241022"]
+MODELS_WITH_CITATIONS = ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"]
 
 if model not in MODELS_WITH_CITATIONS:
     print(f"Warning: {model} may not support citations")
@@ -323,7 +323,7 @@ def extract_citations_safe(response):
 ```python
 # Cache the document, reuse for multiple queries
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     messages=[
         {
@@ -350,7 +350,7 @@ queries = ["Question 1?", "Question 2?", "Question 3?"]
 
 for query in queries:
     response = client.messages.create(
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-5",
         max_tokens=512,
         messages=[
             {"role": "user", "content": [document]},
@@ -397,7 +397,7 @@ def to_ieee(citation, num):
 
 ## Troubleshooting Checklist
 
-- [ ] Using `claude-sonnet-4-5` or supported model?
+- [ ] Using `claude-sonnet-5` or supported model?
 - [ ] Documents have `"citations": {"enabled": True}`?
 - [ ] Document content is actually in the message?
 - [ ] Checking `response.content[].citations`?
@@ -415,7 +415,7 @@ def to_ieee(citation, num):
 | Max document size | 10 MB | Per document |
 | Max documents per message | Unlimited | But affects token count |
 | Citation granularity | Sentence | Minimum unit |
-| Model support | Sonnet 4.5, Haiku 3 | Limited models |
+| Model support | Current models (Sonnet 5, Haiku 4.5, Opus 4.8, Fable 5) | |
 | Compatibility | Not with Structured Outputs | Cannot use both |
 
 ---
@@ -424,13 +424,12 @@ def to_ieee(citation, num):
 
 ```python
 # Best for citations
-model = "claude-sonnet-4-5"  # Full citations support
+model = "claude-sonnet-5"  # Full citations support
 
-# Fast alternative (limited)
-model = "claude-3-5-haiku-20241022"  # Partial support
+# Fast, low-cost alternative
+model = "claude-haiku-4-5"  # Supported, fast
 
-# Not recommended
-model = "claude-3-5-sonnet"  # May not cite consistently
+# Note: legacy claude-3-5-* models are retired and return 404
 ```
 
 ---
@@ -449,7 +448,7 @@ client = anthropic.Anthropic()
 async def ask_document(file_path: str, question: str):
     document = enable_citations_on_document(file_path)
     response = client.messages.create(
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-5",
         max_tokens=1024,
         messages=[
             {"role": "user", "content": [document]},
@@ -464,7 +463,7 @@ async def ask_document(file_path: str, question: str):
 from langchain.chat_models import ChatAnthropic
 from langchain.schema import HumanMessage
 
-chat = ChatAnthropic(model_name="claude-sonnet-4-5")
+chat = ChatAnthropic(model_name="claude-sonnet-5")
 
 message = HumanMessage(
     content=[

--- a/.claude/skills/citations-retrieval/README.md
+++ b/.claude/skills/citations-retrieval/README.md
@@ -294,9 +294,9 @@ The **citations-retrieval** skill provides tools and patterns for:
 ## Models & API Usage
 
 ### Supported Models
-- `claude-sonnet-4-5` - Full support, recommended
-- `claude-3-5-haiku-20241022` - Partial support, fast
-- `claude-3-5-sonnet` - May not cite consistently, not recommended
+- `claude-sonnet-5` - Full support, recommended
+- `claude-haiku-4-5` - Supported, fast and low-cost
+- Legacy `claude-3-5-*` models are retired (requests return 404)
 
 ### API Costs
 

--- a/.claude/skills/citations-retrieval/SKILL.md
+++ b/.claude/skills/citations-retrieval/SKILL.md
@@ -59,7 +59,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     documents=[
         {
@@ -136,7 +136,7 @@ def rag_query(query, chunks, embeddings):
     relevant_chunks = retrieve(query, chunks, embeddings)
 
     response = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-5",
         max_tokens=1024,
         documents=[{
             "type": "document",
@@ -169,7 +169,7 @@ Please provide a short, succinct context for this chunk that will help with retr
 Context:"""
 
     response = client.messages.create(
-        model="claude-haiku-4-20250514",  # Fast, cheap
+        model="claude-haiku-4-5",  # Fast, cheap
         max_tokens=100,
         messages=[{"role": "user", "content": context_prompt}]
     )
@@ -252,7 +252,7 @@ def multi_doc_qa(question, documents):
         })
 
     response = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-5",
         max_tokens=2048,
         documents=doc_inputs,
         messages=[{
@@ -269,7 +269,7 @@ def multi_doc_qa(question, documents):
 ```python
 # Cache static documents for repeated queries
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     documents=[{
         "type": "document",
@@ -431,7 +431,7 @@ def create_rag_system():
 
         # Get cited answer
         response = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-5",
             max_tokens=1024,
             documents=[{
                 "type": "document",

--- a/.claude/skills/complex-reasoning/SKILL.md
+++ b/.claude/skills/complex-reasoning/SKILL.md
@@ -260,12 +260,10 @@ When using these frameworks with extended thinking:
 ```python
 # Enable extended thinking for complex reasoning
 response = client.messages.create(
-    model="claude-opus-4-5-20250514",
+    model="claude-opus-4-8",
     max_tokens=16000,
-    thinking={
-        "type": "enabled",
-        "budget_tokens": 15000  # Higher budget for complex reasoning
-    },
+    thinking={"type": "adaptive"},
+    output_config={"effort": "high"},  # deeper reasoning for complex problems
     system="""You are a systematic problem solver. Use structured
     reasoning frameworks like Chain-of-Thought, Tree-of-Thought,
     or MECE analysis as appropriate for the problem.""",

--- a/.claude/skills/database/SKILL.md
+++ b/.claude/skills/database/SKILL.md
@@ -90,7 +90,7 @@ WHERE a.deleted_at IS NULL
 GROUP BY a.id;
 
 -- JSON operations
-SELECT * FROM agents WHERE config->>'model' = 'claude-sonnet-4-20250514';
+SELECT * FROM agents WHERE config->>'model' = 'claude-sonnet-5';
 SELECT * FROM agents WHERE config @> '{"enabled": true}';
 UPDATE agents SET config = config || '{"version": "2.0"}' WHERE id = $1;
 

--- a/.claude/skills/deep-analysis/SKILL.md
+++ b/.claude/skills/deep-analysis/SKILL.md
@@ -357,16 +357,14 @@ Comprehensive analytical templates for thorough investigation, audits, and evalu
 
 ## Integration with Extended Thinking
 
-For deep analysis tasks, use maximum thinking budget:
+For deep analysis tasks, use adaptive thinking at maximum effort:
 
 ```python
 response = client.messages.create(
-    model="claude-opus-4-5-20250514",
+    model="claude-opus-4-8",
     max_tokens=32000,
-    thinking={
-        "type": "enabled",
-        "budget_tokens": 25000  # Maximum budget for deep analysis
-    },
+    thinking={"type": "adaptive"},
+    output_config={"effort": "max"},  # maximum reasoning depth for deep analysis
     system="""You are a senior technical analyst performing a
     comprehensive review. Use structured analysis templates and
     document all findings systematically.""",

--- a/.claude/skills/extended-thinking/SKILL.md
+++ b/.claude/skills/extended-thinking/SKILL.md
@@ -40,18 +40,19 @@ Enable Claude's extended thinking capabilities for complex reasoning tasks that 
 
 ## Supported Models
 
-| Model | Extended Thinking | Summarized Thinking |
-|-------|------------------|---------------------|
-| Claude Opus 4.5 | ✓ Full | - |
-| Claude Opus 4.1 | ✓ Full | - |
-| Claude Opus 4 | ✓ | ✓ Summarized |
-| Claude Sonnet 4.5 | ✓ Full | - |
-| Claude Sonnet 4 | ✓ | ✓ Summarized |
-| Claude Haiku 4.5 | ✓ Full | - |
+| Model | Thinking configuration |
+|-------|------------------------|
+| Claude Fable 5 (`claude-fable-5`) | Always on — omit the `thinking` param (or `{"type": "adaptive"}`); `{"type": "disabled"}` returns 400 |
+| Claude Opus 4.8 / 4.7 (`claude-opus-4-8`) | `{"type": "adaptive"}` (off when omitted); `budget_tokens` removed — returns 400 |
+| Claude Sonnet 5 (`claude-sonnet-5`) | Adaptive by default when `thinking` omitted; `budget_tokens` removed — returns 400 |
+| Claude Opus 4.6 / Sonnet 4.6 | `{"type": "adaptive"}` recommended; `budget_tokens` deprecated (transitional only) |
+| Older models (Sonnet 4.5, Haiku 4.5, ...) | `{"type": "enabled", "budget_tokens": N}` — the manual budget mechanism below |
 
 ## API Configuration
 
-### Basic Extended Thinking (Python)
+### Adaptive Thinking — current models (Python)
+
+On current models (Opus 4.6+, Sonnet 5, Fable 5), adaptive thinking replaces manual budgets: Claude decides when and how much to think, and `output_config.effort` controls depth.
 
 ```python
 import anthropic
@@ -59,12 +60,10 @@ import anthropic
 client = anthropic.Anthropic()
 
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=16000,
-    thinking={
-        "type": "enabled",
-        "budget_tokens": 10000  # Minimum 1,024
-    },
+    thinking={"type": "adaptive"},
+    output_config={"effort": "high"},  # low | medium | high | xhigh | max
     messages=[{
         "role": "user",
         "content": "Analyze this complex architecture decision..."
@@ -87,12 +86,10 @@ import Anthropic from "@anthropic-ai/sdk";
 const client = new Anthropic();
 
 const response = await client.messages.create({
-  model: "claude-sonnet-4-20250514",
+  model: "claude-sonnet-5",
   max_tokens: 16000,
-  thinking: {
-    type: "enabled",
-    budget_tokens: 10000,
-  },
+  thinking: { type: "adaptive" },
+  output_config: { effort: "high" },
   messages: [
     {
       role: "user",
@@ -102,16 +99,30 @@ const response = await client.messages.create({
 });
 ```
 
-### Streaming (Required for max_tokens > 21,333)
+### Manual Budgets — older models only (`budget_tokens`)
+
+On older models (Sonnet 4.5 / Haiku 4.5 era), extended thinking is enabled with a fixed token budget. `budget_tokens` must be >= 1,024 and < `max_tokens`. **Do not use this shape on current models** — `budget_tokens` is removed on Opus 4.7+, Sonnet 5, and Fable 5 and returns a 400 error (deprecated but still functional on Opus 4.6 / Sonnet 4.6).
+
+```python
+response = client.messages.create(
+    model="claude-sonnet-4-5",  # older model — manual budget still applies
+    max_tokens=16000,
+    thinking={
+        "type": "enabled",
+        "budget_tokens": 10000  # Minimum 1,024
+    },
+    messages=[{"role": "user", "content": "..."}]
+)
+```
+
+### Streaming (Required for large max_tokens)
 
 ```python
 with client.messages.stream(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=32000,
-    thinking={
-        "type": "enabled",
-        "budget_tokens": 20000
-    },
+    thinking={"type": "adaptive"},
+    output_config={"effort": "high"},
     messages=[{"role": "user", "content": prompt}]
 ) as stream:
     for event in stream:
@@ -122,7 +133,19 @@ with client.messages.stream(
                 print(event.delta.text, end="", flush=True)
 ```
 
-## Budget Recommendations
+## Thinking Depth Recommendations
+
+### Current models — effort levels (`output_config: {"effort": ...}`)
+
+| Effort | Use Case |
+|--------|----------|
+| `low` | Simple clarifications, latency-sensitive tasks, subagents |
+| `medium` | Code review, debugging, design decisions (good cost balance) |
+| `high` (default) | Architecture planning, security audits, intelligence-sensitive work |
+| `xhigh` | The hardest coding and agentic tasks (Opus 4.7+, Sonnet 5, Fable 5) |
+| `max` | Correctness matters more than cost; can be prone to overthinking |
+
+### Older models — budget_tokens
 
 | Task Complexity | Budget Tokens | Use Case |
 |-----------------|---------------|----------|
@@ -139,9 +162,9 @@ with client.messages.stream(
 ```python
 # Initial request with thinking
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=16000,
-    thinking={"type": "enabled", "budget_tokens": 8000},
+    thinking={"type": "adaptive"},
     tools=[{
         "name": "analyze_code",
         "description": "Analyze code for issues",
@@ -160,9 +183,9 @@ tool_result = execute_tool(tool_use_block)
 
 # Continue with thinking blocks preserved
 follow_up = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=16000,
-    thinking={"type": "enabled", "budget_tokens": 8000},
+    thinking={"type": "adaptive"},
     tools=[...],
     messages=[
         {"role": "user", "content": "Analyze this code..."},
@@ -176,27 +199,27 @@ follow_up = client.messages.create(
 )
 ```
 
-## Interleaved Thinking (Claude 4 Models)
+## Interleaved Thinking
 
-For Claude 4 models, use interleaved thinking for thinking between tool calls:
+On current models (Opus 4.6+, Sonnet 5, Fable 5), adaptive thinking automatically interleaves thinking between tool calls — no beta header needed:
 
 ```python
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=16000,
-    thinking={"type": "enabled", "budget_tokens": 10000},
-    betas=["interleaved-thinking-2025-05-14"],  # Required for Claude 4
+    thinking={"type": "adaptive"},
     messages=[...]
 )
 ```
 
+On older Claude 4 models using manual `budget_tokens`, interleaved thinking requires the `interleaved-thinking-2025-05-14` beta header.
+
 ## Constraints
 
-- **Minimum budget**: 1,024 tokens
-- **Maximum output**: 128k tokens (thinking + response)
-- **Temperature**: Must be 1 (default) - cannot modify
-- **top_k**: Cannot be used with extended thinking
-- **Streaming required**: When max_tokens > 21,333
+- **Current models (Opus 4.7+, Sonnet 5, Fable 5)**: `budget_tokens`, `temperature`, `top_p`, and `top_k` are all removed — sending any of them returns 400
+- **Older models**: minimum `budget_tokens` is 1,024 and must be < `max_tokens`; temperature must be 1 (default); `top_k` cannot be used with extended thinking
+- **Maximum output**: 128k tokens (thinking + response); Haiku 4.5 caps at 64k
+- **Streaming required**: For large max_tokens (above ~16k, to avoid SDK HTTP timeouts)
 - **System prompts**: Fully compatible
 
 ## Best Practices
@@ -216,7 +239,7 @@ When using Claude Code CLI with extended thinking models:
 # The CLI automatically handles extended thinking for supported models
 # Use opus or sonnet models for complex tasks
 
-claude --model claude-opus-4-5-20250514 "Analyze this codebase architecture"
+claude --model claude-opus-4-8 "Analyze this codebase architecture"
 ```
 
 ## See Also

--- a/.claude/skills/llm-integration/SKILL.md
+++ b/.claude/skills/llm-integration/SKILL.md
@@ -37,7 +37,7 @@ client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
 
 # Basic completion
 message = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     messages=[
         {"role": "user", "content": "Hello, Claude!"}
@@ -47,7 +47,7 @@ print(message.content[0].text)
 
 # With system prompt
 message = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     system="You are a helpful coding assistant.",
     messages=[
@@ -57,7 +57,7 @@ message = client.messages.create(
 
 # Streaming
 with client.messages.stream(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     messages=[{"role": "user", "content": "Tell me a story."}]
 ) as stream:
@@ -80,7 +80,7 @@ tools = [
 ]
 
 message = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=tools,
     messages=[{"role": "user", "content": "What's the weather in San Francisco?"}]
@@ -207,7 +207,7 @@ class LLMProvider(ABC):
         pass
 
 class ClaudeProvider(LLMProvider):
-    def __init__(self, api_key: str, model: str = "claude-sonnet-4-20250514"):
+    def __init__(self, api_key: str, model: str = "claude-sonnet-5"):
         self.client = anthropic.Anthropic(api_key=api_key)
         self.model = model
 
@@ -295,14 +295,14 @@ import anthropic
 
 client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
 
-# Enable extended thinking (Claude Sonnet 4 and Opus 4)
+# Adaptive thinking (current models: Opus 4.6+, Sonnet 5, Fable 5)
+# Note: budget_tokens is removed on Opus 4.7+/Sonnet 5/Fable 5 (returns 400);
+# use output_config effort levels to control depth
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=16000,
-    thinking={
-        "type": "enabled",
-        "budget_tokens": 10000  # Reserve tokens for thinking
-    },
+    thinking={"type": "adaptive"},
+    output_config={"effort": "high"},
     messages=[
         {
             "role": "user",
@@ -324,12 +324,9 @@ for block in response.content:
 \`\`\`python
 # Stream thinking process in real-time
 with client.messages.stream(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=16000,
-    thinking={
-        "type": "enabled",
-        "budget_tokens": 10000
-    },
+    thinking={"type": "adaptive"},
     messages=[
         {"role": "user", "content": "Analyze the time complexity of this sorting algorithm..."}
     ]
@@ -356,7 +353,7 @@ from dataclasses import dataclass
 @dataclass
 class ThinkingConfig:
     enabled: bool = False
-    budget_tokens: Optional[int] = None
+    effort: str = "high"  # low | medium | high | xhigh | max
     show_thinking: bool = True
 
 class ExtendedThinkingProvider:
@@ -380,13 +377,11 @@ class ExtendedThinkingProvider:
 
         thinking_params = {}
         if self.config.enabled:
-            thinking_params["thinking"] = {
-                "type": "enabled",
-                "budget_tokens": self.config.budget_tokens or 10000
-            }
+            thinking_params["thinking"] = {"type": "adaptive"}
+            thinking_params["output_config"] = {"effort": self.config.effort}
 
         response = client.messages.create(
-            model=kwargs.get("model", "claude-sonnet-4-20250514"),
+            model=kwargs.get("model", "claude-sonnet-5"),
             max_tokens=kwargs.get("max_tokens", 16000),
             messages=[{"role": "user", "content": prompt}],
             **thinking_params
@@ -429,7 +424,7 @@ First, think through the problem systematically, then provide your final answer.
 # Usage
 thinking_provider = ExtendedThinkingProvider(
     provider="claude",
-    config=ThinkingConfig(enabled=True, budget_tokens=8000)
+    config=ThinkingConfig(enabled=True, effort="high")
 )
 
 result = thinking_provider.generate_with_thinking(
@@ -587,7 +582,7 @@ When analyzing security:
 
 # Usage
 message = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=4096,
     system=ROLE_BASED_SYSTEM_PROMPTS["code_reviewer"],
     messages=[
@@ -614,38 +609,49 @@ Show your work for each step."""
 
 # For complex reasoning, combine with extended thinking
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=16000,
-    thinking={"type": "enabled", "budget_tokens": 10000},
+    thinking={"type": "adaptive"},
     messages=[
         {"role": "user", "content": COT_PROMPT.format(problem=complex_problem)}
     ]
 )
 \`\`\`
 
-### 6. Prefill Responses for Format Control
+### 6. Structured Outputs for Format Control
 
 \`\`\`python
-# Force JSON output by prefilling assistant response
-messages = [
-    {"role": "user", "content": "Extract entities from: 'Apple Inc. hired John Smith as CEO in 2023.'"},
-    {"role": "assistant", "content": "{"}  # Prefill to force JSON
-]
-
+# NOTE: assistant-turn prefills return a 400 on current models
+# (Opus 4.6+, Sonnet 5, Fable 5). Use structured outputs instead:
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
-    messages=messages
+    output_config={
+        "format": {
+            "type": "json_schema",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "entities": {"type": "array", "items": {"type": "string"}}
+                },
+                "required": ["entities"],
+                "additionalProperties": False
+            }
+        }
+    },
+    messages=[
+        {"role": "user", "content": "Extract entities from: 'Apple Inc. hired John Smith as CEO in 2023.'"}
+    ]
 )
 
-# Claude will complete the JSON starting with "{"
-json_output = "{" + response.content[0].text
+# Output is guaranteed to match the schema
+json_output = response.content[0].text
 \`\`\`
 
 ### 7. Long Context Best Practices
 
 \`\`\`python
-# For Claude's 200k token context window
+# For Claude's 1M token context window (200k on Haiku 4.5)
 LONG_CONTEXT_TEMPLATE = """I'm providing a large codebase for analysis.
 The most important files for this task are at the END of this message.
 
@@ -671,7 +677,7 @@ Focus primarily on the critical files when answering the task."""
 \`\`\`python
 import anthropic
 
-def count_tokens_anthropic(text: str, model: str = "claude-sonnet-4-20250514") -> int:
+def count_tokens_anthropic(text: str, model: str = "claude-sonnet-5") -> int:
     """Count tokens using Anthropic's API"""
     client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
 
@@ -683,7 +689,7 @@ def count_tokens_anthropic(text: str, model: str = "claude-sonnet-4-20250514") -
 
     return result.input_tokens
 
-def count_tokens_with_system(messages: list, system: str = None, model: str = "claude-sonnet-4-20250514") -> dict:
+def count_tokens_with_system(messages: list, system: str = None, model: str = "claude-sonnet-5") -> dict:
     """Count tokens including system prompt and messages"""
     client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
 
@@ -711,21 +717,22 @@ import anthropic
 class TokenBudgetManager:
     """Intelligent token budget management for LLM calls"""
 
-    def __init__(self, model: str = "claude-sonnet-4-20250514"):
+    def __init__(self, model: str = "claude-sonnet-5"):
         self.model = model
         self.client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
 
         # Model-specific limits
         self.limits = {
-            "claude-opus-4-20250514": {"context": 200000, "output": 16384},
-            "claude-sonnet-4-20250514": {"context": 200000, "output": 16384},
-            "claude-haiku-3-5-20250514": {"context": 200000, "output": 8192},
+            "claude-fable-5": {"context": 1000000, "output": 128000},
+            "claude-opus-4-8": {"context": 1000000, "output": 128000},
+            "claude-sonnet-5": {"context": 1000000, "output": 128000},
+            "claude-haiku-4-5": {"context": 200000, "output": 64000},
         }
 
     def get_budget(self, model: str = None) -> Dict[str, int]:
         """Get token limits for model"""
         model = model or self.model
-        return self.limits.get(model, {"context": 200000, "output": 16384})
+        return self.limits.get(model, {"context": 200000, "output": 64000})
 
     def check_budget(
         self,
@@ -836,7 +843,7 @@ class TokenBudgetManager:
         return recommendations
 
 # Usage example
-manager = TokenBudgetManager(model="claude-sonnet-4-20250514")
+manager = TokenBudgetManager(model="claude-sonnet-5")
 
 messages = [
     {"role": "user", "content": "What is Python?"},
@@ -936,7 +943,7 @@ logger.log_activity(
     activity_type="llm_api_call",
     details={
         "provider": "anthropic",
-        "model": "claude-sonnet-4-20250514",
+        "model": "claude-sonnet-5",
         "input_tokens": 1500,
         "output_tokens": 800,
         "thinking_tokens": 3000,
@@ -950,35 +957,36 @@ logger.log_activity(
 
 ### Claude Models
 
-| Model | Best For | Context | Output | Cost |
-|-------|----------|---------|--------|------|
-| **Opus 4** | Complex reasoning, architecture design | 200K | 16K | Highest |
-| **Sonnet 4** | General development, balanced performance | 200K | 16K | Medium |
-| **Haiku 3.5** | Fast tasks, simple queries, high throughput | 200K | 8K | Lowest |
+| Model | Best For | Context | Output | Cost (in/out per MTok) |
+|-------|----------|---------|--------|------------------------|
+| **Fable 5** (`claude-fable-5`) | Hardest long-horizon reasoning and agentic work | 1M | 128K | $10 / $50 |
+| **Opus 4.8** (`claude-opus-4-8`) | Complex reasoning, architecture design | 1M | 128K | $5 / $25 |
+| **Sonnet 5** (`claude-sonnet-5`) | General development, balanced performance | 1M | 128K | $3 / $15 |
+| **Haiku 4.5** (`claude-haiku-4-5`) | Fast tasks, simple queries, high throughput | 200K | 64K | $1 / $5 |
 
-**Extended Thinking:** Only available on Sonnet 4 and Opus 4
+**Thinking:** All current models support adaptive thinking (`{"type": "adaptive"}`); on Fable 5 thinking is always on (omit the `thinking` param). Manual `budget_tokens` applies only to older models.
 
 ### When to Use Each Model
 
 \`\`\`python
 MODEL_SELECTION = {
-    "strategic_planning": "claude-opus-4-20250514",
-    "system_architecture": "claude-opus-4-20250514",
-    "complex_debugging": "claude-sonnet-4-20250514",
-    "code_review": "claude-sonnet-4-20250514",
-    "code_generation": "claude-sonnet-4-20250514",
-    "documentation": "claude-haiku-3-5-20250514",
-    "simple_queries": "claude-haiku-3-5-20250514",
-    "batch_processing": "claude-haiku-3-5-20250514"
+    "strategic_planning": "claude-opus-4-8",
+    "system_architecture": "claude-opus-4-8",
+    "complex_debugging": "claude-sonnet-5",
+    "code_review": "claude-sonnet-5",
+    "code_generation": "claude-sonnet-5",
+    "documentation": "claude-haiku-4-5",
+    "simple_queries": "claude-haiku-4-5",
+    "batch_processing": "claude-haiku-4-5"
 }
 
 def select_model(task_type: str, use_thinking: bool = False) -> str:
     """Select appropriate model based on task"""
-    model = MODEL_SELECTION.get(task_type, "claude-sonnet-4-20250514")
+    model = MODEL_SELECTION.get(task_type, "claude-sonnet-5")
 
-    # Ensure model supports extended thinking if requested
+    # Prefer a stronger model when deep reasoning is requested
     if use_thinking and "haiku" in model:
-        model = "claude-sonnet-4-20250514"
+        model = "claude-sonnet-5"
 
     return model
 \`\`\`
@@ -990,7 +998,7 @@ def select_model(task_type: str, use_thinking: bool = False) -> str:
 \`\`\`python
 # Cache large system prompts or context
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=4096,
     system=[
         {
@@ -1034,7 +1042,7 @@ async def process_batch(items: List[str], batch_size: int = 10):
 \`\`\`python
 # Always use streaming for long-running tasks
 with client.messages.stream(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=8192,
     messages=[{"role": "user", "content": complex_task}]
 ) as stream:

--- a/.claude/skills/prompt-caching/SKILL.md
+++ b/.claude/skills/prompt-caching/SKILL.md
@@ -47,7 +47,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     system=[
         {
@@ -78,7 +78,7 @@ Cache breakpoints are checked in this order:
 
 - **Minimum tokens:** 1024-4096 (varies by model)
 - **Maximum breakpoints:** 4 per request
-- **Supported models:** Claude Opus 4.5, Sonnet 4.5, Haiku 4.5
+- **Supported models:** All current models (Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5)
 
 ## Implementation Patterns
 
@@ -132,7 +132,7 @@ system = [
 ```python
 # Warm the cache before batch
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=100,
     system=[{
         "type": "text",
@@ -145,7 +145,7 @@ response = client.messages.create(
 # Now run batch - all requests hit the cache
 for item in batch_items:
     response = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-5",
         max_tokens=1024,
         system=[{
             "type": "text",
@@ -174,7 +174,7 @@ print(f"Cache hit rate: {cache_read / (cache_read + cache_write + uncached) * 10
 ### Cost Calculation
 
 ```python
-def calculate_cost(usage, model="claude-sonnet-4-20250514"):
+def calculate_cost(usage, model="claude-sonnet-5"):
     # Example rates (check current pricing)
     base_input_rate = 0.003  # per 1K tokens
 
@@ -214,9 +214,9 @@ Changes that invalidate cache:
 ```python
 # Cache + Extended Thinking
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=16000,
-    thinking={"type": "enabled", "budget_tokens": 10000},
+    thinking={"type": "adaptive"},
     system=[{
         "type": "text",
         "text": large_context,

--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -59,7 +59,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 with client.messages.stream(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     messages=[{"role": "user", "content": "Write a short story."}]
 ) as stream:
@@ -71,7 +71,7 @@ with client.messages.stream(
 
 ```python
 with client.messages.stream(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     messages=[{"role": "user", "content": "Hello"}]
 ) as stream:
@@ -96,7 +96,7 @@ import Anthropic from '@anthropic-ai/sdk';
 const client = new Anthropic();
 
 const stream = client.messages.stream({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-5',
     max_tokens: 1024,
     messages: [{ role: 'user', content: 'Write a story.' }]
 });
@@ -160,7 +160,7 @@ def stream_with_tools(client, messages, tools):
     tool_input_buffer = ""
 
     with client.messages.stream(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-5",
         max_tokens=4096,
         messages=messages,
         tools=tools
@@ -193,9 +193,9 @@ thinking_content = ""
 signature = ""
 
 with client.messages.stream(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=16000,
-    thinking={"type": "enabled", "budget_tokens": 10000},
+    thinking={"type": "adaptive"},
     messages=[{"role": "user", "content": "Solve this complex problem..."}]
 ) as stream:
     for event in stream:
@@ -299,7 +299,7 @@ http_client = httpx.Client(
 async def stream_to_ui(websocket, prompt):
     """Stream Claude response to WebSocket client"""
     async with client.messages.stream(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-5",
         max_tokens=4096,
         messages=[{"role": "user", "content": prompt}]
     ) as stream:

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -177,7 +177,7 @@ def test_uppercase(input, expected):
     assert uppercase(input) == expected
 
 @pytest.mark.parametrize('agent_type,expected_model', [
-    ('claude', 'claude-sonnet-4-20250514'),
+    ('claude', 'claude-sonnet-5'),
     ('gpt', 'gpt-4'),
     ('gemini', 'gemini-pro'),
 ])

--- a/.claude/skills/tool-use/QUICK-REFERENCE.md
+++ b/.claude/skills/tool-use/QUICK-REFERENCE.md
@@ -80,7 +80,7 @@ for tool_use in tool_uses:
 
 # CRITICAL: All results in ONE user message
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=tools,
     messages=[
@@ -109,7 +109,7 @@ betas=["structured-outputs-2025-11-13"]
 
 ```python
 # ✅ Works with extended thinking
-thinking={"type": "enabled", "budget_tokens": 2048},
+thinking={"type": "adaptive"},
 tool_choice={"type": "auto"}  # Only auto or none
 
 # ❌ Doesn't work with extended thinking
@@ -220,8 +220,8 @@ if response.stop_reason == "max_tokens":
 
 | Model | Best For | Note |
 |-------|----------|------|
-| Claude Opus 4.5 | Complex tools, ambiguous queries | Best parallel tool use |
-| Claude Sonnet 4.5 | General tool use, balance | Good default choice |
+| Claude Opus 4.8 | Complex tools, ambiguous queries | Best parallel tool use |
+| Claude Sonnet 5 | General tool use, balance | Good default choice |
 | Claude Haiku 4.5 | Straightforward tools | May infer missing params |
 
 ## Stop Reasons
@@ -245,7 +245,7 @@ def my_tool(param: str) -> str:
     return "result"
 
 runner = client.beta.messages.tool_runner(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=[my_tool],
     messages=[{"role": "user", "content": "..."}]

--- a/.claude/skills/tool-use/SKILL.md
+++ b/.claude/skills/tool-use/SKILL.md
@@ -145,7 +145,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=[{
         "name": "get_weather",
@@ -175,7 +175,7 @@ if response.stop_reason == "tool_use":
 
     # Return result to Claude
     response = client.messages.create(
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-5",
         max_tokens=1024,
         tools=[...],  # Same tools
         messages=[
@@ -201,7 +201,7 @@ Tools often require sequential calls where one tool's output feeds into another:
 # Flow: get_location() → get_weather(location)
 
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=[
         {
@@ -230,7 +230,7 @@ location_result = "San Francisco, CA"
 
 # Send location result back
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=[...],
     messages=[
@@ -250,7 +250,7 @@ weather_result = "68°F, sunny"
 
 # Final result
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=[...],
     messages=[
@@ -279,7 +279,7 @@ Claude can call multiple independent tools simultaneously:
 
 ```python
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=[...],
     messages=[{
@@ -314,7 +314,7 @@ for tool_use in tool_uses:
 
 # IMPORTANT: Return all results in ONE user message
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=[...],
     messages=[
@@ -444,7 +444,7 @@ if response.stop_reason == "max_tokens":
     if last_block.type == "tool_use":
         # Incomplete tool use, retry with more tokens
         response = client.messages.create(
-            model="claude-sonnet-4-5",
+            model="claude-sonnet-5",
             max_tokens=4096,  # Increased
             messages=messages,
             tools=tools
@@ -457,7 +457,7 @@ Use tools to guarantee structured JSON output without tool execution:
 
 ```python
 response = client.beta.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     betas=["structured-outputs-2025-11-13"],
     tools=[{
@@ -547,8 +547,8 @@ def measure_parallel_efficiency(messages):
 ```python
 # ✅ ALLOWED with extended thinking
 response = client.messages.create(
-    model="claude-opus-4-5",
-    thinking={"type": "enabled", "budget_tokens": 2048},
+    model="claude-opus-4-8",
+    thinking={"type": "adaptive"},
     tools=[...],
     tool_choice={"type": "auto"},  # Default
     messages=[...]
@@ -610,7 +610,7 @@ def get_weather(location: str, unit: str = "fahrenheit") -> str:
 
 # Tool runner automatically handles tool execution loop
 runner = client.beta.messages.tool_runner(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=[get_weather],
     messages=[{"role": "user", "content": "What's the weather in Paris?"}]
@@ -727,7 +727,7 @@ Use `tool_choice` to force specific behavior:
 ```python
 # Force use of a tool (for JSON output)
 response = client.messages.create(
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-5",
     max_tokens=1024,
     tools=[sentiment_tool],
     tool_choice={"type": "tool", "name": "sentiment_tool"},

--- a/.claude/skills/vision-multimodal/SKILL.md
+++ b/.claude/skills/vision-multimodal/SKILL.md
@@ -74,7 +74,7 @@ with open("image.jpg", "rb") as f:
     image_data = base64.standard_b64encode(f.read()).decode("utf-8")
 
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=1024,
     messages=[{
         "role": "user",
@@ -158,7 +158,7 @@ with open("document.pdf", "rb") as f:
     pdf_data = base64.standard_b64encode(f.read()).decode("utf-8")
 
 response = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     max_tokens=4096,
     messages=[{
         "role": "user",

--- a/.github/workflows/jira-auto-create.yml
+++ b/.github/workflows/jira-auto-create.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Step 1: Checkout repository (for context)
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Step 2: Authenticate with Jira
       - name: Login to Jira

--- a/.github/workflows/jira-build-status.yml
+++ b/.github/workflows/jira-build-status.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Step 1: Checkout repository at the commit that triggered the workflow
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 10

--- a/.github/workflows/jira-deployment-track.yml
+++ b/.github/workflows/jira-deployment-track.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Step 1: Checkout to access deployment metadata
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.deployment.ref }}
           fetch-depth: 50  # Get recent commits for issue extraction

--- a/.github/workflows/jira-pr-sync.yml
+++ b/.github/workflows/jira-pr-sync.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Step 1: Checkout repository to access commit history
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history to extract all commit messages
 

--- a/.github/workflows/marketplace-ci.yml
+++ b/.github/workflows/marketplace-ci.yml
@@ -37,9 +37,9 @@ jobs:
     name: Validate marketplace & every plugin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: pnpm

--- a/.github/workflows/no-tracked-node-modules.yml
+++ b/.github/workflows/no-tracked-node-modules.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fail if dependency folders or build artifacts are tracked
         run: scripts/check-no-tracked-deps.sh

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,10 +37,10 @@ jobs:
       pages_enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.11.0",
-    "ajv": "^8.12.0",
+    "@types/node": "^20.19.43",
+    "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "js-yaml": "^4.1.0",
-    "tsx": "^4.7.0",
-    "typescript": "^5.3.0"
+    "js-yaml": "^4.3.0",
+    "tsx": "^4.23.0",
+    "typescript": "^7.0.2"
   },
   "engines": {
     "node": ">=20"

--- a/plugins/claude-code-expert/.claude-plugin/plugin.json
+++ b/plugins/claude-code-expert/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.local/schemas/plugin.schema.json",
   "name": "claude-code-expert",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 21 behavior-triggering skills, 12 single-intent commands, 18 role-scoped agents bridging engram and Obsidian. Tracks current Claude Code capabilities (Fable 5 + Opus 4.8, agent teams, Tool Search, web/remote).",
   "author": {
     "name": "Markus Ahling"

--- a/plugins/claude-code-expert/CHANGELOG.md
+++ b/plugins/claude-code-expert/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v8.4.0 (2026-07-11) — Sonnet 5 as the current Sonnet tier
+
+### Models
+
+- The `sonnet` alias now documents **Claude Sonnet 5** (`claude-sonnet-5`) everywhere the
+  plugin states the current lineup: `cc-model-routing` skill cost table, MCP `MODEL_DATA`
+  (`cc_docs_model_recommend`), `README.md`, `CLAUDE.md`, and `docs/CC-CAPABILITIES-2026-06.md`.
+- Added Sonnet 5 caveats to `cc-model-routing`: same new tokenizer as Fable 5 (~30% more
+  tokens than Sonnet 4.6 for identical content) and introductory pricing ($2/$10 per MTok
+  through 2026-08-31; the table shows the $3/$15 sticker).
+- Effort guidance updated: `xhigh` is supported on Opus 4.7/4.8, Sonnet 5, and Fable 5.
+
 ## v8.3.0 (2026-06-24) — Namespaced skill & agent names (collision-free)
 
 ### Breaking — renames

--- a/plugins/claude-code-expert/CLAUDE.md
+++ b/plugins/claude-code-expert/CLAUDE.md
@@ -6,7 +6,7 @@ Modern second brain for Claude Code. Five-layer stack deploy + three-tier memory
 > permissions, web/remote, memory) is tracked in [`docs/CC-CAPABILITIES-2026-06.md`](docs/CC-CAPABILITIES-2026-06.md).
 > It is the source of truth — when a skill or command disagrees with it, fix the skill. Latest models:
 > Fable 5 (`claude-fable-5`, new Mythos-class tier above Opus), Opus 4.8 (`claude-opus-4-8`),
-> Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5-20251001`).
+> Sonnet 5 (`claude-sonnet-5`), Haiku 4.5 (`claude-haiku-4-5-20251001`).
 
 ## Fast routing
 

--- a/plugins/claude-code-expert/README.md
+++ b/plugins/claude-code-expert/README.md
@@ -10,7 +10,7 @@ capability snapshot lives in [`docs/CC-CAPABILITIES-2026-06.md`](docs/CC-CAPABIL
 it, the skill gets fixed.
 
 **Current models:** Fable 5 (`claude-fable-5`, Mythos-class tier above Opus) · Opus 4.8
-(`claude-opus-4-8`) · Sonnet 4.6 (`claude-sonnet-4-6`) · Haiku 4.5 (`claude-haiku-4-5-20251001`).
+(`claude-opus-4-8`) · Sonnet 5 (`claude-sonnet-5`) · Haiku 4.5 (`claude-haiku-4-5-20251001`).
 Aliases `fable`/`opus`/`sonnet`/`haiku` auto-resolve to the latest; `/fast` keeps Opus reasoning
 with faster output (not on Fable); `effort` (`low`→`max`, `xhigh` on Opus 4.7/4.8 and Fable 5)
 scales thinking depth without changing model — on Fable 5 it's the only depth control.

--- a/plugins/claude-code-expert/docs/CC-CAPABILITIES-2026-06.md
+++ b/plugins/claude-code-expert/docs/CC-CAPABILITIES-2026-06.md
@@ -17,7 +17,7 @@ tool surface.
 |---|---|---|
 | `fable` | `claude-fable-5` | Hardest long-horizon agentic runs, overnight builds, deepest reasoning — the Claude 5 / Mythos-class tier above Opus |
 | `opus` | `claude-opus-4-8` | Architecture, hard debugging, security review, planning/review gates |
-| `sonnet` | `claude-sonnet-4-6` | Implementation, code review, refactoring, test writing |
+| `sonnet` | `claude-sonnet-5` | Implementation, code review, refactoring, test writing |
 | `haiku` | `claude-haiku-4-5-20251001` | Retrieval, research, docs, bulk mechanical edits |
 
 Helper aliases: `best` (most capable available), `opusplan` (Opus reasoning → Sonnet execution),

--- a/plugins/claude-code-expert/mcp-server/src/index.js
+++ b/plugins/claude-code-expert/mcp-server/src/index.js
@@ -302,7 +302,7 @@ function resolveTask(query) {
 const MODEL_DATA = {
   "fable": { id: "claude-fable-5", inputCost: 10.00, outputCost: 50.00, cacheRead: 1.00, best: "long-horizon autonomous runs, hardest reasoning above Opus's ceiling, multi-hour orchestration" },
   "opus": { id: "claude-opus-4-8", inputCost: 5.00, outputCost: 25.00, cacheRead: 0.50, best: "architecture, complex debugging, security review" },
-  "sonnet": { id: "claude-sonnet-4-6", inputCost: 3.00, outputCost: 15.00, cacheRead: 0.30, best: "implementation, code review, refactoring, test writing" },
+  "sonnet": { id: "claude-sonnet-5", inputCost: 3.00, outputCost: 15.00, cacheRead: 0.30, best: "implementation, code review, refactoring, test writing" },
   "haiku": { id: "claude-haiku-4-5-20251001", inputCost: 1.00, outputCost: 5.00, cacheRead: 0.10, best: "lookups, research, docs, simple Q&A, commit messages" },
 };
 

--- a/plugins/claude-code-expert/skills/cc-model-routing/SKILL.md
+++ b/plugins/claude-code-expert/skills/cc-model-routing/SKILL.md
@@ -30,16 +30,16 @@ Claude model choice is the biggest cost lever in Claude Code. Match the model to
 |---|---|---|---|---|
 | Fable 5 | `fable` / `claude-fable-5` | $10 | $50 | 3.3× |
 | Opus 4.8 | `opus` / `claude-opus-4-8` | $5 | $25 | 1.7× |
-| Sonnet 4.6 | `sonnet` / `claude-sonnet-4-6` | $3 | $15 | 1× |
+| Sonnet 5 | `sonnet` / `claude-sonnet-5` | $3 | $15 | 1× |
 | Haiku 4.5 | `haiku` / `claude-haiku-4-5-20251001` | $1 | $5 | 0.33× |
 
-Output tokens are the dominant cost in most Claude Code sessions. Two caveats on Fable 5: its new tokenizer produces ~30% more tokens for the same content (so the effective gap vs Opus is wider than the per-token price), and turns run longer. Use it where the capability ceiling matters, not as a default.
+Output tokens are the dominant cost in most Claude Code sessions. Two caveats on Fable 5: its new tokenizer produces ~30% more tokens for the same content (so the effective gap vs Opus is wider than the per-token price), and turns run longer. Use it where the capability ceiling matters, not as a default. Sonnet 5 uses the same new tokenizer (~30% more tokens than Sonnet 4.6 for identical content) and launched with introductory pricing ($2/$10 per MTok through 2026-08-31) — the table shows the sticker price.
 
 **Aliases auto-resolve to the latest generation** — prefer `fable`/`opus`/`sonnet`/`haiku` over pinned IDs so a model refresh doesn't strand your config. Use `opusplan` for Opus-reasoning + Sonnet-execution, or `best` for "most capable available". Extended 1M-token context: `opus[1m]` / `sonnet[1m]` (Fable 5 is 1M by default; `claude-fable-5[1m]` is the long-context ID form).
 
 **Fast mode** (`/fast` in-session, `--fast` at launch) keeps you on Opus (4.6/4.7/4.8) but optimizes for faster output — it does **not** downgrade to a smaller model. Toggle it when you want Opus-level reasoning without the usual latency. Not available on Fable 5.
 
-**Effort levels** scale reasoning depth independently of model: `low` · `medium` · `high` · `xhigh` · `max` (Opus 4.7/4.8 and Fable 5 support `xhigh`). Set via `/effort`, `--effort <level>`, or `effort:` in skill/agent frontmatter — cheaper than jumping a model tier when you just need deeper thinking. On Fable 5 thinking is always on and effort is the *only* depth control — and even `low` effort on Fable often matches or beats `max` on prior models, so sweep downward for routine work.
+**Effort levels** scale reasoning depth independently of model: `low` · `medium` · `high` · `xhigh` · `max` (Opus 4.7/4.8, Sonnet 5, and Fable 5 support `xhigh`). Set via `/effort`, `--effort <level>`, or `effort:` in skill/agent frontmatter — cheaper than jumping a model tier when you just need deeper thinking. On Fable 5 thinking is always on and effort is the *only* depth control — and even `low` effort on Fable often matches or beats `max` on prior models, so sweep downward for routine work.
 
 ## Model cascading
 

--- a/plugins/dotnet-blazor/.claude-plugin/plugin.json
+++ b/plugins/dotnet-blazor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.local/schemas/plugin.schema.json",
   "name": "dotnet-blazor",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Comprehensive .NET 10, Blazor, ASP.NET Core, C#, and Syncfusion expert plugin for building modern web apps, microservices, and cloud-native solutions",
   "author": {
     "name": "Markus Ahling"

--- a/plugins/dotnet-blazor/CHANGELOG.md
+++ b/plugins/dotnet-blazor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.0] - 2026-07-11
+
+### Changed
+
+- All four pinned agents (`aspnet-api-engineer`, `csharp-expert`, `dotnet-performance-engineer`, `syncfusion-ui-specialist`) upgraded from `claude-sonnet-4-6` to `claude-sonnet-5`.
+
 ## [2.0.1] - 2026-06-04
 
 ### Changed

--- a/plugins/dotnet-blazor/agents/aspnet-api-engineer.md
+++ b/plugins/dotnet-blazor/agents/aspnet-api-engineer.md
@@ -14,7 +14,7 @@ inputs:
 risk: low
 cost: medium
 description: API engineering specialist for ASP.NET Core minimal APIs and controllers with OpenAPI, validation, caching, and rate limiting
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools:
   - Read
   - Write

--- a/plugins/dotnet-blazor/agents/csharp-expert.md
+++ b/plugins/dotnet-blazor/agents/csharp-expert.md
@@ -13,7 +13,7 @@ inputs:
 risk: low
 cost: low
 description: C# language expert for modern patterns (primary constructors, records, pattern matching), LINQ, async/await, generics, and source generators
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools:
   - Read
   - Write

--- a/plugins/dotnet-blazor/agents/dotnet-performance-engineer.md
+++ b/plugins/dotnet-blazor/agents/dotnet-performance-engineer.md
@@ -13,7 +13,7 @@ inputs:
 risk: medium
 cost: medium
 description: Performance specialist for Blazor rendering, EF Core queries, API throughput, memory management, and caching
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools:
   - Read
   - Write

--- a/plugins/dotnet-blazor/agents/syncfusion-ui-specialist.md
+++ b/plugins/dotnet-blazor/agents/syncfusion-ui-specialist.md
@@ -13,7 +13,7 @@ inputs:
 risk: low
 cost: medium
 description: Syncfusion Blazor expert for DataGrid, Charts, Scheduler, RichTextEditor, PDF, and 80+ components with theming
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools:
   - Read
   - Write

--- a/plugins/drawio-diagramming/.claude-plugin/plugin.json
+++ b/plugins/drawio-diagramming/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "drawio-diagramming",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Intelligent draw.io diagramming plugin with AI-powered diagram generation, multi-platform embedding (GitHub, Confluence, Azure DevOps, Notion, Teams, Harness), conditional formatting, live data binding, and MCP server integration for programmatic diagram creation and management.",
   "author": {
     "name": "Markus Ahling",

--- a/plugins/drawio-diagramming/CHANGELOG.md
+++ b/plugins/drawio-diagramming/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [2.1.0] - 2026-07-11
+
+### Changed
+
+- `ai-generation` skill: `defaultAiModel` example upgraded from `claude-sonnet-4-20250514` (deprecated, retirement scheduled 2026-06-15) to `claude-sonnet-5`.
+
+## [2.0.0] - 2026-04-17
+
+- Prior release (no changelog was kept before 2.1.0).

--- a/plugins/drawio-diagramming/skills/ai-generation/SKILL.md
+++ b/plugins/drawio-diagramming/skills/ai-generation/SKILL.md
@@ -44,7 +44,7 @@ Configure AI in draw.io via **Extras > Configuration** (JSON editor):
   "gptApiKey": "sk-...",
   "geminiApiKey": "AIza...",
   "claudeApiKey": "sk-ant-...",
-  "defaultAiModel": "claude-sonnet-4-20250514"
+  "defaultAiModel": "claude-sonnet-5"
 }
 ```
 

--- a/plugins/exec-automator/.claude-plugin/plugin.json
+++ b/plugins/exec-automator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "exec-automator",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Genesis (Forerunner) - AI-Powered Executive Director Automation Platform. Analyze organizational responsibilities, score automation potential with 6-factor algorithm, generate LangGraph workflows, and deploy 11 specialized agents for trade associations and nonprofits.",
   "author": {
     "name": "Brookside BI",

--- a/plugins/exec-automator/CHANGELOG.md
+++ b/plugins/exec-automator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.1.0] - 2026-07-11
+
+### Changed
+
+- Migrated all Claude model references to the current generation: `claude-sonnet-4-5`/`claude-sonnet-4-6` -> `claude-sonnet-5`, `claude-opus-4-5` -> `claude-opus-4-8`, `claude-haiku-4`/`claude-haiku-3-5-20250305` -> `claude-haiku-4-5` across the MCP server (`agents/__init__.py`, `langchain_tools.py`, `langgraph_engine.py`, `server.py`, `state_schemas.py`), commands, docs, and skills.
+
+### Fixed
+
+- Removed `temperature` arguments from `ChatAnthropic` calls targeting Sonnet 5 / Opus 4.8 — non-default sampling parameters return a 400 on these models.
+- `langchain-integrations` skill: fixed `ChatAnthronic` typo, removed the invalid `thinking-budget-2024-11-01` beta header, and replaced the removed `budget_tokens` extended-thinking config with adaptive thinking (`{"type": "adaptive"}`).
+
 ## [2.0.1] - 2026-06-04
 
 ### Changed

--- a/plugins/exec-automator/agents/workflow-designer.md
+++ b/plugins/exec-automator/agents/workflow-designer.md
@@ -84,7 +84,7 @@ from langchain_core.messages import HumanMessage
 
 def agent_node(state: WorkflowState) -> WorkflowState:
     """LLM agent decision node."""
-    llm = ChatAnthropic(model="claude-sonnet-4-6")
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     messages = state["messages"]
     context = state["context"]
@@ -629,7 +629,7 @@ def tool_executor_node(state: WorkflowState) -> WorkflowState:
     """Execute tools based on state."""
     tools = [search_documents, update_record]
 
-    llm = ChatAnthropic(model="claude-sonnet-4-6")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     agent = create_tool_calling_agent(llm, tools)
     executor = AgentExecutor(agent=agent, tools=tools)
 

--- a/plugins/exec-automator/commands/export.md
+++ b/plugins/exec-automator/commands/export.md
@@ -166,7 +166,7 @@ Extract and export core platform settings:
       "monitoring_level": "comprehensive"
     },
     "ai_models": {
-      "primary_model": "claude-sonnet-4-6",
+      "primary_model": "claude-sonnet-5",
       "fallback_model": "claude-haiku-4-5-20251001",
       "analysis_model": "claude-opus-4-8",
       "temperature": 0.3,
@@ -296,7 +296,7 @@ Extract and export core platform settings:
         "created_date": "2025-02-01",
         "last_modified": "2025-12-15",
         "configuration": {
-          "model": "claude-sonnet-4-6",
+          "model": "claude-sonnet-5",
           "temperature": 0.5,
           "max_tokens": 8000,
           "system_prompt": "You are an expert grant writer specializing in nonprofit funding...",
@@ -323,7 +323,7 @@ Extract and export core platform settings:
         "created_date": "2025-02-05",
         "last_modified": "2025-12-10",
         "configuration": {
-          "model": "claude-sonnet-4-6",
+          "model": "claude-sonnet-5",
           "temperature": 0.2,
           "max_tokens": 4000,
           "system_prompt": "You are a board meeting coordination assistant...",
@@ -414,7 +414,7 @@ For each active workflow, export:
           "node_id": "research_node",
           "node_name": "Research and Discovery",
           "node_type": "ai_agent",
-          "model": "claude-sonnet-4-6",
+          "model": "claude-sonnet-5",
           "tools": ["research_search", "funder_database"],
           "average_duration_seconds": 35
         },
@@ -422,7 +422,7 @@ For each active workflow, export:
           "node_id": "drafting_node",
           "node_name": "Grant Narrative Drafting",
           "node_type": "ai_agent",
-          "model": "claude-sonnet-4-6",
+          "model": "claude-sonnet-5",
           "tools": ["document_generator", "template_library"],
           "average_duration_seconds": 67
         },
@@ -430,7 +430,7 @@ For each active workflow, export:
           "node_id": "budget_node",
           "node_name": "Budget Generation",
           "node_type": "ai_agent",
-          "model": "claude-sonnet-4-6",
+          "model": "claude-sonnet-5",
           "tools": ["financial_calculator", "accounting_integration"],
           "average_duration_seconds": 18
         },
@@ -474,7 +474,7 @@ For each active workflow, export:
     "configuration_version": "1.3.0",
     "base_configuration": {
       "model_provider": "anthropic",
-      "model_name": "claude-sonnet-4-6",
+      "model_name": "claude-sonnet-5",
       "temperature": 0.5,
       "max_tokens": 8000,
       "top_p": 0.95,
@@ -798,7 +798,7 @@ Gather all generated reports from:
         "prompt_id": "prompt_grant_research_001",
         "prompt_name": "Grant Research Prompt",
         "prompt_category": "grant_writing",
-        "model": "claude-sonnet-4-6",
+        "model": "claude-sonnet-5",
         "version": "1.4.0",
         "prompt_text": "You are conducting research for a grant application...",
         "variables": ["funder_name", "grant_program", "organization_mission"],
@@ -811,7 +811,7 @@ Gather all generated reports from:
         "prompt_id": "prompt_member_email_001",
         "prompt_name": "Member Newsletter Draft Prompt",
         "prompt_category": "communications",
-        "model": "claude-sonnet-4-6",
+        "model": "claude-sonnet-5",
         "version": "2.1.0",
         "prompt_text": "You are drafting a monthly member newsletter...",
         "variables": ["month", "highlights", "upcoming_events", "member_spotlight"],

--- a/plugins/exec-automator/commands/generate.md
+++ b/plugins/exec-automator/commands/generate.md
@@ -94,8 +94,8 @@ Parse the user's command to extract:
   - `prototype` - Simplified code for quick testing
   - `tutorial` - Heavily commented code for learning
 
-- **--models**: LLM models to use (default: `claude-sonnet-4-6`)
-  - Comma-separated list: `claude-sonnet-4-6,gpt-4,gemini-pro`
+- **--models**: LLM models to use (default: `claude-sonnet-5`)
+  - Comma-separated list: `claude-sonnet-5,gpt-4,gemini-pro`
   - Generator will create model-specific configurations
 
 ---
@@ -438,8 +438,7 @@ def agent_analysis_node(state: Workflow{ID}State) -> Workflow{ID}State:
     try:
         # Initialize LLM
         llm = ChatAnthropic(
-            model="claude-sonnet-4-6",
-            temperature=0.3,
+            model="claude-sonnet-5",
             max_tokens=4000
         )
 
@@ -997,7 +996,7 @@ For each workflow, generate agent configuration JSON:
 
   "llm_config": {
     "provider": "anthropic",
-    "model": "claude-sonnet-4-6",
+    "model": "claude-sonnet-5",
     "temperature": 0.3,
     "max_tokens": 4000,
     "top_p": 0.95,

--- a/plugins/exec-automator/commands/map.md
+++ b/plugins/exec-automator/commands/map.md
@@ -455,7 +455,7 @@ def agent_node_name(state: WorkflowState) -> WorkflowState:
     Inputs: state["{input_key}"]
     Outputs: state["{output_key}"]
     """
-    llm = ChatAnthropic(model="claude-sonnet-4-6", temperature=0.3)
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     prompt = ChatPromptTemplate.from_messages([
         ("system", "You are a specialized agent for {task_description}"),

--- a/plugins/exec-automator/commands/orchestrate.md
+++ b/plugins/exec-automator/commands/orchestrate.md
@@ -513,7 +513,7 @@ Spawn 4-6 specialized generation agents in parallel:
        human_feedback: str | None
 
    # Initialize LLM
-   llm = ChatAnthropic(model="claude-sonnet-4-6")
+   llm = ChatAnthropic(model="claude-sonnet-5")
 
    # Define workflow nodes
    def node_1_name(state: WorkflowState) -> WorkflowState:
@@ -545,7 +545,7 @@ Spawn 4-6 specialized generation agents in parallel:
      "agent_id": "agent_{responsibility_id}",
      "agent_name": "{responsibility_title} Assistant",
      "agent_type": "langgraph_workflow",
-     "model": "claude-sonnet-4-6",
+     "model": "claude-sonnet-5",
      "temperature": 0.3,
      "max_tokens": 4000,
      "tools": [

--- a/plugins/exec-automator/docs/README_DEEP_DIVE.md
+++ b/plugins/exec-automator/docs/README_DEEP_DIVE.md
@@ -430,7 +430,7 @@ class MemberCommunicationState(TypedDict):
 
 def categorize_inquiry(state):
     # Use Claude to categorize member inquiry
-    llm = ChatAnthropic(model="claude-sonnet-4-6")
+    llm = ChatAnthropic(model="claude-sonnet-5")
     category = llm.invoke(f"Categorize this inquiry: {state['inquiry_text']}")
     return {"inquiry_category": category}
 
@@ -710,7 +710,7 @@ class BoardMeetingState(TypedDict):
     status: Literal["collecting", "drafting", "review", "scheduled", "completed"]
 
 # Initialize LLM
-llm = ChatAnthropic(model="claude-sonnet-4-6", temperature=0.3)
+llm = ChatAnthropic(model="claude-sonnet-5")
 
 # Node 1: Collect agenda items from committees
 def collect_agenda_items(state: BoardMeetingState) -> BoardMeetingState:
@@ -875,7 +875,7 @@ if __name__ == "__main__":
   "agent_name": "Board Meeting Coordinator",
   "agent_type": "langgraph_workflow",
   "workflow_file": "workflow-resp_001-board-meeting.py",
-  "model": "claude-sonnet-4-6",
+  "model": "claude-sonnet-5",
   "temperature": 0.3,
   "max_tokens": 4000,
   "tools": [
@@ -2363,9 +2363,9 @@ export OBSIDIAN_VAULT_PATH="/path/to/vault"
     "size": "medium"
   },
   "models": {
-    "default": "claude-sonnet-4-6",
+    "default": "claude-sonnet-5",
     "strategic": "claude-opus-4-8-20251101",
-    "cost_effective": "claude-haiku-3-5-20250305"
+    "cost_effective": "claude-haiku-4-5"
   },
   "scoring": {
     "weights_profile": "default",

--- a/plugins/exec-automator/mcp-server/OVERVIEW.md
+++ b/plugins/exec-automator/mcp-server/OVERVIEW.md
@@ -375,7 +375,7 @@ OPENAI_API_KEY=sk-...
 CHECKPOINT_DIR=./checkpoints
 PATTERN_LIBRARY=./data/patterns.json
 TEMPLATES_DIR=./templates
-DEFAULT_MODEL=claude-sonnet-4-6
+DEFAULT_MODEL=claude-sonnet-5
 MAX_RETRIES=3
 ENABLE_STREAMING=true
 ```

--- a/plugins/exec-automator/mcp-server/README.md
+++ b/plugins/exec-automator/mcp-server/README.md
@@ -68,7 +68,7 @@ export OPENAI_API_KEY="your-key"
 export CHECKPOINT_DIR="./checkpoints"
 export PATTERN_LIBRARY="./data/patterns.json"
 export TEMPLATES_DIR="./templates"
-export DEFAULT_MODEL="claude-sonnet-4-6"
+export DEFAULT_MODEL="claude-sonnet-5"
 ```
 
 ## Usage
@@ -139,7 +139,7 @@ result = await mcp.call_tool("generate_workflow", {
     "responsibility_id": "resp_001",
     "workflow_type": "human_in_loop",  # or "autonomous", "assisted", "advisory"
     "options": {
-        "model": "claude-sonnet-4-6",
+        "model": "claude-sonnet-5",
         "approval_threshold": 0.8
     }
 })
@@ -425,7 +425,7 @@ def create_my_workflow() -> StateGraph:
 DOMAIN_AGENTS["my_domain"] = {
     "name": "My Domain Agent",
     "description": "...",
-    "model": "claude-sonnet-4-6",
+    "model": "claude-sonnet-5",
     "system_prompt": "...",
     "tools": [...],
     "capabilities": [...]

--- a/plugins/exec-automator/mcp-server/src/agents/__init__.py
+++ b/plugins/exec-automator/mcp-server/src/agents/__init__.py
@@ -20,7 +20,7 @@ DOMAIN_AGENTS = {
     "governance": {
         "name": "Governance Agent",
         "description": "Specialist in board relations, policy development, and compliance",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "system_prompt": """You are a governance specialist for nonprofit and association management.
 
 Your expertise includes:
@@ -45,7 +45,7 @@ role of human judgment in board-level decisions.""",
     "financial": {
         "name": "Financial Agent",
         "description": "Specialist in budgeting, financial reporting, and fiscal management",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "system_prompt": """You are a financial management specialist for nonprofit organizations.
 
 Your expertise includes:
@@ -71,7 +71,7 @@ accountability in all financial matters.""",
     "operations": {
         "name": "Operations Agent",
         "description": "Specialist in daily operations, process optimization, and facilities",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "system_prompt": """You are an operations management specialist for associations.
 
 Your expertise includes:
@@ -95,7 +95,7 @@ You streamline operations to create capacity for strategic initiatives.""",
     "strategic": {
         "name": "Strategic Agent",
         "description": "Specialist in strategic planning, partnerships, and growth",
-        "model": "claude-opus-4-5",  # Use Opus for strategic thinking
+        "model": "claude-opus-4-8",  # Use Opus for strategic thinking
         "system_prompt": """You are a strategic planning specialist for nonprofit organizations.
 
 Your expertise includes:
@@ -120,7 +120,7 @@ true to their mission.""",
     "communications": {
         "name": "Communications Agent",
         "description": "Specialist in marketing, PR, and member communications",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "system_prompt": """You are a communications and marketing specialist for associations.
 
 Your expertise includes:
@@ -146,7 +146,7 @@ organizational objectives.""",
     "membership": {
         "name": "Membership Agent",
         "description": "Specialist in member recruitment, retention, and engagement",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "system_prompt": """You are a membership development specialist for associations.
 
 Your expertise includes:
@@ -170,7 +170,7 @@ You build strong member relationships and demonstrate clear value.""",
     "programs": {
         "name": "Programs Agent",
         "description": "Specialist in events, education, and member services",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "system_prompt": """You are a program management specialist for associations.
 
 Your expertise includes:
@@ -195,7 +195,7 @@ achieve organizational goals.""",
     "staff": {
         "name": "Staff Management Agent",
         "description": "Specialist in hiring, training, and performance management",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "system_prompt": """You are a human resources and staff management specialist.
 
 Your expertise includes:
@@ -220,7 +220,7 @@ with employment law.""",
     "technology": {
         "name": "Technology Agent",
         "description": "Specialist in systems, digital transformation, and IT oversight",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "system_prompt": """You are a technology and digital transformation specialist.
 
 Your expertise includes:
@@ -245,7 +245,7 @@ member value.""",
     "external_relations": {
         "name": "External Relations Agent",
         "description": "Specialist in government relations, coalitions, and partnerships",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "system_prompt": """You are an external relations and advocacy specialist.
 
 Your expertise includes:

--- a/plugins/exec-automator/mcp-server/src/langchain_tools.py
+++ b/plugins/exec-automator/mcp-server/src/langchain_tools.py
@@ -206,7 +206,7 @@ async def extract_responsibilities(text: str, document_type: str) -> List[Respon
     """
     logger.info(f"Extracting responsibilities from {document_type}")
 
-    llm = ChatAnthropic(model="claude-sonnet-4-5", temperature=0)
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     prompt = f"""You are an expert in association management and nonprofit governance.
 
@@ -278,7 +278,7 @@ async def categorize_responsibility(responsibility: Responsibility) -> str:
     Returns:
         Category string
     """
-    llm = ChatAnthropic(model="claude-haiku-4", temperature=0)
+    llm = ChatAnthropic(model="claude-haiku-4-5")
 
     prompt = f"""Categorize this executive director responsibility into ONE category.
 
@@ -467,7 +467,7 @@ async def identify_org_type(text: str, responsibilities: List[Responsibility]) -
     """
     logger.info("Identifying organization type")
 
-    llm = ChatAnthropic(model="claude-sonnet-4-5", temperature=0)
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     prompt = f"""Analyze this organizational document and extract:
 
@@ -560,7 +560,7 @@ async def generate_workflow_spec(
     """
     logger.info(f"Generating workflow spec: {workflow_type}")
 
-    llm = ChatAnthropic(model="claude-sonnet-4-5", temperature=0)
+    llm = ChatAnthropic(model="claude-sonnet-5")
 
     prompt = f"""Generate a complete LangGraph workflow specification for this responsibility automation.
 
@@ -620,7 +620,7 @@ async def generate_agent_spec(responsibility: Responsibility) -> Dict[str, Any]:
     agent_spec = {
         "name": f"agent_{responsibility['id']}",
         "description": f"Specialized agent for: {responsibility['raw_text']}",
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-5",
         "tools": [],
         "system_prompt": f"You are a specialized AI agent responsible for: {responsibility['raw_text']}",
         "capabilities": [],

--- a/plugins/exec-automator/mcp-server/src/langgraph_engine.py
+++ b/plugins/exec-automator/mcp-server/src/langgraph_engine.py
@@ -279,7 +279,7 @@ def create_workflow_generation_workflow() -> StateGraph:
         """Analyze responsibility to determine workflow requirements."""
         logger.info(f"Analyzing responsibility: {state['responsibility_id']}")
 
-        llm = ChatAnthropic(model="claude-sonnet-4-5")
+        llm = ChatAnthropic(model="claude-sonnet-5")
 
         # Load responsibility details
         # (In production, this would query from database/checkpoint)

--- a/plugins/exec-automator/mcp-server/src/server.py
+++ b/plugins/exec-automator/mcp-server/src/server.py
@@ -77,7 +77,7 @@ CONFIG = {
     "checkpoint_dir": os.getenv("CHECKPOINT_DIR", "./checkpoints"),
     "pattern_library_path": os.getenv("PATTERN_LIBRARY", "./data/patterns.json"),
     "templates_dir": os.getenv("TEMPLATES_DIR", "./templates"),
-    "default_model": os.getenv("DEFAULT_MODEL", "claude-sonnet-4-5"),
+    "default_model": os.getenv("DEFAULT_MODEL", "claude-sonnet-5"),
     "max_retries": int(os.getenv("MAX_RETRIES", "3")),
     "enable_streaming": os.getenv("ENABLE_STREAMING", "true").lower() == "true",
 }

--- a/plugins/exec-automator/mcp-server/src/state_schemas.py
+++ b/plugins/exec-automator/mcp-server/src/state_schemas.py
@@ -268,7 +268,7 @@ class AgentSpec(TypedDict):
     agent_id: str
     agent_name: str
     description: str
-    model: str  # "claude-sonnet-4-5", "claude-opus-4-5", etc.
+    model: str  # "claude-sonnet-5", "claude-opus-4-8", etc.
     tools: List[str]
     system_prompt: str
     capabilities: List[str]

--- a/plugins/exec-automator/skills/langchain-integrations/langchain-integrations.md
+++ b/plugins/exec-automator/skills/langchain-integrations/langchain-integrations.md
@@ -42,7 +42,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
 
 # Components
-llm = ChatAnthropic(model="claude-sonnet-4-6")
+llm = ChatAnthropic(model="claude-sonnet-5")
 prompt = ChatPromptTemplate.from_template(
     "You are an expert in {domain}. Answer this question: {question}"
 )
@@ -345,7 +345,7 @@ prompt = ChatPromptTemplate.from_messages([
 ])
 
 # Create agent
-llm = ChatAnthropic(model="claude-sonnet-4-6")
+llm = ChatAnthropic(model="claude-sonnet-5")
 agent = create_tool_calling_agent(llm, tools, prompt)
 
 # Create executor
@@ -1064,9 +1064,10 @@ result = await chain.ainvoke(
 from langchain_anthropic import ChatAnthropic
 
 # Claude Sonnet
-llm = ChatAnthronic(
-    model="claude-sonnet-4-6",
-    temperature=0.7,
+# Note: Sonnet 5 / Opus 4.7+ reject sampling params (temperature/top_p/top_k)
+# with a 400 — steer style via prompting instead.
+llm = ChatAnthropic(
+    model="claude-sonnet-5",
     max_tokens=4096,
     anthropic_api_key=os.getenv("ANTHROPIC_API_KEY")
 )
@@ -1074,22 +1075,17 @@ llm = ChatAnthronic(
 # Claude Opus (for complex reasoning)
 opus_llm = ChatAnthropic(
     model="claude-opus-4-8",
-    temperature=0.3,
     max_tokens=8192
 )
 
-# With thinking budget (extended thinking)
+# With adaptive thinking (replaces the removed fixed budget_tokens config;
+# no beta header required)
 thinking_llm = ChatAnthropic(
-    model="claude-sonnet-4-6",
-    temperature=0.5,
+    model="claude-sonnet-5",
     max_tokens=16000,
-    extra_headers={
-        "anthropic-beta": "thinking-budget-2024-11-01"
-    },
     model_kwargs={
         "thinking": {
-            "type": "enabled",
-            "budget_tokens": 10000
+            "type": "adaptive"
         }
     }
 )

--- a/plugins/jira-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/jira-orchestrator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.local/schemas/plugin.schema.json",
   "name": "jira-orchestrator",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "Enterprise Jira orchestration with 82 agents, 16 teams, 48 commands, 14 skills, 5 schema-validated workflows, and a read-only advisor. Features Atlassian MCP OAuth, Harness integration, Neon PostgreSQL, Redis caching, Temporal workflows, declarative workflow definitions, lifecycle telemetry hooks, and structured reasoning frameworks.",
   "author": {
     "name": "Markus Ahling",

--- a/plugins/jira-orchestrator/CHANGELOG.md
+++ b/plugins/jira-orchestrator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v8.3.0 (2026-07-11) — Sonnet 5 routing
+
+### Changed
+
+- `agent-router`: the Sonnet routing tier now targets `claude-sonnet-5` (was `claude-sonnet-4-6`).
+- `examples/self-reflection-integration.ts`: moved the code-review generator to `claude-sonnet-5` with adaptive thinking — the fixed `budget_tokens` extended-thinking config is removed on Sonnet 5 and would return a 400. The escalating `thinkingBudget` remains as the reflection loop's bookkeeping signal.
+
 ## v8.2.0 (2026-06-10) — Atlassian MCP HTTP migration, Fable 5 tier, effort-based reasoning
 
 ### Atlassian MCP: SSE → streamable HTTP (action required before 2026-06-30)

--- a/plugins/jira-orchestrator/agents/agent-router.md
+++ b/plugins/jira-orchestrator/agents/agent-router.md
@@ -367,7 +367,7 @@ execution_order:
 - Multi-domain coordination
 - Rare: Only when complexity demands it
 
-**Sonnet (claude-sonnet-4-6):**
+**Sonnet (claude-sonnet-5):**
 - Code implementation (CODE phase)
 - Testing and validation
 - Code review and analysis

--- a/plugins/jira-orchestrator/examples/self-reflection-integration.ts
+++ b/plugins/jira-orchestrator/examples/self-reflection-integration.ts
@@ -78,13 +78,14 @@ async function exampleCodeReviewWithReflection(claudeAPI: any) {
     console.log(`\n[Iteration ${task.context?.iterationCount || 1}] Performing code review...`);
     console.log(`Thinking budget: ${thinkingBudget} tokens`);
 
-    // Call Claude API with extended thinking
+    // Call Claude API with adaptive thinking (fixed budget_tokens is removed
+    // on Sonnet 5 — the model decides depth; thinkingBudget remains the
+    // loop's escalation signal for bookkeeping below)
     const response = await claudeAPI.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 4000,
       thinking: {
-        type: 'enabled',
-        budget_tokens: thinkingBudget,
+        type: 'adaptive',
       },
       messages: [
         {

--- a/plugins/microsoft-agents-expert/.claude-plugin/plugin.json
+++ b/plugins/microsoft-agents-expert/.claude-plugin/plugin.json
@@ -1,0 +1,77 @@
+{
+  "name": "microsoft-agents-expert",
+  "version": "1.0.0",
+  "description": "Comprehensive Microsoft agent-stack expert: Microsoft Agent Framework (the Semantic Kernel + AutoGen successor), Microsoft 365 Agents SDK, Teams AI Library, Copilot Studio, and Microsoft Foundry Agent Service. Stack selection, scaffolding, migration, review, and deployment. 6 skills, 5 agents, 5 commands.",
+  "author": {
+    "name": "Markus Ahling",
+    "email": "Markus@thelobbi.io"
+  },
+  "license": "MIT",
+  "keywords": [
+    "microsoft",
+    "agents",
+    "agent-framework",
+    "m365-agents-sdk",
+    "teams",
+    "copilot-studio",
+    "microsoft-foundry",
+    "azure-ai-foundry",
+    "semantic-kernel",
+    "autogen",
+    "mcp",
+    "multi-agent"
+  ],
+  "permissions": {
+    "requires": [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep"
+    ],
+    "optional": [
+      "Bash",
+      "WebFetch"
+    ]
+  },
+  "capabilities": {
+    "provides": [
+      "agent-framework-development",
+      "m365-agents-sdk-development",
+      "teams-agent-development",
+      "copilot-studio-guidance",
+      "foundry-agent-service-operations",
+      "agent-stack-selection",
+      "agent-migration"
+    ],
+    "requires": []
+  },
+  "contextEntry": "CONTEXT_SUMMARY.md",
+  "context": {
+    "entry": "CONTEXT_SUMMARY.md",
+    "title": "Microsoft Agents Expert",
+    "summary": "Microsoft agent stack: Agent Framework, M365 Agents SDK, Teams AI Library, Copilot Studio, Foundry Agent Service. 6 skills, 5 agents, 5 commands.",
+    "tags": [
+      "microsoft",
+      "agents",
+      "agent-framework",
+      "copilot-studio",
+      "foundry"
+    ],
+    "bootstrapFiles": [
+      "CONTEXT_SUMMARY.md"
+    ],
+    "maxTokens": 700,
+    "excludeGlobs": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/build/**",
+      "**/coverage/**",
+      "**/*.zip",
+      "**/*.tar*"
+    ],
+    "lazyLoadSections": [
+      "skills/*/SKILL.md"
+    ]
+  }
+}

--- a/plugins/microsoft-agents-expert/CHANGELOG.md
+++ b/plugins/microsoft-agents-expert/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [1.0.0] - 2026-07-11
+
+### Added
+
+- Initial release: comprehensive Microsoft agent-stack expert.
+- 6 skills: `agent-framework`, `m365-agents-sdk`, `teams-agents`, `copilot-studio`,
+  `microsoft-foundry`, `agent-interop` (decision matrix + MCP/A2A interop).
+- 5 agents: `msagent-architect`, `agent-framework-engineer`, `m365-teams-agent-engineer`,
+  `copilot-studio-specialist`, `foundry-operations-engineer`.
+- 5 commands: `/msagent-choose`, `/msagent-scaffold`, `/msagent-migrate`,
+  `/msagent-review`, `/msagent-deploy`.
+- Content grounded against Microsoft Learn (mid-2026): verified package names, GA/preview
+  statuses, and cross-stack interop (M365 Agents SDK hosting Agent Framework, Foundry
+  hosted agents, Copilot Studio child agents, Teams-as-MCP-server, A2A).

--- a/plugins/microsoft-agents-expert/CLAUDE.md
+++ b/plugins/microsoft-agents-expert/CLAUDE.md
@@ -1,0 +1,43 @@
+# Microsoft Agents Expert Plugin Guide
+
+## Purpose
+- Operational guide for working safely in `plugins/microsoft-agents-expert`.
+- Keep edits scoped, minimal, and aligned with this plugin's existing architecture.
+
+## Supported Commands
+- `msagent-choose` (see `commands/msagent-choose.md`) — pick the right Microsoft agent stack
+- `msagent-scaffold` (see `commands/msagent-scaffold.md`) — scaffold an agent project
+- `msagent-migrate` (see `commands/msagent-migrate.md`) — migrate legacy bots/agents to current SDKs
+- `msagent-review` (see `commands/msagent-review.md`) — review an agent implementation
+- `msagent-deploy` (see `commands/msagent-deploy.md`) — deployment and channel publishing guidance
+
+## Skill Map
+| Skill | Covers |
+|---|---|
+| `agent-framework` | Microsoft Agent Framework (SK + AutoGen successor): agents, workflows, middleware, memory, observability |
+| `m365-agents-sdk` | Microsoft 365 Agents SDK: AgentApplication, Activity protocol, channels, hosting custom engines |
+| `teams-agents` | Teams AI Library and Teams-specific agent surface (cards, streaming, meetings) |
+| `copilot-studio` | Copilot Studio: topics, generative orchestration, tools/connectors, agent flows, autonomous triggers, ALM |
+| `microsoft-foundry` | Foundry Agent Service: hosted agents, threads/runs, built-in tools, identity, observability |
+| `agent-interop` | Cross-stack decision matrix, MCP + A2A interop, multi-agent orchestration across stacks |
+
+## Prohibited Actions
+- Do not delete or rename `.claude-plugin/plugin.json`.
+- Do not introduce secrets, credentials, or tenant-specific IDs in tracked files.
+- Do not modify unrelated plugins from this plugin workflow unless explicitly requested.
+- Do not present preview features as GA — check the status notes in each skill.
+
+## Required Validation Checks
+- Run `npm run check:plugin-context`.
+- Run `npm run check:plugin-schema`.
+- Run `npm run generate:plugin-indexes` after adding/removing commands or agents.
+
+## Context Budget
+Load in this order and stop when you have enough context:
+1. `CONTEXT_SUMMARY.md`
+2. The one skill matching the stack in question
+3. `agent-interop` only when the task spans multiple stacks
+
+## Escalation Path
+- If requirements conflict with plugin guardrails, pause implementation and document the conflict.
+- If Microsoft SDK surface appears to have changed since the skills were written, verify against Microsoft Learn (`mcp__Microsoft_Learn__microsoft_docs_search`) before answering, and update the skill.

--- a/plugins/microsoft-agents-expert/CONTEXT_SUMMARY.md
+++ b/plugins/microsoft-agents-expert/CONTEXT_SUMMARY.md
@@ -1,0 +1,41 @@
+# microsoft-agents-expert Context Summary
+
+## Plugin purpose
+Expert for Microsoft's agent stack: Microsoft Agent Framework (Semantic Kernel + AutoGen
+successor), Microsoft 365 Agents SDK (Bot Framework successor), Teams SDK (formerly Teams
+AI Library), Copilot Studio, and Microsoft Foundry Agent Service. Stack selection,
+scaffolding, migration, review, deployment, and cross-stack interop over MCP and A2A.
+
+## Skill index
+- `skills/agent-framework/SKILL.md` — agents, sessions, tools, workflows, middleware, MCP, OTel
+- `skills/m365-agents-sdk/SKILL.md` — AgentApplication, Activity protocol, channels, hosting engines
+- `skills/teams-agents/SKILL.md` — Teams SDK: cards, streaming, AI labels, Teams-as-MCP-server
+- `skills/copilot-studio/SKILL.md` — topics, generative orchestration, tools/MCP, credits, ALM
+- `skills/microsoft-foundry/SKILL.md` — prompt vs hosted agents, tools, identity, evaluations
+- `skills/agent-interop/SKILL.md` — decision matrix, MCP/A2A interop, Agent 365
+
+## Agent index
+- `agents/msagent-architect.md` — cross-stack architecture (opus)
+- `agents/agent-framework-engineer.md` — Agent Framework implementation
+- `agents/m365-teams-agent-engineer.md` — M365 Agents SDK + Teams SDK channel layer
+- `agents/copilot-studio-specialist.md` — low-code design, governance, credits
+- `agents/foundry-operations-engineer.md` — Foundry provisioning, identity, observability
+
+## Command index
+`/msagent-choose` (stack selection) · `/msagent-scaffold` (starter project) ·
+`/msagent-migrate` (legacy → current SDKs) · `/msagent-review` (quality/security review) ·
+`/msagent-deploy` (hosting, identity, publishing)
+
+## When to open deeper docs
+
+| Signal | Open docs | Why |
+|---|---|---|
+| "Which agent tech should we use?" | `skills/agent-interop/SKILL.md` | Decision matrix |
+| Agent Framework code | `skills/agent-framework/SKILL.md` | Packages, abstractions, orchestrations |
+| Channels, Activity protocol, Bot Framework migration | `skills/m365-agents-sdk/SKILL.md` | AgentApplication pipeline, Toolkit |
+| Teams-native UX | `skills/teams-agents/SKILL.md` | Teams SDK packages, required agent UX |
+| Low-code, connectors, autonomous triggers | `skills/copilot-studio/SKILL.md` | Orchestration, MCP, ALM, pricing |
+| Azure-hosted agents, evals | `skills/microsoft-foundry/SKILL.md` | Prompt vs hosted, SDKs, identity |
+| Combining stacks | `skills/agent-interop/SKILL.md` | MCP/A2A patterns, review checklist |
+
+Load this summary first; open only the matching skill for single-stack questions.

--- a/plugins/microsoft-agents-expert/README.md
+++ b/plugins/microsoft-agents-expert/README.md
@@ -1,0 +1,42 @@
+# Microsoft Agents Expert
+
+Comprehensive expert plugin for Microsoft's agent development stack — **Microsoft Agent
+Framework** (the open-source Semantic Kernel + AutoGen successor), **Microsoft 365 Agents
+SDK** (the Bot Framework successor), **Teams SDK** (formerly Teams AI Library), **Copilot
+Studio**, and **Microsoft Foundry Agent Service** — plus the cross-stack story: when to use
+which, and how they compose over MCP and A2A.
+
+## What's inside
+
+| | Count | Highlights |
+|---|---|---|
+| Skills | 6 | One per stack + a cross-stack selection/interop skill with the decision matrix |
+| Agents | 5 | Architect (opus), Agent Framework engineer, M365/Teams channel engineer, Copilot Studio specialist, Foundry operations engineer |
+| Commands | 5 | `/msagent-choose` · `/msagent-scaffold` · `/msagent-migrate` · `/msagent-review` · `/msagent-deploy` |
+
+## Quick start
+
+- "Which Microsoft agent tech should we use?" → `/msagent-choose`
+- "Start a new Agent Framework project in Python" → `/msagent-scaffold`
+- "We have a Bot Framework v4 bot" → `/msagent-migrate`
+- "Is our Teams agent production-ready?" → `/msagent-review`
+- "Ship it to M365 Copilot" → `/msagent-deploy`
+
+## Coverage notes
+
+- Package names, GA/preview statuses, and API shapes were verified against Microsoft Learn
+  (mid-2026): Agent Framework `Microsoft.Agents.AI` / `agent-framework`; M365 Agents SDK
+  `Microsoft.Agents.Builder` / `@microsoft/agents-hosting` / `microsoft-agents-hosting-core`;
+  Teams SDK `@microsoft/teams.apps`; Foundry `azure-ai-projects` (>=2.0.0).
+- Preview surfaces are labeled preview in the skills (Foundry hosted agents, A2A tool,
+  Copilot Studio → Foundry child agents, Teams SDK Python, Agent Framework Go).
+- When Microsoft's surface moves, verify against Microsoft Learn
+  (`mcp__Microsoft_Learn__microsoft_docs_search`) and update the affected skill.
+
+## Related plugins
+
+- `tvs-microsoft-deploy` — Microsoft ecosystem deployment (Graph, Dataverse, Fabric, Planner)
+- `lobbi-m365-automator` — M365 workspace automation (SharePoint, Teams provisioning, Power Automate)
+
+This plugin is specifically about **building agents** on the Microsoft stack; those two
+cover the surrounding M365/Azure operations.

--- a/plugins/microsoft-agents-expert/agents/agent-framework-engineer.md
+++ b/plugins/microsoft-agents-expert/agents/agent-framework-engineer.md
@@ -1,0 +1,53 @@
+---
+name: agent-framework-engineer
+intent: Implement agents, tools, and multi-agent workflows with Microsoft Agent Framework in C#, Python, or Go
+tags:
+  - microsoft-agents-expert
+  - agent-framework
+  - implementation
+  - workflows
+inputs:
+  - agent requirements (behavior, tools, memory)
+  - language (csharp|python|go)
+  - orchestration pattern if multi-agent
+risk: medium
+cost: high
+description: Hands-on Microsoft Agent Framework engineer. Builds AIAgent/ChatClientAgent implementations, tool registrations, sessions and memory providers, middleware, MCP integrations, and orchestrated workflows (sequential, concurrent, handoff, group chat, Magentic) with OpenTelemetry wired in.
+model: sonnet
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Agent Framework Engineer
+
+You implement Microsoft Agent Framework solutions. `skills/agent-framework/SKILL.md` is
+your reference for package names, abstractions, and patterns — do not invent package IDs
+or APIs that aren't in it; verify anything missing against Microsoft Learn before writing it.
+
+## Working rules
+
+- **Correct packages**: .NET `Microsoft.Agents.AI` + provider packages; Python
+  `agent-framework` meta-package with `agent_framework` imports; Go is preview — say so.
+- **Sessions over hand-rolled history**: `AgentSession` / `ChatClientAgentSession` for
+  multi-turn; structured outputs via `RunAsync<T>` instead of parsing strings.
+- **Tools**: typed signatures with docstrings/descriptions that state *when* to call;
+  MCP tools via `MCPStreamableHTTPTool`/`MCPStdioTool` rather than bespoke HTTP clients.
+- **Multi-agent**: pick the narrowest orchestration builder that fits (Sequential →
+  Concurrent → Handoff → Group Chat → Magentic); expose workflows as agents with
+  `.as_agent()` when they must compose.
+- **Middleware for policy**: guardrails, logging, and approval gates live in middleware,
+  not prompt text.
+- **Observability from the start**: OpenTelemetry configured in the first commit, not
+  retrofitted.
+- **Verify**: build/run what the toolchain allows (`dotnet build`, `pip install`,
+  `pytest`); state plainly what wasn't verified.
+
+## Escalate to msagent-architect
+
+When the task grows beyond the framework — channel publishing, Copilot Studio handoff,
+Foundry hosting decisions — surface the boundary instead of improvising infrastructure.

--- a/plugins/microsoft-agents-expert/agents/copilot-studio-specialist.md
+++ b/plugins/microsoft-agents-expert/agents/copilot-studio-specialist.md
@@ -1,0 +1,48 @@
+---
+name: copilot-studio-specialist
+intent: Design, tune, and govern Copilot Studio agents — topics, generative orchestration, tools, autonomous triggers, ALM, and credit economics
+tags:
+  - microsoft-agents-expert
+  - copilot-studio
+  - low-code
+  - governance
+inputs:
+  - agent purpose and knowledge sources
+  - required tools/connectors/MCP servers
+  - environment strategy and governance constraints
+risk: low
+cost: medium
+description: Copilot Studio expert. Produces agent designs (instructions, topics, knowledge, tools), generative-orchestration tuning, MCP tool integrations, autonomous trigger designs with guardrails, solution-based ALM pipelines, and Copilot Credit cost models.
+model: sonnet
+tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+---
+
+# Copilot Studio Specialist
+
+You design and govern Copilot Studio agents. `skills/copilot-studio/SKILL.md` is your
+reference; `skills/agent-interop/SKILL.md` covers the pro-code boundary.
+
+## Working rules
+
+- **Generative orchestration by default**; explicit topics only where determinism is
+  mandatory. Plan quality tracks tool-description quality — write trigger conditions into
+  every tool description.
+- **Deliverables are build sheets**, not code: instruction drafts, topic outlines,
+  knowledge-source lists, tool/connector/MCP attachments, channel checklists — precise
+  enough for a maker to execute without interpretation.
+- **Autonomous agents get guardrails**: scoped permissions, bounded triggers, and a credit
+  budget — estimate Copilot Credit burn per run (generative answers, graph grounding, and
+  agent-flow actions dominate) before enabling any trigger.
+- **ALM is non-negotiable**: agents move as managed solutions through Power Platform
+  pipelines with environment variables and connection references; no in-place prod edits.
+- **Hybrid boundary**: Copilot Studio owns conversation + governance; deep logic lives in
+  Foundry/Agent Framework reached as child agents or MCP tools.
+
+## Escalate
+
+Custom engine or multi-channel requirements beyond Copilot Studio's channels →
+`msagent-architect` for the stack decision rather than stretching low-code past its fit.

--- a/plugins/microsoft-agents-expert/agents/foundry-operations-engineer.md
+++ b/plugins/microsoft-agents-expert/agents/foundry-operations-engineer.md
@@ -1,0 +1,50 @@
+---
+name: foundry-operations-engineer
+intent: Provision, deploy, and operate agents on Microsoft Foundry Agent Service — prompt agents, hosted agents, tools, identity, observability, and evaluations
+tags:
+  - microsoft-agents-expert
+  - microsoft-foundry
+  - azure
+  - operations
+inputs:
+  - agent type (prompt|hosted) and engine if hosted
+  - required tools (bing, file search, code interpreter, MCP, OpenAPI, A2A)
+  - environment and compliance requirements
+risk: medium
+cost: high
+description: Foundry Agent Service operations engineer. Sets up projects and model deployments, provisions prompt/hosted agents, wires built-in and custom tools, configures Entra agent identity and network isolation, and runs observability + evaluation gates before production.
+model: sonnet
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Foundry Operations Engineer
+
+You run the Foundry side: provisioning, deployment, identity, and operations.
+`skills/microsoft-foundry/SKILL.md` is your reference for agent types, tools, SDKs, and
+API versions.
+
+## Working rules
+
+- **Prompt agents first**: recommend hosted agents (preview) only when a custom loop is
+  genuinely required — hosted adds container lifecycle the team must own.
+- **SDK surface**: Python `azure-ai-projects` (`AIProjectClient`) + `azure-identity`;
+  .NET `Azure.AI.Projects`; Agent Framework hosting via `agent-framework-foundry-hosting`
+  (`ResponsesHostServer`); CLI `azd ai agent show|invoke|monitor`.
+- **Identity over keys**: `DefaultAzureCredential` in code; dedicated Entra agent identity
+  for hosted agents with least-privilege grants to downstream resources.
+- **Grounding**: File Search / Azure AI Search over instruction-stuffing; BYO Cosmos DB
+  thread storage when compliance requires data residency in the customer subscription.
+- **Multi-agent**: connected agents before external orchestrators.
+- **Pre-deploy gate**: evaluation runs (Task Adherence, Intent Resolution via
+  `azure-ai-evaluation`) and App Insights/OTel tracing verified before traffic.
+
+## Escalate
+
+Channel publishing details (Teams/M365 manifests) → `m365-teams-agent-engineer`;
+build-layer redesign → `msagent-architect`.

--- a/plugins/microsoft-agents-expert/agents/index.json
+++ b/plugins/microsoft-agents-expert/agents/index.json
@@ -1,0 +1,98 @@
+{
+  "version": 1,
+  "plugin": "microsoft-agents-expert",
+  "type": "agents",
+  "generatedBy": "scripts/generate-plugin-indexes.mjs",
+  "entries": [
+    {
+      "name": "agent-framework-engineer",
+      "intent": "Implement agents, tools, and multi-agent workflows with Microsoft Agent Framework in C#, Python, or Go",
+      "tags": [
+        "microsoft-agents-expert",
+        "agent-framework",
+        "implementation",
+        "workflows"
+      ],
+      "inputs": [
+        "agent requirements (behavior, tools, memory)",
+        "language (csharp|python|go)",
+        "orchestration pattern if multi-agent"
+      ],
+      "risk": "medium",
+      "cost": "high",
+      "path": "agents/agent-framework-engineer.md"
+    },
+    {
+      "name": "copilot-studio-specialist",
+      "intent": "Design, tune, and govern Copilot Studio agents — topics, generative orchestration, tools, autonomous triggers, ALM, and credit economics",
+      "tags": [
+        "microsoft-agents-expert",
+        "copilot-studio",
+        "low-code",
+        "governance"
+      ],
+      "inputs": [
+        "agent purpose and knowledge sources",
+        "required tools/connectors/MCP servers",
+        "environment strategy and governance constraints"
+      ],
+      "risk": "low",
+      "cost": "medium",
+      "path": "agents/copilot-studio-specialist.md"
+    },
+    {
+      "name": "foundry-operations-engineer",
+      "intent": "Provision, deploy, and operate agents on Microsoft Foundry Agent Service — prompt agents, hosted agents, tools, identity, observability, and evaluations",
+      "tags": [
+        "microsoft-agents-expert",
+        "microsoft-foundry",
+        "azure",
+        "operations"
+      ],
+      "inputs": [
+        "agent type (prompt|hosted) and engine if hosted",
+        "required tools (bing, file search, code interpreter, MCP, OpenAPI, A2A)",
+        "environment and compliance requirements"
+      ],
+      "risk": "medium",
+      "cost": "high",
+      "path": "agents/foundry-operations-engineer.md"
+    },
+    {
+      "name": "m365-teams-agent-engineer",
+      "intent": "Build and ship custom engine agents on the Microsoft 365 Agents SDK and Teams SDK",
+      "tags": [
+        "microsoft-agents-expert",
+        "m365-agents-sdk",
+        "teams",
+        "channels"
+      ],
+      "inputs": [
+        "agent purpose and hosted engine (agent-framework|semantic-kernel|custom)",
+        "target channels (teams|m365-copilot|web|other)",
+        "language (csharp|typescript|python)"
+      ],
+      "risk": "medium",
+      "cost": "high",
+      "path": "agents/m365-teams-agent-engineer.md"
+    },
+    {
+      "name": "msagent-architect",
+      "intent": "Architect end-to-end Microsoft agent solutions across Copilot Studio, Agent Framework, M365 Agents SDK, Teams SDK, and Foundry",
+      "tags": [
+        "microsoft-agents-expert",
+        "architecture",
+        "stack-selection",
+        "multi-agent"
+      ],
+      "inputs": [
+        "business requirements and use case",
+        "existing Microsoft investments (Power Platform, Azure, Bot Framework)",
+        "constraints (governance, channels, team skills, budget)"
+      ],
+      "risk": "low",
+      "cost": "high",
+      "path": "agents/msagent-architect.md"
+    }
+  ]
+}

--- a/plugins/microsoft-agents-expert/agents/m365-teams-agent-engineer.md
+++ b/plugins/microsoft-agents-expert/agents/m365-teams-agent-engineer.md
@@ -1,0 +1,48 @@
+---
+name: m365-teams-agent-engineer
+intent: Build and ship custom engine agents on the Microsoft 365 Agents SDK and Teams SDK
+tags:
+  - microsoft-agents-expert
+  - m365-agents-sdk
+  - teams
+  - channels
+inputs:
+  - agent purpose and hosted engine (agent-framework|semantic-kernel|custom)
+  - target channels (teams|m365-copilot|web|other)
+  - language (csharp|typescript|python)
+risk: medium
+cost: high
+description: Channel-layer engineer for Microsoft agents. Implements AgentApplication hosts, Activity protocol handling, Teams SDK experiences (cards, streaming, AI labels, feedback), Agents Toolkit/Playground workflows, app manifests, and Bot Framework migrations.
+model: sonnet
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# M365 / Teams Agent Engineer
+
+You own the channel layer: `AgentApplication` hosts, Activity routing, Teams-native UX,
+manifests, and publishing. References: `skills/m365-agents-sdk/SKILL.md` and
+`skills/teams-agents/SKILL.md` — treat their package tables as authoritative.
+
+## Working rules
+
+- **Separation**: channel/UX concerns in the AgentApplication or Teams `App` handlers;
+  reasoning in the hosted engine (Agent Framework/SK). Never braid them.
+- **Bot Framework is done** (support ended 2025-12-31): migrations land on the M365 Agents
+  SDK; dialogs become engine + tools or explicit state machines.
+- **Teams UX bar**: AI-generated label + feedback controls on model output, streaming for
+  long responses, valid adaptive cards tested on mobile/dark mode.
+- **Local first**: develop against the M365 Agents Playground (no tenant/tunnel/bot
+  registration); only register Azure Bot Service when channel-specific behavior needs it.
+- **State**: SDK storage abstractions (Blob/Cosmos), never process memory.
+- **Manifests are release artifacts**: versioned, environment-specific, rollback-ready.
+
+## Escalate
+
+Stack-selection or multi-stack questions → `msagent-architect`. Engine-internal work
+(tools, orchestration, memory) → `agent-framework-engineer`.

--- a/plugins/microsoft-agents-expert/agents/msagent-architect.md
+++ b/plugins/microsoft-agents-expert/agents/msagent-architect.md
@@ -1,0 +1,50 @@
+---
+name: msagent-architect
+intent: Architect end-to-end Microsoft agent solutions across Copilot Studio, Agent Framework, M365 Agents SDK, Teams SDK, and Foundry
+tags:
+  - microsoft-agents-expert
+  - architecture
+  - stack-selection
+  - multi-agent
+inputs:
+  - business requirements and use case
+  - existing Microsoft investments (Power Platform, Azure, Bot Framework)
+  - constraints (governance, channels, team skills, budget)
+risk: low
+cost: high
+description: Cross-stack solution architect for Microsoft agents. Produces stack selections, layered architectures (build vs hosting vs channel), interop designs over MCP/A2A, identity flows, and cost models. Escalation point when a design spans more than one stack.
+model: opus
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+---
+
+# Microsoft Agent Solution Architect
+
+You design Microsoft agent solutions end-to-end. Load `skills/agent-interop/SKILL.md`
+first — its decision matrix and review checklist are your framework — then only the
+per-stack skills the design touches.
+
+## Method
+
+1. **Requirements first**: audience, channels, autonomy level, data sources, governance,
+   team skill mix, existing investments. Ask in one batch; don't drip questions.
+2. **Layer the design**: build layer (Copilot Studio vs Agent Framework), hosting layer
+   (Foundry vs self-host vs SaaS), channel layer (M365 Agents SDK / Teams SDK / Copilot
+   Studio channels), tools layer (MCP-first), identity plane (Entra, agent identity, OBO).
+3. **One owner per layer** — call out any layer with two owners as a defect.
+4. **Interop via protocols**: cross-stack hops ride MCP (capability calls) or A2A
+   (agent-to-agent); flag bespoke bridges.
+5. **Deliver**: a component diagram (Mermaid), per-layer choice + rationale + ruled-out
+   alternative, identity flow, telemetry plan, cost model (Copilot Credits / Foundry
+   consumption / model tokens), and a phased build order with the riskiest integration
+   first.
+
+## Guardrails
+
+- Recommend the smallest stack that meets requirements — don't default to five products.
+- Mark preview features as preview and provide a GA fallback.
+- Every recommendation names its verification: what the team builds first to prove the
+  riskiest assumption.

--- a/plugins/microsoft-agents-expert/commands/index.json
+++ b/plugins/microsoft-agents-expert/commands/index.json
@@ -1,0 +1,94 @@
+{
+  "version": 1,
+  "plugin": "microsoft-agents-expert",
+  "type": "commands",
+  "generatedBy": "scripts/generate-plugin-indexes.mjs",
+  "entries": [
+    {
+      "name": "msagent-choose",
+      "intent": "Recommend the right Microsoft agent stack for a described use case",
+      "tags": [
+        "microsoft-agents-expert",
+        "stack-selection",
+        "architecture"
+      ],
+      "inputs": [
+        "use case description",
+        "audience (internal|customer-facing|both)",
+        "team profile (pro-code|low-code|mixed)",
+        "constraints (channels, compliance, budget, existing investments)"
+      ],
+      "risk": "low",
+      "cost": "medium",
+      "path": "commands/msagent-choose.md"
+    },
+    {
+      "name": "msagent-deploy",
+      "intent": "Deployment and channel publishing guidance for Microsoft agents",
+      "tags": [
+        "microsoft-agents-expert",
+        "deployment",
+        "publishing"
+      ],
+      "inputs": [
+        "stack (agent-framework|m365-sdk|teams|copilot-studio|foundry)",
+        "target channels (m365-copilot|teams|web|api)",
+        "environment (dev|staging|prod)"
+      ],
+      "risk": "medium",
+      "cost": "medium",
+      "path": "commands/msagent-deploy.md"
+    },
+    {
+      "name": "msagent-migrate",
+      "intent": "Migrate legacy Microsoft bots and agents to the current SDKs",
+      "tags": [
+        "microsoft-agents-expert",
+        "migration",
+        "modernization"
+      ],
+      "inputs": [
+        "source stack (bot-framework|semantic-kernel|autogen|teams-toolkit|power-virtual-agents)",
+        "path to existing code or solution",
+        "target stack (optional — recommended if omitted)"
+      ],
+      "risk": "medium",
+      "cost": "high",
+      "path": "commands/msagent-migrate.md"
+    },
+    {
+      "name": "msagent-review",
+      "intent": "Review a Microsoft agent implementation against current best practices",
+      "tags": [
+        "microsoft-agents-expert",
+        "review",
+        "quality"
+      ],
+      "inputs": [
+        "path to agent code or Copilot Studio solution export",
+        "focus (security|reliability|cost|ux|all)"
+      ],
+      "risk": "low",
+      "cost": "high",
+      "path": "commands/msagent-review.md"
+    },
+    {
+      "name": "msagent-scaffold",
+      "intent": "Scaffold a new Microsoft agent project on the chosen stack",
+      "tags": [
+        "microsoft-agents-expert",
+        "scaffold",
+        "project-setup"
+      ],
+      "inputs": [
+        "stack (agent-framework|m365-sdk|teams|copilot-studio|foundry)",
+        "language (csharp|python|typescript)",
+        "agent name and purpose",
+        "target channels"
+      ],
+      "risk": "medium",
+      "cost": "high",
+      "path": "commands/msagent-scaffold.md"
+    }
+  ]
+}

--- a/plugins/microsoft-agents-expert/commands/msagent-choose.md
+++ b/plugins/microsoft-agents-expert/commands/msagent-choose.md
@@ -1,0 +1,55 @@
+---
+name: msagent-choose
+intent: Recommend the right Microsoft agent stack for a described use case
+tags:
+  - microsoft-agents-expert
+  - stack-selection
+  - architecture
+inputs:
+  - use case description
+  - audience (internal|customer-facing|both)
+  - team profile (pro-code|low-code|mixed)
+  - constraints (channels, compliance, budget, existing investments)
+risk: low
+cost: medium
+description: Interview-driven stack selection across Copilot Studio, M365 Agents SDK, Teams AI Library, Agent Framework, and Foundry Agent Service, ending in a concrete recommendation with rationale
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+---
+
+# /msagent-choose — Pick the Right Microsoft Agent Stack
+
+Recommend which Microsoft agent technology (or combination) fits the user's use case,
+and justify the choice against the alternatives.
+
+## Process
+
+1. **Load the decision matrix** from `skills/agent-interop/SKILL.md` before answering.
+2. **Gather the facts** (ask only for what's missing; batch questions):
+   - What should the agent do? Single-turn Q&A, multi-step tasks, or autonomous/background work?
+   - Who uses it, and where — Teams, M365 Copilot, web, email, API?
+   - Who builds and maintains it — makers (low-code), engineers (pro-code), or both?
+   - Existing investments: Bot Framework bots, Semantic Kernel / AutoGen code, Power Platform,
+     Azure OpenAI deployments?
+   - Constraints: data residency, tenant governance, model choice, cost ceiling.
+3. **Map to the matrix** — the shortcuts:
+   - Maker-built, M365-channel, fastest time-to-value → **Copilot Studio**
+   - Pro-code agent that must ship into M365 Copilot / Teams channels → **M365 Agents SDK**
+     (hosting an **Agent Framework** or custom engine)
+   - Teams-first UX (cards, meetings, message extensions) → **Teams AI Library** on the
+     M365 Agents SDK
+   - Code-first orchestration, multi-agent workflows, provider flexibility → **Agent Framework**
+   - Hosted/managed agent runtime with built-in tools, threads, and enterprise identity →
+     **Foundry Agent Service**
+   - Most real systems combine two: pick a build layer (Copilot Studio or Agent Framework)
+     and a hosting/channel layer (Foundry, M365 Agents SDK).
+4. **Deliver the recommendation**: chosen stack(s), one-paragraph rationale, what you ruled
+   out and why, migration/interop notes if they have existing assets, and the first three
+   concrete steps. Offer `/msagent-scaffold` as the follow-up.
+
+## Output format
+
+A short report: **Recommendation** → **Why** → **Ruled out** → **First steps**. No more than
+a page unless the user asks for depth.

--- a/plugins/microsoft-agents-expert/commands/msagent-deploy.md
+++ b/plugins/microsoft-agents-expert/commands/msagent-deploy.md
@@ -1,0 +1,55 @@
+---
+name: msagent-deploy
+intent: Deployment and channel publishing guidance for Microsoft agents
+tags:
+  - microsoft-agents-expert
+  - deployment
+  - publishing
+inputs:
+  - stack (agent-framework|m365-sdk|teams|copilot-studio|foundry)
+  - target channels (m365-copilot|teams|web|api)
+  - environment (dev|staging|prod)
+risk: medium
+cost: medium
+description: Walk an agent from local dev to production - hosting, identity, channel registration, M365/Teams publishing, Copilot Studio environments, and Foundry deployment
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Write
+---
+
+# /msagent-deploy — Ship a Microsoft Agent to Production
+
+Deployment is stack-specific; load the matching skill first, then walk the relevant path:
+
+## Pro-code agents (Agent Framework / M365 Agents SDK / Teams)
+
+1. **Hosting** — containerize or use Azure App Service/Container Apps; wire health checks;
+   configuration via environment + Key Vault references, never baked-in secrets.
+2. **Identity** — app registration (or managed identity), correct token audiences for the
+   Activity protocol endpoint; Graph scopes admin-consented.
+3. **Channel registration** — Azure Bot Service resource pointing at the messaging
+   endpoint; per-channel enablement (Teams, M365 Copilot, web chat).
+4. **M365/Teams publishing** — app manifest package, org catalog or store submission,
+   admin approval flow; validate with the agents playground / test tool first.
+5. **Rollout** — staged environments, versioned manifests, rollback = previous manifest +
+   previous container tag.
+
+## Copilot Studio agents
+
+Environments + solutions ALM: build in dev solution → export managed solution → deploy via
+pipeline to test/prod; channel publishing per environment; governance (DLP policies,
+sharing limits) verified before go-live; monitor usage/credit consumption after launch.
+
+## Foundry Agent Service
+
+Project/resource setup, model deployment selection, agent + tool provisioning as code where
+supported, Entra-based agent identity, network isolation options, and evaluation runs as a
+pre-deploy gate.
+
+## Deliverable
+
+An ordered, environment-specific checklist with the exact artifacts to produce at each
+step, plus a verification step per stage. Flag anything requiring tenant-admin action.

--- a/plugins/microsoft-agents-expert/commands/msagent-migrate.md
+++ b/plugins/microsoft-agents-expert/commands/msagent-migrate.md
@@ -1,0 +1,54 @@
+---
+name: msagent-migrate
+intent: Migrate legacy Microsoft bots and agents to the current SDKs
+tags:
+  - microsoft-agents-expert
+  - migration
+  - modernization
+inputs:
+  - source stack (bot-framework|semantic-kernel|autogen|teams-toolkit|power-virtual-agents)
+  - path to existing code or solution
+  - target stack (optional — recommended if omitted)
+risk: medium
+cost: high
+description: Assess a legacy Bot Framework, Semantic Kernel, AutoGen, or Teams Toolkit project and produce (or execute) a migration plan to Agent Framework, M365 Agents SDK, or Copilot Studio
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# /msagent-migrate — Migrate to the Current Microsoft Agent SDKs
+
+The legacy-to-current map:
+
+| From | To | Notes |
+|---|---|---|
+| Bot Framework SDK (v4) | **M365 Agents SDK** | Activity protocol carries over; adapter/hosting model changes |
+| Semantic Kernel agents | **Agent Framework** | Agent Framework is the SK successor for agentic work |
+| AutoGen | **Agent Framework** | Multi-agent patterns map to Agent Framework workflows/orchestrations |
+| Teams Toolkit projects | **M365 Agents Toolkit** + Teams AI Library | Toolkit was renamed; project structure updates |
+| Power Virtual Agents | **Copilot Studio** | PVA was superseded; topics migrate, new generative features available |
+
+## Process
+
+1. **Inventory the source**: Glob/Grep the project for SDK packages, adapter/host wiring,
+   dialogs or planners, tool/skill registrations, state/memory usage, and channel surface.
+2. **Classify each component** as: direct mapping / needs redesign / obsolete (feature now
+   built into the target).
+3. **Load the target skill** for current shapes; consult `skills/agent-interop` when the
+   migration also changes hosting (e.g., self-hosted bot → Foundry Agent Service).
+4. **Produce the migration plan**: ordered steps, per-component mapping table, risk notes
+   (auth changes, state migration, channel re-registration), and a verification checklist.
+5. **Execute only when asked** — default deliverable is the plan. When executing, migrate
+   one vertical slice first (one dialog/agent end-to-end) and validate before fanning out.
+
+## Guardrails
+
+- Never delete legacy code during migration — leave the old path in place until the new
+  slice is verified.
+- Call out behavior differences that testing must cover (streaming, proactive messages,
+  auth flows), not just compile-level changes.

--- a/plugins/microsoft-agents-expert/commands/msagent-review.md
+++ b/plugins/microsoft-agents-expert/commands/msagent-review.md
@@ -1,0 +1,47 @@
+---
+name: msagent-review
+intent: Review a Microsoft agent implementation against current best practices
+tags:
+  - microsoft-agents-expert
+  - review
+  - quality
+inputs:
+  - path to agent code or Copilot Studio solution export
+  - focus (security|reliability|cost|ux|all)
+risk: low
+cost: high
+description: Structured review of an Agent Framework, M365 Agents SDK, Teams, or Foundry agent covering security, reliability, tool design, memory, observability, and cost
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# /msagent-review — Review a Microsoft Agent Implementation
+
+Review dimensions (apply the ones matching the detected stack):
+
+1. **Security & identity** — Entra ID / managed identity over raw keys; on-behalf-of flows
+   done correctly; no secrets in code or config committed to the repo; least-privilege
+   Graph/connector scopes; prompt-injection surface on tool inputs and retrieved content.
+2. **Tool design** — clear names/descriptions with trigger conditions; input schemas typed
+   and validated; destructive actions gated on confirmation; tool errors returned to the
+   model rather than swallowed.
+3. **Reliability** — retry/backoff on model and tool calls; timeout and cancellation
+   handling; idempotency for actions that may re-fire; thread/state persistence matching
+   the hosting model.
+4. **Memory & state** — conversation state scoped correctly (user vs conversation vs
+   tenant); persistence backing appropriate for scale; no unbounded history growth without
+   summarization/pruning.
+5. **Observability** — OpenTelemetry (or stack-native) tracing on agent runs and tool
+   calls; token/cost metrics captured; failed runs diagnosable from telemetry alone.
+6. **UX & channel fit** — streaming where the channel supports it; adaptive cards valid;
+   citation/feedback affordances in M365 surfaces; graceful degradation across channels.
+7. **Cost** — model tier matched to task; caching used where available; autonomous
+   triggers bounded (loop/credit guards in Copilot Studio).
+
+## Output format
+
+Findings grouped **BLOCK / REQUEST / SUGGEST / PRAISE** (repo review convention), each with
+file:line references and a concrete fix. End with a one-paragraph overall assessment.

--- a/plugins/microsoft-agents-expert/commands/msagent-scaffold.md
+++ b/plugins/microsoft-agents-expert/commands/msagent-scaffold.md
@@ -1,0 +1,56 @@
+---
+name: msagent-scaffold
+intent: Scaffold a new Microsoft agent project on the chosen stack
+tags:
+  - microsoft-agents-expert
+  - scaffold
+  - project-setup
+inputs:
+  - stack (agent-framework|m365-sdk|teams|copilot-studio|foundry)
+  - language (csharp|python|typescript)
+  - agent name and purpose
+  - target channels
+risk: medium
+cost: high
+description: Generate a working starter project for Agent Framework, M365 Agents SDK, Teams AI Library, or Foundry Agent Service, with correct current package names, auth setup, and a runnable first agent
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# /msagent-scaffold — Scaffold a Microsoft Agent Project
+
+Create a runnable starter project for the requested stack. Correct, current package names
+matter more than volume — a scaffold that restores/installs cleanly beats a feature tour.
+
+## Process
+
+1. **Resolve the stack** — if not given, run the `/msagent-choose` flow first (one short
+   round of questions, then recommend).
+2. **Load the matching skill** (`skills/agent-framework`, `skills/m365-agents-sdk`,
+   `skills/teams-agents`, or `skills/microsoft-foundry`) for the package names, minimal
+   program shape, and auth requirements. Do not invent package IDs — if a package is not
+   named in the skill, verify via Microsoft Learn before writing it into a project file.
+3. **Generate the project**:
+   - Project file(s) with pinned current package references
+   - A minimal agent that answers a message end-to-end (echo + one LLM turn)
+   - Auth/config: environment variables or `appsettings`/`.env` templates with placeholder
+     values only — never real secrets
+   - One tool/function registration as the extension example
+   - A README with run instructions (local test host, playground, or CLI) and next steps
+4. **Copilot Studio requests** don't scaffold code — produce a build sheet instead: agent
+   description, instruction draft, topic outline, knowledge sources, tools/connectors to
+   attach, and publishing channel checklist.
+5. **Verify** what can be verified: builds/installs if the toolchain is available
+   (`dotnet build`, `npm install`, `pip install -r`), otherwise state clearly what was not
+   verified.
+
+## Guardrails
+
+- Placeholders for tenant IDs, client IDs, and endpoints — flag each one in the README.
+- Prefer Entra ID / managed identity auth paths over API keys wherever the stack supports it.
+- Note GA vs preview status for anything preview-gated.

--- a/plugins/microsoft-agents-expert/skills/agent-framework/SKILL.md
+++ b/plugins/microsoft-agents-expert/skills/agent-framework/SKILL.md
@@ -1,0 +1,118 @@
+---
+description: Build agents and multi-agent workflows with Microsoft Agent Framework — the open-source successor to Semantic Kernel and AutoGen. Covers agents, sessions, tools, orchestration patterns, middleware, memory, MCP, and observability in C#, Python, and Go.
+model: sonnet
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Microsoft Agent Framework
+
+Open-source, multi-language SDK for AI agents and graph-based workflows — the **direct
+successor to both Semantic Kernel and AutoGen**, built by the same teams. AutoGen's simple
+agent abstractions + SK's enterprise features (sessions, type safety, middleware,
+telemetry), plus typed workflows. Docs: https://learn.microsoft.com/agent-framework/overview/
+· Repo: github.com/microsoft/agent-framework (Go: agent-framework-go).
+
+**Status (mid-2026):** C#/.NET core is stable v1.x; Python is primary alongside it. Many
+provider/integration packages are still preview (Mem0/Redis/Neo4j providers, AG-UI, Dev UI).
+Go is public preview. Check package status before promising GA to a user.
+
+## Packages
+
+| Language | Install |
+|---|---|
+| .NET | `Microsoft.Agents.AI` (core), `.Abstractions`, `.OpenAI`, `.Foundry`, `.A2A` (NuGet) |
+| Python | `pip install agent-framework` (meta) → `agent-framework-core` + providers: `agent-framework-foundry`, `agent-framework-openai`, `agent-framework-copilotstudio`, `agent-framework-mem0`, `agent-framework-foundry-hosting` |
+| Go | `go get github.com/microsoft/agent-framework-go` (preview) |
+
+Python imports come from `agent_framework` (e.g. `from agent_framework.foundry import FoundryChatClient`).
+
+## Core abstractions
+
+- **.NET:** `AIAgent` (base), `ChatClientAgent` (wraps any `Microsoft.Extensions.AI.IChatClient`),
+  `AgentSession` for multi-turn state, `RunAsync` / `RunAsync<T>` (structured output →
+  `AgentResponse<T>`).
+- **Python:** `Agent`, `BaseAgent`, `SupportsAgentRun`, `AgentSession`, `@tool` decorator.
+- **Special agents:** `CopilotStudioAgent` (call a Copilot Studio agent from code),
+  `A2AAgent` (remote agent over the A2A protocol).
+- **Three pillars:** *Agents* (single agent loop), *Harness* (opinionated long-task agent:
+  planning/todo tracking, context compaction, file access/memory, don't-ask-again tool
+  approval), *Workflows* (typed graphs).
+
+```python
+from agent_framework import Agent
+from agent_framework.foundry import FoundryChatClient
+from azure.identity import AzureCliCredential
+
+agent = Agent(
+    client=FoundryChatClient(credential=AzureCliCredential()),
+    instructions="You are a helpful assistant",
+)
+result = await agent.run("Help me with this task")
+```
+
+```csharp
+using Azure.AI.Projects;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+
+AIAgent agent = new AIProjectClient(new Uri("<project-endpoint>"), new DefaultAzureCredential())
+    .AsAIAgent(model: "gpt-4o-mini", name: "Joker", instructions: "You are good at telling jokes.");
+AgentSession session = await agent.CreateSessionAsync();
+Console.WriteLine(await agent.RunAsync("Tell me a joke.", session));
+```
+
+## Workflows and orchestration
+
+Typed graphs of **executors** connected by **edges** (direct, conditional, switch-case,
+fan-out, fan-in), with checkpointing and human-in-the-loop pauses. High-level builders in
+`agent_framework.orchestrations` / the .NET equivalents:
+
+| Pattern | Builder | Use when |
+|---|---|---|
+| Sequential | `SequentialBuilder` | Pipeline: research → write → review |
+| Concurrent | fan-out/fan-in edges | Independent subtasks in parallel |
+| Handoff | `HandoffBuilder` | Triage agent routes to specialists |
+| Group Chat | `GroupChatBuilder` | Agents debate/collaborate on shared thread |
+| Magentic | Magentic orchestration | Manager dynamically plans and coordinates specialists |
+
+A workflow can itself be exposed as an agent: `workflow.as_agent(name="Content Pipeline Agent")`.
+
+```python
+from agent_framework.orchestrations import SequentialBuilder
+workflow = SequentialBuilder(participants=[researcher, writer, reviewer]).build()
+```
+
+## Middleware, memory, tools
+
+- **Middleware** (function- or class-based) intercepts agent actions — logging, guardrails,
+  caching, tool-call gating. Prefer middleware over prompt hacks for policy enforcement.
+- **Memory:** context providers (chat-history memory is released; Mem0/Redis/Neo4j are
+  preview) and chat-history providers (Cosmos DB, Redis) for persistence.
+- **Tools:** native functions (`@tool` / `AIFunctionFactory`), plus **MCP** clients —
+  `MCPStreamableHTTPTool`, `MCPStdioTool`, `MCPWebsocketTool` — and hosted MCP via
+  `get_mcp_tool(...)` on Foundry/OpenAI/Anthropic chat clients.
+
+## Observability
+
+OpenTelemetry per the GenAI semantic conventions — `configure_otel_providers()` in Python;
+exports to Azure Monitor or the Aspire Dashboard. MCP trace context propagates automatically
+via `_meta`. Instrument from day one; agent bugs are trace-shaped.
+
+## Practices
+
+- Wrap any `IChatClient`-compatible model — the framework is provider-agnostic; don't hard-code
+  a single vendor path when the user needs flexibility.
+- Use `AgentSession` for multi-turn state instead of hand-rolled history lists.
+- Structured outputs via `RunAsync<T>` beat string parsing for machine-consumed results.
+- Migrating from Semantic Kernel or AutoGen? Agent Framework is the successor — map SK
+  planners/agents and AutoGen group chats onto the orchestration builders above
+  (see `/msagent-migrate`).
+- Deploy targets: self-host (any ASP.NET/ASGI app), inside the **M365 Agents SDK** for
+  channel reach (`skills/m365-agents-sdk`), or as a **Foundry hosted agent**
+  (`agent-framework-foundry-hosting`, `ResponsesHostServer` — see `skills/microsoft-foundry`).

--- a/plugins/microsoft-agents-expert/skills/agent-interop/SKILL.md
+++ b/plugins/microsoft-agents-expert/skills/agent-interop/SKILL.md
@@ -1,0 +1,77 @@
+---
+description: Choose and combine Microsoft agent stacks — the Copilot Studio vs Teams SDK vs M365 Agents SDK vs Agent Framework vs Foundry decision matrix, plus interop patterns - MCP as the tool fabric, A2A as the agent protocol, hosting matrices, and Agent 365 identity/observability.
+model: opus
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+---
+
+# Microsoft Agent Stack — Selection and Interop
+
+The five pieces solve different layers of the same problem. Most production systems combine
+a **build layer** (Copilot Studio or Agent Framework) with a **hosting/channel layer**
+(Foundry Agent Service or M365 Agents SDK/Teams SDK).
+
+## Decision matrix
+
+Source: https://learn.microsoft.com/microsoft-365/copilot/extensibility/overview-custom-engine-agent
+
+| | Copilot Studio | Teams SDK | M365 Agents SDK | Foundry |
+|---|---|---|---|---|
+| Approach | Low-code SaaS | Pro-code | Pro-code | Low-code or pro-code PaaS |
+| Orchestrator | Copilot Studio | Bring your own | Bring your own (Agent Framework, SK, LangChain) | Bring your own / managed |
+| Channels | M365 Copilot, Teams, web, custom (Direct Line) | M365 Copilot, Teams | M365 Copilot, Teams + 10+ channels via Azure Bot Service | M365 Copilot, Teams (others via custom integration) |
+| Languages | n/a | C#, TS/JS, Python (preview) | C#, JS, Python | Python, C# |
+
+**Rules of thumb**
+
+- Maker-built, governed, Power-Platform-integrated, department scale → **Copilot Studio**
+  (Copilot Credits abstract LLM token pricing).
+- Code-level control of the agent loop, multi-agent workflows, provider flexibility →
+  **Agent Framework** (it's the library, not the host).
+- Azure-managed runtime, model catalog, enterprise identity/observability → **Foundry
+  Agent Service** (CAF decision tree: SaaS → Copilot Studio; PaaS pro-code → Foundry).
+- Same agent on many channels (the Bot Framework succession path) → **M365 Agents SDK**.
+- Deeply Teams-native collaborative experience → **Teams SDK**.
+
+## Interop patterns
+
+| Pattern | How |
+|---|---|
+| Agent Framework inside M365 Agents SDK | AgentApplication turn handler calls `agent.run(...)`; SDK owns channels/auth, framework owns reasoning |
+| Agent Framework on Foundry | Hosted agent via `agent-framework-foundry-hosting` (`ResponsesHostServer`) — managed endpoint, Entra agent identity |
+| Foundry agent in M365/Teams | Publish from the Foundry portal (auto-provisions Azure Bot Service + Entra) or an Agents Toolkit proxy app |
+| Copilot Studio → Foundry | Connect an external Foundry agent as a **child agent** (preview; new-portal agents only) |
+| Code → Copilot Studio | `CopilotStudioAgent` (`agent-framework-copilotstudio`); M365 Agents SDK OBO-auth samples |
+| Humans in the loop from any stack | Teams as an MCP server: `notify` / `ask` / `request_approval` |
+
+## The two protocols
+
+- **MCP is the common tool fabric** — Copilot Studio adds MCP servers as tools, Foundry has
+  an MCP tool type, Agent Framework ships MCP clients (`MCPStreamableHTTPTool` et al.), and
+  Teams itself can be exposed as an MCP server. Build a capability once as an MCP server
+  and every stack can consume it.
+- **A2A is the common agent-to-agent protocol** — Agent Framework `A2AAgent` /
+  `Microsoft.Agents.AI.A2A`, Foundry's A2A tool (preview), Teams SDK bot-to-bot A2A.
+  Use A2A when two *agents* converse; use MCP when an agent calls a *capability*.
+
+## Cross-cutting: Agent 365
+
+The Agent 365 SDK (`@microsoft/agents-a365-*`) provides Entra-based **agent identity**, an
+agent **registry**, and **OpenTelemetry observability** for agents from any framework —
+including agents registered from Google Vertex AI or Amazon Bedrock. Reach for it when an
+organization needs one governance plane over heterogeneous agents.
+
+## Architecture review checklist
+
+When reviewing a proposed multi-stack design:
+
+1. Exactly one owner per layer — conversation/channel, orchestration, tools, hosting,
+   identity. Two components owning the same layer is the #1 design smell.
+2. Every cross-stack hop uses MCP or A2A (or a documented connector) — no bespoke HTTP
+   bridges that bypass identity and telemetry.
+3. Identity flows end-to-end: user → channel → agent (Entra agent identity) → downstream
+   scopes, with on-behalf-of where user context must survive.
+4. One telemetry plane (OpenTelemetry / Agent 365) across all stacks in the design.
+5. Cost model named per layer: Copilot Credits, Foundry consumption, model tokens.

--- a/plugins/microsoft-agents-expert/skills/copilot-studio/SKILL.md
+++ b/plugins/microsoft-agents-expert/skills/copilot-studio/SKILL.md
@@ -1,0 +1,86 @@
+---
+description: Design, govern, and extend Microsoft Copilot Studio agents — topics, generative orchestration, knowledge, tools and MCP, agent flows, autonomous triggers, publishing channels, Copilot Credits pricing, and solution-based ALM on Power Platform.
+model: sonnet
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+---
+
+# Microsoft Copilot Studio
+
+SaaS low-code agent platform on Power Platform (copilotstudio.microsoft.com). GA.
+Docs hub: https://learn.microsoft.com/microsoft-copilot-studio/
+
+## Building blocks
+
+- **Topics** — deterministic dialogs with trigger phrases and slot filling; still the right
+  tool for flows that must behave identically every time.
+- **Generative orchestration** — the LLM planner interprets intent (multi-intent, last 10
+  turns of history) and builds a plan across **topics, tools, knowledge sources, child
+  agents, and triggers**. This is the default architecture for new agents.
+  Guidance: https://learn.microsoft.com/microsoft-copilot-studio/guidance/generative-orchestration
+- **Knowledge / generative answers** — RAG over attached sources with citations.
+- **Tools** — Power Platform **connectors** (1,400+), **prompts**, **agent flows**
+  (flow-style automation), and **MCP servers**.
+- **Autonomous agents** — event/scheduled triggers (e.g., Dataverse events) run the agent
+  without a human in the loop; scope permissions tightly and use the built-in guardrails.
+  Custom triggers like On Plan Complete; computer use; multi-agent via child/connected agents.
+
+## MCP integration
+
+Tools tab → **+ Add a tool** → *Model Context Protocol* wizard (server name/URL, OAuth).
+Supports MCP **tools and resources**; server-side changes reflect dynamically. Requires
+generative orchestration.
+Docs: https://learn.microsoft.com/microsoft-copilot-studio/agent-extend-action-mcp
+
+## Publishing channels
+
+Teams, Microsoft 365 Copilot, SharePoint, Power Pages, demo/custom websites, mobile apps,
+and custom clients via the **Direct Line API** (REST + WebSocket). Entra ID auth is the
+default for organizational channels.
+
+## Pricing — Copilot Credits
+
+**Copilot Credits** are the common currency (renamed from "messages", effective 2025-09-01).
+Representative rates: classic answer 1 · generative answer 2 · agent action 5 · tenant graph
+grounding 10 · agent flow actions 13/100 actions · tiered AI-tool rates · voice 10/35/75 per
+minute. Purchase via prepaid packs, the Azure pay-as-you-go meter, or Copilot Credit
+prepurchase (CCCUs). M365 Copilot-licensed users are no-charge for most features. Monthly
+enforcement, no rollover — budget autonomous triggers especially, since nobody is watching
+the meter mid-run.
+
+## ALM and governance
+
+Agents are Dataverse **solution** components:
+
+- In-app solution manager: preferred solutions, export/import managed solutions
+- **Power Platform pipelines** for dev → test → prod promotion; environment variables +
+  connection references for per-environment config
+- Native Git integration; Azure DevOps/GitHub CI/CD
+- Governance via Power Platform admin center: DLP policies, RBAC, Purview integration
+
+Never edit prod agents in place — all changes travel as solutions.
+
+## Pro-code extensibility
+
+- **Call Copilot Studio from code:** Agent Framework's `agent-framework-copilotstudio`
+  package provides `CopilotStudioAgent` (see `skills/agent-framework`); the M365 Agents SDK
+  has on-behalf-of auth samples calling Copilot Studio agents.
+- **Call Foundry from Copilot Studio:** connect an external **Microsoft Foundry agent** as
+  a child agent (preview; new-Foundry-portal agents only).
+- **Custom clients:** Direct Line API.
+
+## Practices
+
+- Start from the instruction + knowledge + tools triad; add explicit topics only where
+  determinism is required.
+- Give every tool a crisp description with *when to use it* — the orchestrator's plan
+  quality tracks tool-description quality.
+- Watch credit burn per conversation in analytics before and after each change; generative
+  answers and graph grounding dominate cost.
+- For maker/pro-code hybrids, define the boundary explicitly: Copilot Studio owns the
+  conversation and governance; code-side agents (Foundry/Agent Framework) own deep logic,
+  reached as child agents or MCP tools. See `skills/agent-interop`.

--- a/plugins/microsoft-agents-expert/skills/m365-agents-sdk/SKILL.md
+++ b/plugins/microsoft-agents-expert/skills/m365-agents-sdk/SKILL.md
@@ -1,0 +1,101 @@
+---
+description: Build and host custom engine agents with the Microsoft 365 Agents SDK — AgentApplication, the Activity protocol, channel reach via Azure Bot Service, hosting Agent Framework or Semantic Kernel engines, and the Agents Toolkit/Playground workflow. Successor to the Bot Framework SDK.
+model: sonnet
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Microsoft 365 Agents SDK
+
+The channel and hosting layer for **custom engine agents**: receives and sends messages
+across Microsoft 365 Copilot, Teams, web, and 10+ third-party channels (Slack, Facebook
+Messenger, Twilio, SMS, email) via **Azure Bot Service**, which translates channel traffic
+into Activities. It is the **successor to the Bot Framework SDK** (BF SDK and Emulator are
+archived; support ended 2025-12-31). AI-agnostic: host Microsoft Agent Framework, Semantic
+Kernel, LangChain, OpenAI Agents, or Foundry agents inside it.
+Docs: https://learn.microsoft.com/microsoft-365/agents-sdk/agents-sdk-overview
+
+**Status (mid-2026):** GA — .NET v1.6.x (.NET 8+), JavaScript v1.6.x (Node 18+), Python v1.1.x.
+
+## Packages
+
+| Language | Packages |
+|---|---|
+| .NET | **`Microsoft.Agents.Builder`** (AgentApplication, routing, middleware, turn context), `Microsoft.Agents.Core` (Activity models), `Microsoft.Agents.Storage`, `Microsoft.Agents.Authentication`, `Microsoft.Agents.Connector`, `Microsoft.Agents.Storage.Transcript` |
+| JS/TS | **`@microsoft/agents-hosting`**, `@microsoft/agents-hosting-express`, `@microsoft/agents-activity` |
+| Python | `microsoft-agents-hosting-core`, `microsoft-agents-activity`, `microsoft-agents-hosting-aiohttp`, `microsoft-agents-authentication-msal`, `microsoft-agents-storage-blob` / `-cosmos`, `microsoft-agents-hosting-teams` (imports from `microsoft_agents`) |
+
+## Core concepts
+
+- **Activity Protocol** — the standard JSON message format shared across channels; typed
+  models live in `Microsoft.Agents.Core` / `@microsoft/agents-activity`.
+- **`AgentApplication`** — your entry point. Pipeline: Channel → hosting layer (HTTP auth)
+  → AgentApplication routing → your handlers, with turn state loaded before and saved after
+  each handler. Route ranking (`RouteRank.Last`) orders catch-alls.
+- **`CloudAdapter`** processes `/api/messages`; agents are stateless with pluggable storage
+  (memory, Blob, Cosmos).
+- **Tooling:** **Microsoft 365 Agents Toolkit** (formerly Teams Toolkit — VS, VS Code, CLI)
+  for scaffolding/manifests/publishing, and the **Microsoft 365 Agents Playground** — a
+  local Teams-like sandbox needing no tenant, tunnel, or bot registration.
+- **Agent 365 SDK** (`@microsoft/agents-a365-*`) layers on enterprise observability
+  (OpenTelemetry), notifications, MCP tool-server management, and Entra-based agent identity.
+
+## Minimal agents
+
+```csharp
+public class EchoAgent : AgentApplication
+{
+    public EchoAgent(AgentApplicationOptions options) : base(options)
+        => OnActivity(ActivityTypes.Message, OnMessageAsync, rank: RouteRank.Last);
+
+    private async Task OnMessageAsync(ITurnContext tc, ITurnState ts, CancellationToken ct)
+        => await tc.SendActivityAsync($"You said: {tc.Activity.Text}", cancellationToken: ct);
+}
+```
+
+```typescript
+import { AgentApplication, MemoryStorage, TurnContext, TurnState } from '@microsoft/agents-hosting'
+import { startServer } from '@microsoft/agents-hosting-express'
+
+const app = new AgentApplication<TurnState>({ storage: new MemoryStorage() })
+app.onActivity('message', async (ctx: TurnContext) => ctx.sendActivity(`You said: ${ctx.activity.text}`))
+startServer(app)
+```
+
+## Hosting an AI engine inside
+
+The SDK is plumbing; the intelligence is whatever you host. The documented pattern for
+Agent Framework / Semantic Kernel: instantiate the engine agent once, then call it from the
+message handler and relay the result as an activity.
+Guide: https://learn.microsoft.com/microsoft-365/agents-sdk/using-semantic-kernel-agent-framework
+
+Keep the layers separate: channel/UX concerns (activities, cards, auth) in the
+AgentApplication handler; reasoning/tools in the engine (see `skills/agent-framework`).
+
+## Bot Framework migration
+
+Coming from Bot Framework v4 (see `/msagent-migrate`):
+
+- The Activity protocol carries over — message shapes and channel semantics are familiar.
+- `ActivityHandler`/adapter wiring becomes `AgentApplication` routing; middleware moves to
+  the new pipeline.
+- Dialogs have no direct successor — replace waterfall dialogs with an LLM engine + tools,
+  or explicit state machines for strictly deterministic flows.
+- Re-register the messaging endpoint against Azure Bot Service; update auth to the current
+  `Microsoft.Agents.Authentication` / MSAL configuration.
+
+## Practices
+
+- Develop against the Agents Playground first; only stand up tunnels/bot registrations when
+  channel-specific behavior needs testing.
+- Store per-conversation state via the SDK's storage abstractions, not process memory, so
+  scale-out works.
+- One agent codebase, many channels: guard Teams-only affordances (cards, meetings) behind
+  channel checks — see `skills/teams-agents` for the Teams-native layer.
+- Publishing to M365 Copilot/Teams flows through app manifests and the Agents Toolkit —
+  see `/msagent-deploy`.

--- a/plugins/microsoft-agents-expert/skills/microsoft-foundry/SKILL.md
+++ b/plugins/microsoft-agents-expert/skills/microsoft-foundry/SKILL.md
@@ -1,0 +1,94 @@
+---
+description: Run agents on Microsoft Foundry (formerly Azure AI Foundry) Agent Service — prompt agents vs hosted agents, threads/runs and the Responses API, built-in tools (Bing grounding, code interpreter, file search, MCP, OpenAPI, A2A), connected agents, Entra agent identity, SDKs, and observability/evaluations.
+model: sonnet
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Microsoft Foundry — Agent Service
+
+Azure's managed agent runtime. Now branded **Microsoft Foundry** (portal ai.azure.com; docs
+under `/azure/foundry/`, previous generation under `/azure/foundry-classic/`; RBAC roles
+renamed "Foundry User/Owner/…"). The classic Agent Service went **GA May 2025** (REST
+api-version `2025-05-01`) with the OpenAI-Assistants-style **agents / threads / runs /
+messages** model; the current service centers on the **Responses API** as the single entry
+point. Overview: https://learn.microsoft.com/azure/foundry/agents/overview
+
+## Two agent types
+
+| Type | What it is | When |
+|---|---|---|
+| **Prompt agents** | Config-only: instructions + model + tools, authored in portal or SDK/REST. Fully managed runtime — no code or compute to manage. | Tool-using assistants where instructions + built-in tools suffice |
+| **Hosted agents** (preview) | *Your* code — built with **Agent Framework, LangGraph, OpenAI Agents SDK, Anthropic SDK, GitHub Copilot SDK, or custom** — shipped as a container or zip. Foundry provides the managed endpoint, autoscale, **dedicated Entra identity per agent**, session-state persistence, and observability. Your code calls the Responses API for models + platform tools. | Custom agent loops that still want managed hosting/identity/observability |
+
+Classic threads/runs semantics: run states `queued → in_progress → requires_action →
+completed/failed/cancelled/expired`; threads up to 100K messages; optional BYO Cosmos DB
+for thread storage.
+
+## Tools
+
+- **Built-in:** web search / Grounding with Bing (+ Bing Custom Search), Code Interpreter,
+  File Search (vector stores), function calling, Azure AI Search, Azure Functions, Logic
+  Apps (event triggers), Microsoft Fabric, SharePoint, Deep Research (o3-deep-research),
+  Browser Automation, Computer Use, Image Generation, memory.
+- **Custom:** **MCP** servers, **OpenAPI 3.0/3.1** specs, **A2A** (preview).
+- **Connected agents** — compose multi-agent systems without an external orchestrator.
+- Publishing targets include Teams / M365 Copilot and the **Entra Agent Registry**.
+
+## SDKs and CLI
+
+| Surface | Names |
+|---|---|
+| Python | **`azure-ai-projects` (>=2.0.0, `AIProjectClient`)** + `azure-identity`; classic threads/runs library `azure-ai-agents`; hosted-agent server libs `azure-ai-agentserver-responses` / `azure-ai-agentserver-invocations` |
+| .NET | `Azure.AI.Projects` (`AgentAdministrationClient`) |
+| Agent Framework hosting | `pip install agent-framework agent-framework-foundry-hosting` → `ResponsesHostServer` |
+| CLI | `azd ext install microsoft.foundry`; `azd ai agent show \| invoke \| monitor` |
+
+```python
+import os
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+
+project_client = AIProjectClient(
+    endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+    credential=DefaultAzureCredential(),
+)
+agent = project_client.agents.get("<your-agent-name>")
+client = project_client.get_openai_client()   # Responses API access
+```
+
+```bash
+# Classic threads/runs REST (GA api-version 2025-05-01)
+curl -X POST "$ENDPOINT/threads/thread_abc123/runs?api-version=2025-05-01" \
+  -H "Authorization: Bearer $AGENT_TOKEN" -H "Content-Type: application/json" \
+  -d '{"assistant_id": "asst_abc123"}'
+```
+
+## Identity, observability, evaluation
+
+- **Identity:** hosted agents get a dedicated **Microsoft Entra identity**; grant that
+  identity least-privilege access to downstream resources instead of sharing app secrets.
+- **Observability:** server-side traces for prompt and hosted agents in the portal
+  (90 days); Application Insights auto-injection for hosted agents; OpenTelemetry via the
+  **Microsoft OpenTelemetry Distro** (`microsoft-opentelemetry`). External agents can be
+  registered for trace/eval scoping.
+- **Evaluations:** agent evaluators (Task Adherence, Intent Resolution) and
+  `AIAgentConverter` in `azure-ai-evaluation` — run evaluations as a pre-deploy gate
+  (see `/msagent-deploy`).
+
+## Practices
+
+- Prefer prompt agents until you actually need a custom loop; hosted agents add container
+  lifecycle you must own.
+- Use connected agents before reaching for an external orchestrator; reserve Agent
+  Framework workflows for logic Foundry can't express.
+- Ground on your data via File Search/Azure AI Search rather than stuffing context into
+  instructions.
+- BYO thread storage (Cosmos DB) when compliance requires data in your subscription.
+- Reaching M365 channels: publish from the portal (auto-provisions Azure Bot Service +
+  Entra) or front with the M365 Agents SDK — see `skills/agent-interop`.

--- a/plugins/microsoft-agents-expert/skills/teams-agents/SKILL.md
+++ b/plugins/microsoft-agents-expert/skills/teams-agents/SKILL.md
@@ -1,0 +1,89 @@
+---
+description: Build Teams-native agents with the Teams SDK (formerly Teams AI Library v2) — App class, activity routing, adaptive cards, streaming, AI-generated labels, feedback, message extensions, Teams-as-MCP-server, and the bring-your-own-AI pattern with Agent Framework.
+model: sonnet
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Teams Agents — Teams SDK
+
+The **Teams AI Library is now renamed to Teams SDK** (branded "Teams AI Library v2" in some
+docs) — rebuilt from the ground up for Teams-native agents. **GA for JavaScript and C#;
+Python is developer preview. v1 is deprecated.**
+Docs: https://learn.microsoft.com/microsoftteams/platform/teams-ai-library/welcome/overview
+· Repos: microsoft/teams.ts, microsoft/teams.py
+
+## Packages and CLI
+
+- npm: **`@microsoft/teams.apps`** (the `App` class), `@microsoft/teams.api`
+  (`MessageActivity` and friends), `@microsoft/teams.common`
+- CLI: `npm i -g @microsoft/teams.cli@preview` → `teams new my-agent --template echo`
+
+**Bring your own AI.** The SDK deprecated its own AI packages (`@microsoft/teams.ai`
+ChatPrompt/Model, old `@microsoft/teams.mcp`, `@microsoft/teams.a2a`). The documented
+pattern: run the agent loop with the OpenAI SDK or **Microsoft Agent Framework**
+(`skills/agent-framework`) and wire MCP/A2A directly — Teams SDK handles activity routing
+and Teams affordances.
+
+## Minimal agent
+
+```typescript
+import { App } from '@microsoft/teams.apps';
+
+const app = new App();
+app.on('message', async ({ send, activity }) => {
+  await send({ type: 'typing' });
+  await send(`you said "${activity.text}"`);
+});
+app.start(process.env.PORT || 3978).catch(console.error);
+```
+
+## Agent Framework loop streaming into Teams (Python preview)
+
+```python
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]):
+    async for chunk in agent.run(ctx.activity.text or "", stream=True):
+        if chunk.text:
+            ctx.stream.emit(chunk.text)
+    ctx.stream.emit(MessageActivityInput().add_ai_generated().add_feedback(mode="custom"))
+```
+
+## Teams-specific capabilities
+
+| Capability | Notes |
+|---|---|
+| Adaptive Cards | Dialogs, message extensions, link unfurling — validate card JSON against the schema |
+| Streaming | `ctx.stream.emit(...)` for progressive responses |
+| AI-generated label | `.addAiGenerated()` — required UX for AI output in Teams |
+| Feedback controls | `.addFeedback('custom')` — thumbs/feedback affordances on agent messages |
+| Citations | Attach sources to generated answers |
+| Prompt starters | Suggested first prompts in the agent's Teams surface |
+| Proactive messages | Agent-initiated notifications to users/channels |
+| Meetings | Meeting-aware agents (join context, transcripts where permitted) |
+| Teams as MCP server | Expose Teams to agents: `notify` / `ask` / `request_approval` reach humans |
+| Bot-to-bot A2A | Agent-to-agent conversations across Teams bots |
+
+## Relationship to the M365 Agents SDK
+
+Teams SDK is Teams-centric (collaborative, multi-user, meetings, real-time). To extend the
+same agent to Outlook, M365 Copilot, and other channels, use the **M365 Agents SDK**
+(`skills/m365-agents-sdk`) — which also ships `microsoft-agents-hosting-teams` for the
+Teams surface. Both build and publish through the **Microsoft 365 Agents Toolkit**.
+
+Rule of thumb: Teams-only experience → Teams SDK; multi-channel custom engine agent →
+M365 Agents SDK, adding Teams affordances through its Teams hosting package.
+
+## Practices
+
+- Always attach the AI-generated label and feedback controls to model-generated messages —
+  reviewers and store validation look for both.
+- Stream long responses; Teams users perceive non-streaming agents as hung.
+- Keep card payloads small and versioned; test dark mode and mobile rendering.
+- Migrating from Teams AI v1 or Teams Toolkit projects: the toolkit is now the
+  **Microsoft 365 Agents Toolkit** — see `/msagent-migrate` for the project-structure map.

--- a/plugins/mui-expert/.claude-plugin/plugin.json
+++ b/plugins/mui-expert/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.local/schemas/plugin.schema.json",
   "name": "mui-expert",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Comprehensive Material UI (MUI) expert plugin — 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
   "author": {
     "name": "Claude Code",

--- a/plugins/mui-expert/CHANGELOG.md
+++ b/plugins/mui-expert/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.0] - 2026-07-11
+
+### Changed
+
+- All five pinned agents (`mui-a11y-auditor`, `mui-migration-specialist`, `mui-performance-optimizer`, `mui-reviewer`, `mui-x-specialist`) upgraded from `claude-sonnet-4-6` to `claude-sonnet-5` — near-Opus quality on coding/agentic work at the same sticker price.
+
 ## [2.1.1] - 2026-06-04
 
 ### Changed

--- a/plugins/mui-expert/agents/mui-a11y-auditor.md
+++ b/plugins/mui-expert/agents/mui-a11y-auditor.md
@@ -14,7 +14,7 @@ risk: low
 cost: high
 description: |
   Comprehensive accessibility auditor for MUI applications. Checks WCAG 2.1 compliance across all MUI component usage — ARIA attributes, keyboard navigation, color contrast, focus management, screen reader compatibility, and semantic HTML. Produces actionable report with auto-fix support.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools:
   - Read
   - Glob

--- a/plugins/mui-expert/agents/mui-migration-specialist.md
+++ b/plugins/mui-expert/agents/mui-migration-specialist.md
@@ -14,7 +14,7 @@ risk: medium
 cost: high
 description: |
   Analyzes codebases for MUI version compatibility and executes migrations between MUI v4→v5 or v5→v6. Detects breaking changes, generates a file-by-file migration plan with effort estimates, applies codemods and manual transforms, and verifies results with TypeScript compilation.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools:
   - Read
   - Glob

--- a/plugins/mui-expert/agents/mui-performance-optimizer.md
+++ b/plugins/mui-expert/agents/mui-performance-optimizer.md
@@ -14,7 +14,7 @@ risk: low
 cost: high
 description: |
   Analyzes MUI applications for performance issues including bundle size, render optimization, Emotion overhead, DataGrid performance, and SSR efficiency. Produces prioritized recommendations with estimated impact and auto-applies safe fixes.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools:
   - Read
   - Glob

--- a/plugins/mui-expert/agents/mui-reviewer.md
+++ b/plugins/mui-expert/agents/mui-reviewer.md
@@ -14,7 +14,7 @@ risk: low
 cost: medium
 description: |
   Reviews React code that uses Material UI and identifies issues related to best practices, accessibility, performance, and correctness. Produces a categorized report with file:line references and actionable fix code covering imports, theming, styling approach, a11y, performance, component usage, TypeScript typing, DataGrid, and DatePicker patterns.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools:
   - Read
   - Glob

--- a/plugins/mui-expert/agents/mui-x-specialist.md
+++ b/plugins/mui-expert/agents/mui-x-specialist.md
@@ -16,7 +16,7 @@ risk: low
 cost: high
 description: |
   Specialist in MUI X premium components. Handles advanced DataGrid patterns (server-side data source, row grouping, aggregation, master-detail, Excel export, cell selection, clipboard), Date/Time Pickers (timezone, custom fields, validation, shortcuts), Charts (composition API, custom renderers, dual axes), and Tree View (lazy loading, drag-drop, virtualization).
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools:
   - Read
   - Glob

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,178 +12,178 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^20.11.0
-        version: 20.19.39
+        specifier: ^20.19.43
+        version: 20.19.43
       ajv:
-        specifier: ^8.12.0
-        version: 8.18.0
+        specifier: ^8.20.0
+        version: 8.20.0
       ajv-formats:
         specifier: ^3.0.1
-        version: 3.0.1(ajv@8.18.0)
+        version: 3.0.1(ajv@8.20.0)
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.1
+        specifier: ^4.3.0
+        version: 4.3.0
       tsx:
-        specifier: ^4.7.0
-        version: 4.21.0
+        specifier: ^4.23.0
+        version: 4.23.0
       typescript:
-        specifier: ^5.3.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
 
 packages:
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -191,8 +191,128 @@ packages:
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
-  '@types/node@20.19.39':
-    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -202,33 +322,30 @@ packages:
       ajv:
         optional: true
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  get-tsconfig@4.14.0:
-    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -238,17 +355,14 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+  tsx@4.23.0:
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@6.21.0:
@@ -256,144 +370,200 @@ packages:
 
 snapshots:
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@types/js-yaml@4.0.9': {}
 
-  '@types/node@20.19.39':
+  '@types/node@20.19.43':
     dependencies:
       undici-types: 6.21.0
 
-  ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
 
-  ajv@8.18.0:
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   argparse@2.0.1: {}
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.3: {}
 
   fsevents@2.3.3:
     optional: true
 
-  get-tsconfig@4.14.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -401,15 +571,33 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resolve-pkg-maps@1.0.0: {}
-
-  tsx@4.21.0:
+  tsx@4.23.0:
     dependencies:
-      esbuild: 0.27.7
-      get-tsconfig: 4.14.0
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 
-  typescript@5.9.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@6.21.0: {}

--- a/site/data/plugins.json
+++ b/site/data/plugins.json
@@ -7,19 +7,19 @@
       "name": "Markus Ahling",
       "email": "markus@thelobbi.io"
     },
-    "generatedAt": "2026-06-23T17:42:25.751Z",
+    "generatedAt": "2026-07-11T19:45:17.435Z",
     "repo": "https://github.com/markus41/claude",
     "url": "https://markus41.github.io/claude/"
   },
   "stats": {
-    "plugins": 35,
+    "plugins": 36,
     "subplugins": 6,
-    "commands": 294,
-    "agents": 261,
-    "skills": 250,
+    "commands": 299,
+    "agents": 266,
+    "skills": 256,
     "hooks": 17,
     "mcp": 8,
-    "categories": 8
+    "categories": 9
   },
   "categories": [
     "AI & Claude Code",
@@ -29,6 +29,7 @@
     "Lobbi Domain",
     "Marketplace & Platform",
     "Microsoft & Enterprise",
+    "Other",
     "Project Management"
   ],
   "stacks": [
@@ -168,7 +169,7 @@
     },
     {
       "name": "claude-code-expert",
-      "version": "8.2.0",
+      "version": "8.4.0",
       "description": "Modern Claude Code second brain: 5-layer stack deploy + three-tier memory (engram + Obsidian vault + plugin rules) + 22-tool MCP reference server. 21 behavior-triggering skills, 12 single-intent commands, 18 role-scoped agents bridging engram and Obsidian. Tracks current Claude Code capabilities (Fable 5 + Opus 4.8, agent teams, Tool Search, web/remote).",
       "author": "Markus Ahling",
       "authorUrl": "",
@@ -300,7 +301,7 @@
     },
     {
       "name": "dotnet-blazor",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "description": "Comprehensive .NET 10, Blazor, ASP.NET Core, C#, and Syncfusion expert plugin for building modern web apps, microservices, and cloud-native solutions",
       "author": "Markus Ahling",
       "authorUrl": "",
@@ -333,7 +334,7 @@
     },
     {
       "name": "drawio-diagramming",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "description": "Intelligent draw.io diagramming plugin with AI-powered diagram generation, multi-platform embedding (GitHub, Confluence, Azure DevOps, Notion, Teams, Harness), conditional formatting, live data binding, and MCP server integration for programmatic diagram creation and management.",
       "author": "Markus Ahling",
       "authorUrl": "https://github.com/markus41",
@@ -366,7 +367,7 @@
     },
     {
       "name": "exec-automator",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "description": "Genesis (Forerunner) - AI-Powered Executive Director Automation Platform. Analyze organizational responsibilities, score automation potential with 6-factor algorithm, generate LangGraph workflows, and deploy 11 specialized agents for trade associations and nonprofits.",
       "author": "Brookside BI",
       "authorUrl": "",
@@ -531,7 +532,7 @@
     },
     {
       "name": "jira-orchestrator",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "description": "Enterprise Jira orchestration with 82 agents, 16 teams, 48 commands, 14 skills, 5 schema-validated workflows, and a read-only advisor. Features Atlassian MCP OAuth, Harness integration, Neon PostgreSQL, Redis caching, Temporal workflows, declarative workflow definitions, lifecycle telemetry hooks, and structured reasoning frameworks.",
       "author": "Markus Ahling",
       "authorUrl": "",
@@ -953,8 +954,41 @@
       "hasReadme": true
     },
     {
+      "name": "microsoft-agents-expert",
+      "version": "1.0.0",
+      "description": "Comprehensive Microsoft agent-stack expert: Microsoft Agent Framework (the Semantic Kernel + AutoGen successor), Microsoft 365 Agents SDK, Teams AI Library, Copilot Studio, and Microsoft Foundry Agent Service. Stack selection, scaffolding, migration, review, and deployment. 6 skills, 5 agents, 5 commands.",
+      "author": "Markus Ahling",
+      "authorUrl": "",
+      "source": "./plugins/microsoft-agents-expert",
+      "category": "Other",
+      "keywords": [
+        "microsoft",
+        "agents",
+        "agent-framework",
+        "m365-agents-sdk",
+        "teams",
+        "copilot-studio",
+        "microsoft-foundry",
+        "azure-ai-foundry",
+        "semantic-kernel",
+        "autogen",
+        "mcp",
+        "multi-agent"
+      ],
+      "license": "MIT",
+      "homepage": "",
+      "counts": {
+        "commands": 5,
+        "agents": 5,
+        "skills": 6,
+        "hooks": 0
+      },
+      "mcp": false,
+      "hasReadme": true
+    },
+    {
       "name": "mui-expert",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "description": "Comprehensive Material UI (MUI) expert plugin — 26 skills, 14 commands, 7 agents covering theming, CSS variables, Pigment CSS, components, sx/styled, slots API, MUI X (DataGrid, DatePickers, Charts, TreeView), accessibility, performance, SSR/Next.js, animations, virtualization, forms, white-label/multi-tenant, headless (MUI Base), Joy UI, i18n/RTL, testing, migration, entity-driven CRUD, ecosystem integrations, and 200+ creative widget patterns.",
       "author": "Claude Code",
       "authorUrl": "https://github.com/markus41/claude",

--- a/site/index.html
+++ b/site/index.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Claude Orchestration — Plugin Marketplace for Claude Code</title>
-  <meta name="description" content="An enterprise marketplace of 35 Claude Code plugins: multi-agent orchestration, infrastructure, frontend design systems, project management, and domain automation. 294 commands, 261 agents, 250 skills." />
+  <meta name="description" content="An enterprise marketplace of 36 Claude Code plugins: multi-agent orchestration, infrastructure, frontend design systems, project management, and domain automation. 299 commands, 266 agents, 256 skills." />
   <meta name="color-scheme" content="dark light" />
 
   <!-- Open Graph / social -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Claude Orchestration — Plugin Marketplace for Claude Code" />
-  <meta property="og:description" content="35 enterprise Claude Code plugins. 294 commands · 261 agents · 250 skills · 8 MCP servers. Multi-agent orchestration, infrastructure, design systems, and domain automation." />
+  <meta property="og:description" content="36 enterprise Claude Code plugins. 299 commands · 266 agents · 256 skills · 8 MCP servers. Multi-agent orchestration, infrastructure, design systems, and domain automation." />
   <meta property="og:url" content="https://markus41.github.io/claude/" />
   <meta property="og:image" content="https://markus41.github.io/claude/assets/og.svg" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -95,10 +95,10 @@
 
         <!-- animated headline stats -->
         <dl class="stats" id="heroStats" aria-label="Marketplace at a glance">
-          <div class="stat"><dt>Plugins</dt><dd data-count data-bind="stats.plugins">35</dd></div>
-          <div class="stat"><dt>Agents</dt><dd data-count data-bind="stats.agents">261</dd></div>
-          <div class="stat"><dt>Skills</dt><dd data-count data-bind="stats.skills">250</dd></div>
-          <div class="stat"><dt>Commands</dt><dd data-count data-bind="stats.commands">294</dd></div>
+          <div class="stat"><dt>Plugins</dt><dd data-count data-bind="stats.plugins">36</dd></div>
+          <div class="stat"><dt>Agents</dt><dd data-count data-bind="stats.agents">266</dd></div>
+          <div class="stat"><dt>Skills</dt><dd data-count data-bind="stats.skills">256</dd></div>
+          <div class="stat"><dt>Commands</dt><dd data-count data-bind="stats.commands">299</dd></div>
           <div class="stat"><dt>MCP servers</dt><dd data-count data-bind="stats.mcp">8</dd></div>
         </dl>
       </div>
@@ -124,7 +124,7 @@
         <article class="block">
           <span class="block__icon">🤖</span>
           <h3>Multi-agent by design</h3>
-          <p><strong data-bind="stats.agents">261</strong> role-scoped agents and ready-made teams. Orchestration patterns — councils, pipelines, swarms — are first-class, not bolted on.</p>
+          <p><strong data-bind="stats.agents">266</strong> role-scoped agents and ready-made teams. Orchestration patterns — councils, pipelines, swarms — are first-class, not bolted on.</p>
         </article>
         <article class="block">
           <span class="block__icon">🔌</span>
@@ -149,7 +149,7 @@
         <div class="catalog__row">
           <label class="search" for="search">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
-            <input id="search" type="search" placeholder="Search 35 plugins — press / to focus" autocomplete="off" aria-label="Search plugins" />
+            <input id="search" type="search" placeholder="Search 36 plugins — press / to focus" autocomplete="off" aria-label="Search plugins" />
             <kbd class="search__kbd">/</kbd>
           </label>
           <label class="sort">
@@ -227,19 +227,19 @@
           <span class="block__icon">⌘</span>
           <h3>Commands</h3>
           <p>Single-intent slash commands. Deterministic entry points like <code>/deploy</code> or <code>/jira-work</code>.</p>
-          <span class="block__metric"><strong data-bind="stats.commands">294</strong> across the catalog</span>
+          <span class="block__metric"><strong data-bind="stats.commands">299</strong> across the catalog</span>
         </article>
         <article class="block">
           <span class="block__icon">✦</span>
           <h3>Skills</h3>
           <p>Behavior-triggering knowledge that activates on intent — no command needed. Progressive disclosure for the model itself.</p>
-          <span class="block__metric"><strong data-bind="stats.skills">250</strong> skills installed</span>
+          <span class="block__metric"><strong data-bind="stats.skills">256</strong> skills installed</span>
         </article>
         <article class="block">
           <span class="block__icon">◎</span>
           <h3>Agents</h3>
           <p>Specialized sub-agents with scoped tools and models. Compose into teams for parallel, role-based work.</p>
-          <span class="block__metric"><strong data-bind="stats.agents">261</strong> role-scoped agents</span>
+          <span class="block__metric"><strong data-bind="stats.agents">266</strong> role-scoped agents</span>
         </article>
         <article class="block">
           <span class="block__icon">⚙</span>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://markus41.github.io/claude/</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-07-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Full marketplace upgrade pass, in commit order:

### 1. Registry/marketplace sync (`b7e16a5`)
On-disk `plugin.json` files as source of truth: 13 unregistered plugins added to the registry, version drift fixed across all registry sections, stale catalog metadata refreshed, stats recounted.

### 2. Claude 5-era model upgrades for six plugins (`ab9642a`)
claude-code-expert 8.4.0, exec-automator 2.1.0, jira-orchestrator 8.3.0, mui-expert 2.2.0, dotnet-blazor 2.1.0, drawio-diagramming 2.1.0 — model IDs to the current generation (Sonnet 5 / Opus 4.8 / Haiku 4.5) plus API-shape fixes (`temperature` and `budget_tokens` removed where they now 400). scrapin-aint-easy, project-management-plugin, react-animation-studio audited: alias-only, no changes needed.

### 3. New plugin: `microsoft-agents-expert` v1.0.0 (`7675c4a`)
Microsoft agent-stack expert (Agent Framework, M365 Agents SDK, Teams SDK, Copilot Studio, Microsoft Foundry) — 6 skills, 5 agents, 5 commands, verified against Microsoft Learn. Marketplace now 42 plugins (36 installed).

### 4. Toolchain / CI / site / platform config (`cc307b0`)
- **Deps:** typescript 5.9 → **7.0.2**, tsx → 4.23 (esbuild 0.28.1 — **`pnpm audit` now clean**, was 2 high/1 moderate/1 low), ajv → 8.20; js-yaml kept at v4 (v5 breaks default export + dump format, see lessons-learned)
- **CI:** actions/checkout and actions/setup-node v4 → v5
- **Platform:** settings.json default model → `claude-sonnet-5`; mcps.index.json model registry rebuilt (adds Fable tier, fixes wrong $15/$75 pricing and a nonexistent haiku ID); cc-agent/cc-setup templates + selenium agents upgraded
- **Site:** regenerated data + static counts (36 plugins · 299 commands · 266 agents · 256 skills)

### 5. langgraph-architect 1.1.0 (`46e37ea`)
64 model-ID replacements across the sub-plugin's commands/agents/skills/templates/examples; 13 `temperature` removals and 4 stale `budget_tokens` entries deleted; changelog added.

### 6. Platform skills model migration (`99b5756`)
17 files under `.claude/skills/` (the Claude API teaching skills): current model IDs everywhere, `budget_tokens` → adaptive thinking + effort levels, corrected pricing/context claims, structured outputs replacing prefill guidance; extended-thinking skill rebuilt around the current lineup with manual budgets kept only as labeled legacy docs.

### 7. Lessons learned (`b3ba1f6`)
Documented the js-yaml v5 incompatibility for future upgrade attempts.

## Validation

Every commit gated on: `check:marketplace` (36/36), `check:site`, `check:plugin-schema`, `check:plugin-indexes`, `check:plugin-context`, `check:hooks`, `npx tsc --noEmit` (on TS 7), archetype validation, `pnpm audit` (clean), `test:pm-plugin` (62/62), plus `py_compile`/`node --check`/`JSON.parse` on edited sources.

---

<div align="center">

[[Markus Ahling](https://img.shields.io/badge/%E2%9A%A1-markus41-000000?style=for-the-badge&labelColor=FF4500&color=1a1a2e)](https://github.com/markus41) [[Marketplace](``https://img.shields.io/badge/plugin-marketplace-blueviolet?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/markus41/claude``) [[Status](https://img.shields.io/badge/status-shipped%20%F0%9F%9A%80-brightgreen?style=for-the-badge)](https://github.com/markus41/claude)

*architecture by humans, velocity by machines*

</div>

https://claude.ai/code/session_01N31Qyck54CZbp1ycUUTGeT