### PR TITLE
fix(plugins): restore missing frontmatter descriptions so agents and commands load

### DIFF
--- a/plugins/aws-eks-helm-keycloak/agents/setup-orchestrator.md
+++ b/plugins/aws-eks-helm-keycloak/agents/setup-orchestrator.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Interactive agent that guides users through the comprehensive setup of the AWS EKS + Helm + Keycloak + Harness ecosystem.
 ---
 
 # Setup Orchestrator Agent

--- a/plugins/claude-code-templating-plugin/agents/README.md
+++ b/plugins/claude-code-templating-plugin/agents/README.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Expert system for Harness CI/CD pipeline generation, template management, and intelligent pipeline suggestions.
 ---
 
 # Harness Expert Agent

--- a/plugins/claude-code-templating-plugin/commands/setup.md
+++ b/plugins/claude-code-templating-plugin/commands/setup.md
@@ -10,6 +10,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: The /setup command manages the Claude Code baseline for an installed project.
 category: project-operations
 ---
 

--- a/plugins/drawio-diagramming/agents/auto-documenter.md
+++ b/plugins/drawio-diagramming/agents/auto-documenter.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: |
-  The Auto-Documenter analyzes codebases to automatically generate draw.io diagrams that accurately represent system architecture, data models, API flows, and infrastructure. It detects code changes, updates affected diagrams incrementally, and maintains a diagram inventory to prevent documentation drift.
+description: The Auto-Documenter analyzes codebases to automatically generate draw.io diagrams that accurately represent system architecture, data models, API flows, and infrastructure. It detects code changes, updates affected diagrams incrementally, and maintains a diagram inventory to prevent documentation drift.
 model: sonnet
 tools:
   - Read

--- a/plugins/drawio-diagramming/agents/data-connector.md
+++ b/plugins/drawio-diagramming/agents/data-connector.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: |
-  The Data Connector specializes in binding external data sources to draw.io diagrams. It implements conditional formatting, placeholder variables, live status dashboards, and automated update scripts that keep diagrams synchronized with real-time system state.
+description: The Data Connector specializes in binding external data sources to draw.io diagrams. It implements conditional formatting, placeholder variables, live status dashboards, and automated update scripts that keep diagrams synchronized with real-time system state.
 model: sonnet
 tools:
   - Read

--- a/plugins/drawio-diagramming/agents/diagram-architect.md
+++ b/plugins/drawio-diagramming/agents/diagram-architect.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: |
-  The Diagram Architect is the master strategist for draw.io diagram creation. It combines deep knowledge of every diagram type with expertise in draw.io XML internals to produce publication-ready diagrams. It follows a self-editing workflow of generate, analyze, improve, and finalize, ensuring every diagram meets professional standards for clarity, completeness, and visual quality.
+description: The Diagram Architect is the master strategist for draw.io diagram creation. It combines deep knowledge of every diagram type with expertise in draw.io XML internals to produce publication-ready diagrams. It follows a self-editing workflow of generate, analyze, improve, and finalize, ensuring every diagram meets professional standards for clarity, completeness, and visual quality.
 model: opus
 tools:
   - Read

--- a/plugins/drawio-diagramming/agents/integration-specialist.md
+++ b/plugins/drawio-diagramming/agents/integration-specialist.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: |
-  The Integration Specialist handles all aspects of embedding, syncing, and managing draw.io diagrams across development and collaboration platforms. It knows the specific integration mechanisms for GitHub, Confluence, Jira, Azure DevOps, Notion, Teams, and Harness, including automated export pipelines and cross-platform synchronization strategies.
+description: The Integration Specialist handles all aspects of embedding, syncing, and managing draw.io diagrams across development and collaboration platforms. It knows the specific integration mechanisms for GitHub, Confluence, Jira, Azure DevOps, Notion, Teams, and Harness, including automated export pipelines and cross-platform synchronization strategies.
 model: sonnet
 tools:
   - Read

--- a/plugins/drawio-diagramming/agents/style-engineer.md
+++ b/plugins/drawio-diagramming/agents/style-engineer.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: |
-  The Style Engineer is the visual design authority for all draw.io diagrams. It masters every style property, color palette, typography setting, and visual effect available in draw.io. It creates consistent, branded, accessible diagram themes and ensures every diagram meets professional presentation standards.
+description: The Style Engineer is the visual design authority for all draw.io diagrams. It masters every style property, color palette, typography setting, and visual effect available in draw.io. It creates consistent, branded, accessible diagram themes and ensures every diagram meets professional presentation standards.
 model: sonnet
 tools:
   - Read

--- a/plugins/drawio-diagramming/commands/auto-diagram.md
+++ b/plugins/drawio-diagramming/commands/auto-diagram.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: low
 cost: medium
-description: |
-  Intelligent diagram generation engine that analyzes source code, git diffs, PR descriptions, and conversation context to automatically select the optimal diagram type and produce production-quality draw.io XML. Supports 12+ diagram types with self-editing refinement, multi-file analysis, incremental updates, and deeply nested hierarchy detection.
+description: Intelligent diagram generation engine that analyzes source code, git diffs, PR descriptions, and conversation context to automatically select the optimal diagram type and produce production-quality draw.io XML. Supports 12+ diagram types with self-editing refinement, multi-file analysis, incremental updates, and deeply nested hierarchy detection.
 allowed-tools:
   - Read
   - Write

--- a/plugins/drawio-diagramming/commands/create.md
+++ b/plugins/drawio-diagramming/commands/create.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: low
 cost: medium
-description: |
-  Analyzes project context (code, conversation, explicit request) to automatically select the best diagram type and generate production-quality draw.io XML with proper mxGraphModel structure, style presets, color themes, multi-page support, and layer organization.
+description: Analyzes project context (code, conversation, explicit request) to automatically select the best diagram type and generate production-quality draw.io XML with proper mxGraphModel structure, style presets, color themes, multi-page support, and layer organization.
 allowed-tools:
   - Read
   - Write

--- a/plugins/drawio-diagramming/commands/data-bind.md
+++ b/plugins/drawio-diagramming/commands/data-bind.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: high
-description: |
-  Bind draw.io diagram elements to external data sources such as Jira, GitHub Actions, Kubernetes, Prometheus, and custom REST APIs. Apply conditional formatting based on live status values, deploy state, test coverage, latency metrics, and resource utilization. Uses draw.io custom properties, placeholder variables, and UserObject XML tags to create data-driven diagrams that reflect real-time system state.
+description: Bind draw.io diagram elements to external data sources such as Jira, GitHub Actions, Kubernetes, Prometheus, and custom REST APIs. Apply conditional formatting based on live status values, deploy state, test coverage, latency metrics, and resource utilization. Uses draw.io custom properties, placeholder variables, and UserObject XML tags to create data-driven diagrams that reflect real-time system state.
 allowed-tools:
   - Read
   - Write

--- a/plugins/drawio-diagramming/commands/edit.md
+++ b/plugins/drawio-diagramming/commands/edit.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: low
 cost: medium
-description: |
-  Reads and parses existing .drawio XML files to add, remove, or modify cells (shapes, edges, labels), update styles, adjust layouts, manage layers, merge diagrams, diff versions, and perform bulk operations while preserving diagram integrity.
+description: Reads and parses existing .drawio XML files to add, remove, or modify cells (shapes, edges, labels), update styles, adjust layouts, manage layers, merge diagrams, diff versions, and perform bulk operations while preserving diagram integrity.
 allowed-tools:
   - Read
   - Write

--- a/plugins/drawio-diagramming/commands/embed.md
+++ b/plugins/drawio-diagramming/commands/embed.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: low
 cost: medium
-description: |
-  Generates platform-specific embedding code for draw.io diagrams across 7+ platforms including GitHub, Confluence, Jira, Azure DevOps, Notion, Microsoft Teams, and Harness. Auto-detects target platform from context, handles image sizing, responsive display, and links diagrams to source code.
+description: Generates platform-specific embedding code for draw.io diagrams across 7+ platforms including GitHub, Confluence, Jira, Azure DevOps, Notion, Microsoft Teams, and Harness. Auto-detects target platform from context, handles image sizing, responsive display, and links diagrams to source code.
 allowed-tools:
   - Read
   - Write

--- a/plugins/drawio-diagramming/commands/export.md
+++ b/plugins/drawio-diagramming/commands/export.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: low
 cost: medium
-description: |
-  Exports draw.io diagrams to SVG, PNG, PDF, raw XML, self-editing HTML, and Mermaid.js format. Supports CLI export via draw.io desktop, programmatic export via the draw.io export server, quality settings, multi-page export, batch processing, dark mode, transparent backgrounds, crop-to-content, and CI/CD pipeline integration.
+description: Exports draw.io diagrams to SVG, PNG, PDF, raw XML, self-editing HTML, and Mermaid.js format. Supports CLI export via draw.io desktop, programmatic export via the draw.io export server, quality settings, multi-page export, batch processing, dark mode, transparent backgrounds, crop-to-content, and CI/CD pipeline integration.
 allowed-tools:
   - Read
   - Write

--- a/plugins/drawio-diagramming/commands/layers.md
+++ b/plugins/drawio-diagramming/commands/layers.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: low
 cost: low
-description: |
-  Manage draw.io diagram layers for organizing complex multi-layered visualizations. Create, toggle, lock, reorder, and export layers. Includes templates for infrastructure, application, C4, DevOps, and security layer patterns. Supports cross-layer connections, collapsible groups, layer-based selective export, and z-index management.
+description: Manage draw.io diagram layers for organizing complex multi-layered visualizations. Create, toggle, lock, reorder, and export layers. Includes templates for infrastructure, application, C4, DevOps, and security layer patterns. Supports cross-layer connections, collapsible groups, layer-based selective export, and z-index management.
 allowed-tools:
   - Read
   - Write

--- a/plugins/drawio-diagramming/commands/open.md
+++ b/plugins/drawio-diagramming/commands/open.md
@@ -9,8 +9,7 @@ tags:
 inputs: []
 risk: low
 cost: low
-description: |
-  Opens .drawio diagram files in the draw.io desktop application (Electron) or falls back to the browser-based editor at app.diagrams.net. Supports OS detection (macOS, Windows, Linux), custom editor paths, file watching for live reload, and opening specific pages within multi-page diagrams. Essential for desktop Claude Code workflows where users want visual editing alongside AI-powered generation.
+description: Opens .drawio diagram files in the draw.io desktop application (Electron) or falls back to the browser-based editor at app.diagrams.net. Supports OS detection (macOS, Windows, Linux), custom editor paths, file watching for live reload, and opening specific pages within multi-page diagrams. Essential for desktop Claude Code workflows where users want visual editing alongside AI-powered generation.
 allowed-tools:
   - Read
   - Bash

--- a/plugins/drawio-diagramming/commands/style.md
+++ b/plugins/drawio-diagramming/commands/style.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: low
 cost: low
-description: |
-  Comprehensive styling engine for draw.io diagrams. Apply theme presets (Professional, Sketch, Dark Mode, Blueprint, Minimal, Colorful, Corporate), bulk restyle operations, and fine-grained control over every visual property including fills, strokes, shapes, text, labels, edges, and arrows. Includes style inheritance validation and consistency checking across diagram elements.
+description: Comprehensive styling engine for draw.io diagrams. Apply theme presets (Professional, Sketch, Dark Mode, Blueprint, Minimal, Colorful, Corporate), bulk restyle operations, and fine-grained control over every visual property including fills, strokes, shapes, text, labels, edges, and arrows. Includes style inheritance validation and consistency checking across diagram elements.
 allowed-tools:
   - Read
   - Write

--- a/plugins/home-assistant-architect/agents/ha-automation-architect.md
+++ b/plugins/home-assistant-architect/agents/ha-automation-architect.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Design, create, optimize, and troubleshoot Home Assistant automations, scripts, and scenes with advanced pattern recognition and best practices.
 ---
 
 # Home Assistant Automation Architect Agent

--- a/plugins/home-assistant-architect/agents/ha-camera-nvr.md
+++ b/plugins/home-assistant-architect/agents/ha-camera-nvr.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Complete camera and NVR (Network Video Recorder) integration with motion detection, object recognition, recording management, and multi-camera dashboards.
 ---
 
 # Home Assistant Camera and NVR Integration Agent

--- a/plugins/home-assistant-architect/agents/ha-customization-expert.md
+++ b/plugins/home-assistant-architect/agents/ha-customization-expert.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Customize and extend Home Assistant with themes, custom components, entity configurations, blueprints, and HACS integrations.
 ---
 
 # Home Assistant Customization Expert Agent

--- a/plugins/home-assistant-architect/agents/ha-dashboard-designer.md
+++ b/plugins/home-assistant-architect/agents/ha-dashboard-designer.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Create stunning, highly customized Home Assistant dashboards with advanced layouts, animations, custom styling, and mobile-optimized designs.
 ---
 
 # Home Assistant Advanced Dashboard Designer Agent

--- a/plugins/home-assistant-architect/agents/ha-data-writer.md
+++ b/plugins/home-assistant-architect/agents/ha-data-writer.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Write, update, and manage data in Home Assistant including entity states, input helpers, databases, and configuration files.
 ---
 
 # Home Assistant Data Writer Agent

--- a/plugins/home-assistant-architect/agents/ha-device-controller.md
+++ b/plugins/home-assistant-architect/agents/ha-device-controller.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Control and manage Home Assistant devices, entities, and services with intelligent state management and natural language understanding.
 ---
 
 # Home Assistant Device Controller Agent

--- a/plugins/home-assistant-architect/agents/ha-diagnostics.md
+++ b/plugins/home-assistant-architect/agents/ha-diagnostics.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Troubleshoot, diagnose, and resolve Home Assistant issues including entity problems, automation failures, integration errors, and performance issues.
 ---
 
 # Home Assistant Diagnostics Agent

--- a/plugins/home-assistant-architect/agents/ha-energy-management.md
+++ b/plugins/home-assistant-architect/agents/ha-energy-management.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Comprehensive energy management with solar integration, battery storage, grid monitoring, EV charging, and cost optimization.
 ---
 
 # Home Assistant Energy Management System Agent

--- a/plugins/home-assistant-architect/agents/ha-energy-optimizer.md
+++ b/plugins/home-assistant-architect/agents/ha-energy-optimizer.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Analyze energy consumption patterns, optimize automations for efficiency, and provide recommendations for reducing energy costs while maintaining comfort.
 ---
 
 # Home Assistant Energy Optimizer Agent

--- a/plugins/home-assistant-architect/agents/ha-frontend-builder.md
+++ b/plugins/home-assistant-architect/agents/ha-frontend-builder.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Build and design Home Assistant Lovelace dashboards with production-ready cards, layouts, and responsive designs.
 ---
 
 # Home Assistant Frontend Builder Agent

--- a/plugins/home-assistant-architect/agents/ha-security-auditor.md
+++ b/plugins/home-assistant-architect/agents/ha-security-auditor.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Audit and enhance Home Assistant security including access controls, network exposure, encryption, and compliance with security best practices.
 ---
 
 # Home Assistant Security Auditor Agent

--- a/plugins/home-assistant-architect/agents/ha-sensor-manager.md
+++ b/plugins/home-assistant-architect/agents/ha-sensor-manager.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Comprehensive sensor management with environmental monitoring, presence detection, smart sensor deployment, and data analysis.
 ---
 
 # Home Assistant Sensor Manager Agent

--- a/plugins/home-assistant-architect/agents/ha-voice-assistant.md
+++ b/plugins/home-assistant-architect/agents/ha-voice-assistant.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Configure and optimize voice assistant pipelines with local speech processing (Whisper, Piper) and local LLM integration for privacy-focused voice control.
 ---
 
 # Home Assistant Voice Assistant Agent

--- a/plugins/home-assistant-architect/agents/local-llm-manager.md
+++ b/plugins/home-assistant-architect/agents/local-llm-manager.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Deploy, configure, and optimize local Large Language Models using Ollama, LocalAI, and other backends for Home Assistant voice assistants and intelligent automation.
 ---
 
 # Local LLM Manager Agent

--- a/plugins/home-assistant-architect/agents/ubuntu-ha-deployer.md
+++ b/plugins/home-assistant-architect/agents/ubuntu-ha-deployer.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Deploy, configure, and manage Home Assistant on Ubuntu servers with Docker, including complementary services like MQTT, Zigbee2MQTT, and monitoring.
 ---
 
 # Ubuntu Home Assistant Deployer Agent

--- a/plugins/home-assistant-architect/commands/ha-automation.md
+++ b/plugins/home-assistant-architect/commands/ha-automation.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Create, manage, and debug Home Assistant automations.
 ---
 
 # Home Assistant Automation Command

--- a/plugins/home-assistant-architect/commands/ha-camera.md
+++ b/plugins/home-assistant-architect/commands/ha-camera.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Configure cameras, NVR systems, and video analytics.
 ---
 
 # /ha-camera Command

--- a/plugins/home-assistant-architect/commands/ha-control.md
+++ b/plugins/home-assistant-architect/commands/ha-control.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Control Home Assistant entities and services with natural language.
 ---
 
 # Home Assistant Control Command

--- a/plugins/home-assistant-architect/commands/ha-dashboard.md
+++ b/plugins/home-assistant-architect/commands/ha-dashboard.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Create, customize, and manage Home Assistant Lovelace dashboards.
 ---
 
 # /ha-dashboard Command

--- a/plugins/home-assistant-architect/commands/ha-deploy.md
+++ b/plugins/home-assistant-architect/commands/ha-deploy.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Deploy Home Assistant on Ubuntu server with Docker and complementary services.
 ---
 
 # Home Assistant Deploy Command

--- a/plugins/home-assistant-architect/commands/ha-energy.md
+++ b/plugins/home-assistant-architect/commands/ha-energy.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Configure and manage Home Assistant energy monitoring system.
 ---
 
 # /ha-energy Command

--- a/plugins/home-assistant-architect/commands/ha-mcp.md
+++ b/plugins/home-assistant-architect/commands/ha-mcp.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Configure and manage MCP server integration for Claude with Home Assistant.
 ---
 
 # Home Assistant MCP Command

--- a/plugins/home-assistant-architect/commands/ha-sensor.md
+++ b/plugins/home-assistant-architect/commands/ha-sensor.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Configure and manage sensors, presence detection, and monitoring.
 ---
 
 # /ha-sensor Command

--- a/plugins/home-assistant-architect/commands/ollama-setup.md
+++ b/plugins/home-assistant-architect/commands/ollama-setup.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Setup and configure Ollama for local LLM integration with Home Assistant.
 ---
 
 # Ollama Setup Command

--- a/plugins/home-assistant-architect/hooks/hooks.json
+++ b/plugins/home-assistant-architect/hooks/hooks.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'HA prompt context: only handle HA-specific commands, config files, domains/entities, or MCP tools'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/ha-context-guard.sh prompt",
             "timeout": 10
           }
         ]
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'Reminder: backup HA configuration.yaml, automations, and secrets if significant changes were made'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/ha-context-guard.sh stop",
             "timeout": 10
           }
         ]

--- a/plugins/home-assistant-architect/hooks/scripts/ha-context-guard.sh
+++ b/plugins/home-assistant-architect/hooks/scripts/ha-context-guard.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# ha-context-guard.sh - Emit Home Assistant context ONLY inside an HA project.
+#
+# Previously hooks.json echoed "only handle HA-specific commands..." on every
+# UserPromptSubmit, and a backup reminder on every Stop. Because plugin hooks
+# run in every session regardless of the working directory, that text was
+# injected into unrelated projects and actively steered Claude away from the
+# user's actual task. This guard makes both messages conditional.
+#
+# Usage: ha-context-guard.sh <prompt|stop>
+
+set -uo pipefail
+
+MODE="${1:-prompt}"
+DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+is_ha_project() {
+  # Explicit opt-in / opt-out always wins.
+  case "${HA_ARCHITECT_FORCE:-}" in
+    1|true|TRUE|yes) return 0 ;;
+    0|false|FALSE|no) return 1 ;;
+  esac
+
+  # A Home Assistant config dir has a configuration.yaml alongside at least one
+  # of HA's own directories. configuration.yaml alone is too weak a signal --
+  # plenty of unrelated projects have one.
+  if [ -f "$DIR/configuration.yaml" ] && {
+       [ -d "$DIR/.storage" ] || [ -d "$DIR/custom_components" ] ||
+       [ -d "$DIR/blueprints" ] || [ -f "$DIR/automations.yaml" ] ||
+       [ -f "$DIR/scenes.yaml" ] || [ -f "$DIR/scripts.yaml" ]; }; then
+    return 0
+  fi
+
+  # A repo that talks to HA over the API rather than holding its config.
+  [ -n "${HASS_URL:-}${HASS_TOKEN:-}${HOMEASSISTANT_URL:-}" ] && return 0
+
+  return 1
+}
+
+is_ha_project || exit 0
+
+case "$MODE" in
+  stop)
+    echo "Home Assistant: if configuration.yaml, automations, or secrets changed, back them up before restarting HA."
+    ;;
+  *)
+    echo "Home Assistant project detected: prefer HA domains/entities, HA config files, and the Home Assistant MCP tools when they apply."
+    ;;
+esac
+
+exit 0

--- a/plugins/lobbi-platform-manager/agents/env-manager.md
+++ b/plugins/lobbi-platform-manager/agents/env-manager.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: |
-  Environment configuration manager for the-lobbi/keycloak-alpha repository. Validates environment variables, generates configuration files, checks for missing variables, and ensures proper environment-specific defaults across 8 microservices.
+description: Environment configuration manager for the-lobbi/keycloak-alpha repository. Validates environment variables, generates configuration files, checks for missing variables, and ensures proper environment-specific defaults across 8 microservices.
 model: haiku
 tools:
   - Read

--- a/plugins/lobbi-platform-manager/agents/keycloak-admin.md
+++ b/plugins/lobbi-platform-manager/agents/keycloak-admin.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: |
-  Keycloak administration agent for the-lobbi/keycloak-alpha repository. Handles realm provisioning, user management, client configuration, theme deployment, and multi-tenant authentication workflows. Expert in Keycloak Admin API and OIDC protocols.
+description: Keycloak administration agent for the-lobbi/keycloak-alpha repository. Handles realm provisioning, user management, client configuration, theme deployment, and multi-tenant authentication workflows. Expert in Keycloak Admin API and OIDC protocols.
 model: sonnet
 tools:
   - Bash

--- a/plugins/lobbi-platform-manager/agents/service-orchestrator.md
+++ b/plugins/lobbi-platform-manager/agents/service-orchestrator.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: |
-  Service orchestration agent for the-lobbi/keycloak-alpha repository. Monitors health, validates dependencies, manages service lifecycle across 8 microservices. Expert in Docker Compose, service mesh patterns, and failure recovery.
+description: Service orchestration agent for the-lobbi/keycloak-alpha repository. Monitors health, validates dependencies, manages service lifecycle across 8 microservices. Expert in Docker Compose, service mesh patterns, and failure recovery.
 model: sonnet
 tools:
   - Bash

--- a/plugins/lobbi-platform-manager/agents/test-generator.md
+++ b/plugins/lobbi-platform-manager/agents/test-generator.md
@@ -8,8 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
-description: |
-  Automated test generation agent for the-lobbi/keycloak-alpha repository. Generates Jest test suites from Express routes with Keycloak auth mocking, MongoDB/PostgreSQL fixtures, and integration test patterns for microservices.
+description: Automated test generation agent for the-lobbi/keycloak-alpha repository. Generates Jest test suites from Express routes with Keycloak auth mocking, MongoDB/PostgreSQL fixtures, and integration test patterns for microservices.
 model: haiku
 tools:
   - Read

--- a/plugins/mui-expert/agents/mui-a11y-auditor.md
+++ b/plugins/mui-expert/agents/mui-a11y-auditor.md
@@ -12,8 +12,7 @@ inputs:
   - WCAG conformance level (A, AA, AAA)
 risk: low
 cost: high
-description: |
-  Comprehensive accessibility auditor for MUI applications. Checks WCAG 2.1 compliance across all MUI component usage — ARIA attributes, keyboard navigation, color contrast, focus management, screen reader compatibility, and semantic HTML. Produces actionable report with auto-fix support.
+description: Comprehensive accessibility auditor for MUI applications. Checks WCAG 2.1 compliance across all MUI component usage — ARIA attributes, keyboard navigation, color contrast, focus management, screen reader compatibility, and semantic HTML. Produces actionable report with auto-fix support.
 model: claude-sonnet-5
 tools:
   - Read

--- a/plugins/mui-expert/agents/mui-architect.md
+++ b/plugins/mui-expert/agents/mui-architect.md
@@ -13,8 +13,7 @@ inputs:
   - design requirements and brand tokens
 risk: low
 cost: high
-description: |
-  Designs scalable, maintainable Material UI theme systems and component libraries. Produces architecture decision records covering token hierarchy, palette structure, typography scale, spacing, breakpoints, dark mode strategy, TypeScript augmentation, and component override patterns.
+description: Designs scalable, maintainable Material UI theme systems and component libraries. Produces architecture decision records covering token hierarchy, palette structure, typography scale, spacing, breakpoints, dark mode strategy, TypeScript augmentation, and component override patterns.
 model: opus
 tools:
   - Read

--- a/plugins/mui-expert/agents/mui-design-system-architect.md
+++ b/plugins/mui-expert/agents/mui-design-system-architect.md
@@ -13,8 +13,7 @@ inputs:
   - multi-tenant requirements (if applicable)
 risk: low
 cost: high
-description: |
-  Designs enterprise-grade design systems built on MUI. Covers design token hierarchies, theme architecture, component library structure, CSS variables strategy, white-label/multi-tenant theming, Pigment CSS migration, and TypeScript augmentation. Produces architecture decisions with implementation blueprints.
+description: Designs enterprise-grade design systems built on MUI. Covers design token hierarchies, theme architecture, component library structure, CSS variables strategy, white-label/multi-tenant theming, Pigment CSS migration, and TypeScript augmentation. Produces architecture decisions with implementation blueprints.
 model: opus
 tools:
   - Read

--- a/plugins/mui-expert/agents/mui-migration-specialist.md
+++ b/plugins/mui-expert/agents/mui-migration-specialist.md
@@ -12,8 +12,7 @@ inputs:
   - optional dry-run flag
 risk: medium
 cost: high
-description: |
-  Analyzes codebases for MUI version compatibility and executes migrations between MUI v4→v5 or v5→v6. Detects breaking changes, generates a file-by-file migration plan with effort estimates, applies codemods and manual transforms, and verifies results with TypeScript compilation.
+description: Analyzes codebases for MUI version compatibility and executes migrations between MUI v4→v5 or v5→v6. Detects breaking changes, generates a file-by-file migration plan with effort estimates, applies codemods and manual transforms, and verifies results with TypeScript compilation.
 model: claude-sonnet-5
 tools:
   - Read

--- a/plugins/mui-expert/agents/mui-performance-optimizer.md
+++ b/plugins/mui-expert/agents/mui-performance-optimizer.md
@@ -12,8 +12,7 @@ inputs:
   - webpack/vite/next config for bundler context
 risk: low
 cost: high
-description: |
-  Analyzes MUI applications for performance issues including bundle size, render optimization, Emotion overhead, DataGrid performance, and SSR efficiency. Produces prioritized recommendations with estimated impact and auto-applies safe fixes.
+description: Analyzes MUI applications for performance issues including bundle size, render optimization, Emotion overhead, DataGrid performance, and SSR efficiency. Produces prioritized recommendations with estimated impact and auto-applies safe fixes.
 model: claude-sonnet-5
 tools:
   - Read

--- a/plugins/mui-expert/agents/mui-reviewer.md
+++ b/plugins/mui-expert/agents/mui-reviewer.md
@@ -12,8 +12,7 @@ inputs:
   - optional focus area (accessibility, performance, theming, DataGrid, DatePicker)
 risk: low
 cost: medium
-description: |
-  Reviews React code that uses Material UI and identifies issues related to best practices, accessibility, performance, and correctness. Produces a categorized report with file:line references and actionable fix code covering imports, theming, styling approach, a11y, performance, component usage, TypeScript typing, DataGrid, and DatePicker patterns.
+description: Reviews React code that uses Material UI and identifies issues related to best practices, accessibility, performance, and correctness. Produces a categorized report with file:line references and actionable fix code covering imports, theming, styling approach, a11y, performance, component usage, TypeScript typing, DataGrid, and DatePicker patterns.
 model: claude-sonnet-5
 tools:
   - Read

--- a/plugins/mui-expert/agents/mui-x-specialist.md
+++ b/plugins/mui-expert/agents/mui-x-specialist.md
@@ -14,8 +14,7 @@ inputs:
   - data source description
 risk: low
 cost: high
-description: |
-  Specialist in MUI X premium components. Handles advanced DataGrid patterns (server-side data source, row grouping, aggregation, master-detail, Excel export, cell selection, clipboard), Date/Time Pickers (timezone, custom fields, validation, shortcuts), Charts (composition API, custom renderers, dual axes), and Tree View (lazy loading, drag-drop, virtualization).
+description: Specialist in MUI X premium components. Handles advanced DataGrid patterns (server-side data source, row grouping, aggregation, master-detail, Excel export, cell selection, clipboard), Date/Time Pickers (timezone, custom fields, validation, shortcuts), Charts (composition API, custom renderers, dual axes), and Tree View (lazy loading, drag-drop, virtualization).
 model: claude-sonnet-5
 tools:
   - Read

--- a/plugins/mui-expert/commands/mui-charts.md
+++ b/plugins/mui-expert/commands/mui-charts.md
@@ -14,8 +14,7 @@ inputs:
   - '--theme-aware'
 risk: low
 cost: medium
-description: |
-  Scaffold MUI X Charts with typed data, responsive layout, custom tooltips, click handlers, theme integration, and composition API patterns.
+description: Scaffold MUI X Charts with typed data, responsive layout, custom tooltips, click handlers, theme integration, and composition API patterns.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-creative.md
+++ b/plugins/mui-expert/commands/mui-creative.md
@@ -14,8 +14,7 @@ inputs:
   - '--with-motion'
 risk: low
 cost: high
-description: |
-  Build highly creative, fluid MUI widgets that go far beyond standard Material Design. Sparkline-in-grid cells, heatmap DataGrids, real-time WebSocket grids, AI assistant panels, animated wizards, hardware-style switches, interactive tree browsers, bi-directional chart+grid sync, and more.
+description: Build highly creative, fluid MUI widgets that go far beyond standard Material Design. Sparkline-in-grid cells, heatmap DataGrids, real-time WebSocket grids, AI assistant panels, animated wizards, hardware-style switches, interactive tree browsers, bi-directional chart+grid sync, and more.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-datagrid.md
+++ b/plugins/mui-expert/commands/mui-datagrid.md
@@ -12,8 +12,7 @@ inputs:
   - '--data-source'
 risk: low
 cost: medium
-description: |
-  Scaffold a new MUI X DataGrid component, add features to an existing one, or optimize an existing DataGrid for performance. Includes TypeScript types, server-side integration patterns, and React Query/SWR data fetching.
+description: Scaffold a new MUI X DataGrid component, add features to an existing one, or optimize an existing DataGrid for performance. Includes TypeScript types, server-side integration patterns, and React Query/SWR data fetching.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-design-system.md
+++ b/plugins/mui-expert/commands/mui-design-system.md
@@ -16,8 +16,7 @@ inputs:
   - '--white-label'
 risk: low
 cost: high
-description: |
-  Scaffold a production-ready design system on MUI with design tokens, theme configuration, TypeScript augmentation, component overrides, CSS variables, dark mode, and optional multi-tenant white-label support.
+description: Scaffold a production-ready design system on MUI with design tokens, theme configuration, TypeScript augmentation, component overrides, CSS variables, dark mode, and optional multi-tenant white-label support.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-fingerprint.md
+++ b/plugins/mui-expert/commands/mui-fingerprint.md
@@ -14,8 +14,7 @@ inputs:
   - '--style'
 risk: medium
 cost: high
-description: |
-  Interactive app fingerprinting command. Scans the project to detect existing MUI components, pages, routing, data models, and API endpoints. Asks targeted questions about missing functionality. Then systematically builds every MUI component the app needs — layouts, forms, data tables, navigation, feedback, and custom widgets.
+description: Interactive app fingerprinting command. Scans the project to detect existing MUI components, pages, routing, data models, and API endpoints. Asks targeted questions about missing functionality. Then systematically builds every MUI component the app needs — layouts, forms, data tables, navigation, feedback, and custom widgets.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-perf.md
+++ b/plugins/mui-expert/commands/mui-perf.md
@@ -12,8 +12,7 @@ inputs:
   - '--path'
 risk: low
 cost: high
-description: |
-  Comprehensive MUI performance analysis covering bundle size, render optimization, DataGrid performance, SSR efficiency, and Emotion caching. Reports issues with severity and provides auto-fix for safe optimizations.
+description: Comprehensive MUI performance analysis covering bundle size, render optimization, DataGrid performance, SSR efficiency, and Emotion caching. Reports issues with severity and provides auto-fix for safe optimizations.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-setup.md
+++ b/plugins/mui-expert/commands/mui-setup.md
@@ -17,8 +17,7 @@ inputs:
   - '--with-tailwind'
 risk: low
 cost: medium
-description: |
-  Complete MUI project setup — installs packages, configures the MUI MCP server for Claude Code, sets up LSP/editor tooling, generates starter theme, and configures SSR/bundler integration. One command to go from zero to production-ready MUI.
+description: Complete MUI project setup — installs packages, configures the MUI MCP server for Claude Code, sets up LSP/editor tooling, generates starter theme, and configures SSR/bundler integration. One command to go from zero to production-ready MUI.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-slots.md
+++ b/plugins/mui-expert/commands/mui-slots.md
@@ -12,8 +12,7 @@ inputs:
   - '--mode'
 risk: low
 cost: medium
-description: |
-  List available slots for a component, generate custom slot implementations, or migrate from deprecated components/componentsProps to the slots API.
+description: List available slots for a component, generate custom slot implementations, or migrate from deprecated components/componentsProps to the slots API.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-ssr.md
+++ b/plugins/mui-expert/commands/mui-ssr.md
@@ -14,8 +14,7 @@ inputs:
   - '--dark-mode'
 risk: low
 cost: medium
-description: |
-  Configure MUI for Next.js SSR with correct Emotion cache setup, CSS variables, flash prevention, and React Server Components compatibility.
+description: Configure MUI for Next.js SSR with correct Emotion cache setup, CSS variables, flash prevention, and React Server Components compatibility.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-theme.md
+++ b/plugins/mui-expert/commands/mui-theme.md
@@ -13,8 +13,7 @@ inputs:
   - '--audit-file'
 risk: low
 cost: medium
-description: |
-  Generate a complete MUI createTheme() configuration with palette, typography, spacing, shape, breakpoints, and component overrides — or audit an existing theme file for missing best practices, accessibility issues, and TypeScript gaps.
+description: Generate a complete MUI createTheme() configuration with palette, typography, spacing, shape, breakpoints, and component overrides — or audit an existing theme file for missing best practices, accessibility issues, and TypeScript gaps.
 allowed-tools:
   - Read
   - Write

--- a/plugins/mui-expert/commands/mui-white-label.md
+++ b/plugins/mui-expert/commands/mui-white-label.md
@@ -13,8 +13,7 @@ inputs:
   - '--source'
 risk: low
 cost: high
-description: |
-  Generate a complete multi-tenant white-label theming architecture with tenant-specific branding, component variant overrides, dynamic theme loading, and CSS variables support.
+description: Generate a complete multi-tenant white-label theming architecture with tenant-specific branding, component variant overrides, dynamic theme loading, and CSS variables support.
 allowed-tools:
   - Read
   - Write

--- a/plugins/project-management-plugin/commands/pm-backlog.md
+++ b/plugins/project-management-plugin/commands/pm-backlog.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Provides tools for maintaining the health and quality of the task backlog. Use these operations periodically — especially when the project has evolved, many new tasks have been added manually, or estimates are drifting from actuals. These are all read-analyze-write operations that invoke agents to reason about the backlog and then update tasks.json.
 ---
 
 # /pm:backlog — Backlog Management

--- a/plugins/project-management-plugin/commands/pm-task.md
+++ b/plugins/project-management-plugin/commands/pm-task.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: 'Full create, read, update, and delete interface for individual tasks. Use this when you need to manually intervene in the task backlog: adding tasks that were missed during decomposition, editing fields that need correction, marking tasks complete or blocked by hand, or inspecting a specific task''s full record.'
 ---
 
 # /pm:task — Task Management CRUD

--- a/plugins/project-management-plugin/commands/pm-work.md
+++ b/plugins/project-management-plugin/commands/pm-work.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: 'The main execution engine. Runs one full cycle of the 8-phase work loop: prioritize → select batch → research → decompose check → execute → validate → checkpoint → loop decision. Each invocation processes a batch of tasks and either recurses automatically or surfaces a decision point.'
 ---
 
 # /pm:work — Research-First Task Execution

--- a/plugins/project-management-plugin/tests/pm-state.test.mjs
+++ b/plugins/project-management-plugin/tests/pm-state.test.mjs
@@ -49,8 +49,12 @@ function teardown(tmp) {
 await loadValidators();
 
 test('projectsRoot() honors CLAUDE_PROJECT_DIR', () => {
-  process.env.CLAUDE_PROJECT_DIR = '/tmp/custom';
-  assert.equal(projectsRoot(), '/tmp/custom/.claude/projects');
+  const base = join(tmpdir(), 'pm-projects-root-fixture');
+  process.env.CLAUDE_PROJECT_DIR = base;
+  // Build the expectation with join() too: projectsRoot() uses path.join, which
+  // emits "\" on Windows, so a hardcoded POSIX string fails there even though
+  // the implementation is correct.
+  assert.equal(projectsRoot(), join(base, '.claude', 'projects'));
 });
 
 test('listProjects + readProject + readTasks find the fixture', () => {

--- a/plugins/react-animation-studio/agents/animation-architect.md
+++ b/plugins/react-animation-studio/agents/animation-architect.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Master architect for complex animation systems and choreography in React/TypeScript applications. This agent establishes scalable animation architectures that drive engaging user experiences across your application.
 ---
 
 # Animation Architect

--- a/plugins/react-animation-studio/agents/creative-effects-artist.md
+++ b/plugins/react-animation-studio/agents/creative-effects-artist.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: 'Use for decorative and artistic visual effects in React: animated backgrounds (gradients, particles, aurora, mesh, waves, morphing blobs), accent flourishes (floating shapes, glowing orbs, sparkles, shimmer borders), kinetic typography and text reveals, glitch/liquid/morph effects, and 3D transforms such as tilt, flip cards and parallax depth. Trigger phrases: "make this section more visually interesting", "add a particle or aurora background", "animate this headline", "add a shimmer or glow effect".'
 ---
 
 # Creative Effects Artist Agent

--- a/plugins/react-animation-studio/agents/interaction-specialist.md
+++ b/plugins/react-animation-studio/agents/interaction-specialist.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Micro-interactions, gesture animations, and responsive feedback specialist. This agent creates tactile, satisfying interactions that establish intuitive user experiences and clear visual communication.
 ---
 
 # Interaction Specialist

--- a/plugins/react-animation-studio/agents/motion-designer.md
+++ b/plugins/react-animation-studio/agents/motion-designer.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Creative motion design specialist for physics-based animations, visual effects, and expressive movement in React/TypeScript applications. This agent transforms static interfaces into delightful, living experiences.
 ---
 
 # Motion Designer

--- a/plugins/react-animation-studio/agents/performance-optimizer.md
+++ b/plugins/react-animation-studio/agents/performance-optimizer.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Animation performance optimization specialist ensuring 60fps smooth animations across devices while maintaining accessibility compliance. This agent establishes performance-first animation patterns that deliver measurable improvements to user experience.
 ---
 
 # Performance Optimizer

--- a/plugins/react-animation-studio/agents/transition-engineer.md
+++ b/plugins/react-animation-studio/agents/transition-engineer.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Page transitions, route animations, and layout morphing specialist. This agent creates seamless navigation experiences that establish spatial relationships and maintain context during state changes.
 ---
 
 # Transition Engineer

--- a/plugins/react-animation-studio/commands/animate-3d.md
+++ b/plugins/react-animation-studio/commands/animate-3d.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Create CSS/JS-based 3D animations including flip cards, tilt effects, rotating cubes, parallax depth layers, and 3D carousels without WebGL.
 ---
 
 # /animate-3d Command

--- a/plugins/react-animation-studio/commands/animate-audit.md
+++ b/plugins/react-animation-studio/commands/animate-audit.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Audit animations for performance, accessibility, and best practices compliance.
 ---
 
 # /animate-audit

--- a/plugins/react-animation-studio/commands/animate-background.md
+++ b/plugins/react-animation-studio/commands/animate-background.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Generate stunning animated backgrounds for React applications using CSS gradients, particles, aurora effects, and more.
 ---
 
 # /animate-background Command

--- a/plugins/react-animation-studio/commands/animate-component.md
+++ b/plugins/react-animation-studio/commands/animate-component.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Add animations to existing React components with intelligent analysis and seamless integration.
 ---
 
 # /animate-component

--- a/plugins/react-animation-studio/commands/animate-effects.md
+++ b/plugins/react-animation-studio/commands/animate-effects.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Create artistic and experimental visual effects including morphing shapes, glitch effects, liquid animations, magnetic interactions, and creative loaders.
 ---
 
 # /animate-effects Command

--- a/plugins/react-animation-studio/commands/animate-export.md
+++ b/plugins/react-animation-studio/commands/animate-export.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Export animations as reusable components, hooks, or design tokens.
 ---
 
 # /animate-export

--- a/plugins/react-animation-studio/commands/animate-preset.md
+++ b/plugins/react-animation-studio/commands/animate-preset.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Apply pre-built animation presets from a curated library of beautiful, tested animations.
 ---
 
 # /animate-preset

--- a/plugins/react-animation-studio/commands/animate-scroll.md
+++ b/plugins/react-animation-studio/commands/animate-scroll.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Add scroll-triggered animations to elements and sections with intelligent viewport detection.
 ---
 
 # /animate-scroll

--- a/plugins/react-animation-studio/commands/animate-sequence.md
+++ b/plugins/react-animation-studio/commands/animate-sequence.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Create choreographed animation sequences with precise timing and orchestration.
 ---
 
 # /animate-sequence

--- a/plugins/react-animation-studio/commands/animate-text.md
+++ b/plugins/react-animation-studio/commands/animate-text.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Create expressive text animations including typewriter effects, character reveals, kinetic typography, and gradient text animations.
 ---
 
 # /animate-text Command

--- a/plugins/react-animation-studio/commands/animate-transition.md
+++ b/plugins/react-animation-studio/commands/animate-transition.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Create page transitions and route animations for seamless navigation experiences.
 ---
 
 # /animate-transition

--- a/plugins/react-animation-studio/commands/animate.md
+++ b/plugins/react-animation-studio/commands/animate.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: medium
+description: Generate beautiful, production-ready animation code from natural language descriptions. This command transforms creative descriptions into optimized TypeScript/React animations.
 ---
 
 # /animate

--- a/plugins/upgrade-suggestion/commands/suggest-upgrades.md
+++ b/plugins/upgrade-suggestion/commands/suggest-upgrades.md
@@ -14,8 +14,7 @@ inputs:
   - count
 risk: low
 cost: medium
-description: |
-  AI-powered upgrade intelligence. Spawns a council of specialist agents (performance, security, architecture, UX, DX) that analyze your codebase in parallel, vote on findings with confidence scores, and present a visual impact dashboard with heatmaps, sparklines, and before/after previews.
+description: AI-powered upgrade intelligence. Spawns a council of specialist agents (performance, security, architecture, UX, DX) that analyze your codebase in parallel, vote on findings with confidence scores, and present a visual impact dashboard with heatmaps, sparklines, and before/after previews.
 allowed-tools:
   - Read
   - Grep

--- a/plugins/upgrade-suggestion/commands/upgrade-deep-dive.md
+++ b/plugins/upgrade-suggestion/commands/upgrade-deep-dive.md
@@ -11,8 +11,7 @@ inputs:
   - format
 risk: low
 cost: medium
-description: |
-  Deep-dive analysis of a single upgrade. Produces a full impact report with risk assessment, implementation plan with numbered steps, affected file list, test strategy, rollback plan, and before/after code previews.
+description: Deep-dive analysis of a single upgrade. Produces a full impact report with risk assessment, implementation plan with numbered steps, affected file list, test strategy, rollback plan, and before/after code previews.
 allowed-tools:
   - Read
   - Grep

--- a/plugins/upgrade-suggestion/commands/upgrade-roadmap.md
+++ b/plugins/upgrade-suggestion/commands/upgrade-roadmap.md
@@ -12,8 +12,7 @@ inputs:
   - team-size
 risk: low
 cost: medium
-description: |
-  Generates a prioritized, sequenced upgrade roadmap showing what to implement first, dependency chains between upgrades, estimated effort, and cumulative impact curves. Visualizes the optimal implementation path as a directed graph.
+description: Generates a prioritized, sequenced upgrade roadmap showing what to implement first, dependency chains between upgrades, estimated effort, and cumulative impact curves. Visualizes the optimal implementation path as a directed graph.
 allowed-tools:
   - Read
   - Grep

--- a/plugins/work-automation/commands/wa-pipeline.md
+++ b/plugins/work-automation/commands/wa-pipeline.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: medium
 cost: low
+description: Universal Harness pipeline ops. Uses mcpharness tools.
 flags:
   - name: follow
     type: boolean

--- a/plugins/work-automation/commands/wa-report.md
+++ b/plugins/work-automation/commands/wa-report.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: low
 cost: low
+description: Produce the Work Unit Report per ULTRA §13. Reads session artifacts (files written, test outputs, git status) and fills in all seven sections.
 flags:
   - name: save
     type: boolean

--- a/plugins/work-automation/commands/wa-schedule.md
+++ b/plugins/work-automation/commands/wa-schedule.md
@@ -9,6 +9,7 @@ inputs:
   - task name
 risk: medium
 cost: low
+description: Create a recurring Claude task that runs on a cron. Uses mcpscheduled-taskscreatescheduledtask.
 flags:
   - name: dry-run
     type: boolean

--- a/plugins/work-automation/commands/wa-work-unit.md
+++ b/plugins/work-automation/commands/wa-work-unit.md
@@ -8,6 +8,7 @@ tags:
 inputs: []
 risk: low
 cost: low
+description: 'Start a new ULTRA-governed work unit: capture a measurable one-sentence scope, an explicit completion criterion, a survey of reusable plugins/skills/commands/MCPs, blocking dependencies, and the planned file artifacts. Use when beginning a discrete piece of work, when asked to "open a work unit" or "scope this properly before we start", or to pin down done-criteria up front.'
 flags:
   - name: skip-survey
     type: boolean

--- a/scripts/generate-plugin-indexes.mjs
+++ b/scripts/generate-plugin-indexes.mjs
@@ -5,7 +5,7 @@ import yaml from 'js-yaml';
 
 const ROOT = process.cwd();
 const PLUGINS_DIR = path.join(ROOT, 'plugins');
-const REQUIRED_FIELDS = ['name', 'intent', 'tags', 'inputs', 'risk', 'cost'];
+const REQUIRED_FIELDS = ['name', 'intent', 'tags', 'inputs', 'risk', 'cost', 'description'];
 const ALLOWED_RISK = new Set(['low', 'medium', 'high']);
 const ALLOWED_COST = new Set(['low', 'medium', 'high']);
 
@@ -13,7 +13,7 @@ const args = new Set(process.argv.slice(2));
 const checkOnly = args.has('--check');
 const writeFrontmatter = !args.has('--no-write-frontmatter');
 
-function parseFrontmatter(content) {
+function parseFrontmatter(content, relativePath = '<unknown>') {
   if (!content.startsWith('---\n')) return { data: {}, body: content, hasFrontmatter: false };
   const end = content.indexOf('\n---', 4);
   if (end === -1) return { data: {}, body: content, hasFrontmatter: false };
@@ -22,8 +22,11 @@ function parseFrontmatter(content) {
   let data = {};
   try {
     data = yaml.load(raw) || {};
-  } catch {
-    data = {};
+  } catch (err) {
+    // Never swallow this. Falling back to {} makes the generator rewrite the
+    // file from defaults, silently destroying every field it could not parse
+    // (flags, tools, model, hand-written descriptions). Fail loudly instead.
+    throw new Error(`${relativePath}: invalid YAML frontmatter - ${err.message}`);
   }
   return { data, body, hasFrontmatter: true };
 }
@@ -33,6 +36,27 @@ function inferIntent(data, body, baseName, type) {
   if (typeof data.description === 'string' && data.description.trim()) return data.description.trim();
   const firstLine = body.split('\n').find((line) => line.trim().length > 0) || '';
   return firstLine.replace(/^#\s+/, '').trim() || `${type} action for ${baseName}`;
+}
+
+// Claude Code requires `description` on every agent and command: it is the
+// trigger text the model matches against, and a command with no description is
+// not registered at all. `intent` is a repo-local registry field and is NOT a
+// substitute, so derive a real description whenever one is missing.
+function deriveDescription(data, body, baseName, type, intent) {
+  if (typeof data.description === 'string' && data.description.trim()) {
+    return data.description.trim();
+  }
+  // Prefer the first prose sentence of the body - skip headings, blank lines,
+  // and markdown furniture (tables, lists, code fences, blockquotes, html).
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (/^(#|\||`{3}|>|<|-{3,}|\*|-\s|\d+\.\s)/.test(line)) continue;
+    const cleaned = line.replace(/[*_`]/g, '').trim();
+    if (cleaned.length >= 20) return cleaned;
+  }
+  if (typeof intent === 'string' && intent.trim()) return intent.trim();
+  return `${type} action for ${baseName}`;
 }
 
 function normalizeArray(value, fallback = []) {
@@ -66,14 +90,15 @@ function normalizeCost(value) {
 function buildNormalizedFrontmatter({ data, body, pluginName, type, fileName }) {
   const baseName = fileName.replace(/\.md$/, '');
   const fallbackName = data.name || `${pluginName}:${baseName}`;
+  const intentValue = inferIntent(data, body, baseName, type);
   return {
     name: String(fallbackName),
-    intent: inferIntent(data, body, baseName, type),
+    intent: intentValue,
     tags: normalizeArray(data.tags, [pluginName, type, baseName]),
     inputs: normalizeArray(data.inputs, normalizeArray(data.arguments, [])),
     risk: normalizeRisk(data.risk),
     cost: normalizeCost(data.cost),
-    ...(data.description ? { description: String(data.description) } : {}),
+    description: deriveDescription(data, body, baseName, type, intentValue),
     ...(data.model ? { model: String(data.model) } : {}),
     ...(data.tools ? { tools: data.tools } : {}),
     ...(data.allowedTools ? { allowedTools: data.allowedTools } : {}),
@@ -116,7 +141,7 @@ function ensureIndexesForPlugin(pluginDirName) {
       const filePath = path.join(dir, fileName);
       const relativePath = path.relative(pluginRoot, filePath).replaceAll('\\\\', '/');
       const original = fs.readFileSync(filePath, 'utf8');
-      const { data, body } = parseFrontmatter(original);
+      const { data, body } = parseFrontmatter(original, relativePath);
       const normalized = buildNormalizedFrontmatter({ data, body, pluginName: pluginDirName, type: type.slice(0, -1), fileName });
 
       const missing = REQUIRED_FIELDS.filter((field) => normalized[field] === undefined || normalized[field] === null || normalized[field] === '');

--- a/scripts/validate-plugin-schema.mjs
+++ b/scripts/validate-plugin-schema.mjs
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import Ajv from 'ajv';
 
-const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+// `new URL(import.meta.url).pathname` yields a leading-slash path on Windows
+// ("/C:/repo/scripts"), which path.resolve turns into "C:\C:\repo" and every
+// schema read then fails with ENOENT. fileURLToPath decodes correctly on all
+// platforms, so this check can actually run on Windows.
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PLUGINS_DIR = path.join(ROOT, 'plugins');
 const pluginSchemaPath = path.join(ROOT, 'schemas', 'plugin.schema.json');
 const hooksSchemaPath = path.join(ROOT, 'schemas', 'hooks.schema.json');


### PR DESCRIPTION
## Problem

Several plugins in this marketplace contribute nothing usable to a Claude Code session. `home-assistant-architect` was the clearest case: its 9 commands never appear at all, and its 15 agents show up labelled only *"Agent from home-assistant-architect plugin"*.

Claude Code uses an agent's or command's `description` as the trigger text it matches against. **A command with no `description` is not registered at all**, and an agent with none gets a generic fallback label the model can never match. 91 agent and command files across 10 plugins shipped without one.

Verified directly: this session materialised `home-assistant-architect/commands/*.md` to disk, yet none of those commands were registered — while `github-orchestrator`'s commands, loaded the same way and with equally namespaced `name:` fields, all registered fine. `description` was the only difference.

## Root cause

`scripts/generate-plugin-indexes.mjs` rewrites every agent/command's frontmatter into this repo's registry shape. It *derives* `intent` when absent, but only ever passed `description` through when it already existed:

```js
...(data.description ? { description: String(data.description) } : {}),
```

So a file that never had one could never gain one — and `--check` passed happily, because `description` was not in `REQUIRED_FIELDS`. **Fixing the 91 files alone would have been silently reverted on the next generator run.**

## Changes

**Generator (`scripts/generate-plugin-indexes.mjs`)**
- `description` is now a required field, always emitted, derived from the body's first prose sentence (falling back to `intent`) when absent.
- Malformed YAML frontmatter now **throws** with the file and reason instead of being swallowed into `data = {}`. That fallback made the generator rewrite the file from defaults, destroying `flags`, `tools`, `model` and hand-written descriptions on a single bad character. I hit this for real mid-PR — it silently ate a `flags:` block.

**Content** — 91 files across `home-assistant-architect` (24), `mui-expert` (18), `react-animation-studio` (18), `drawio-diagramming` (14), `lobbi-platform-manager`, `work-automation`, `project-management-plugin`, `upgrade-suggestion`, `claude-code-templating-plugin`, `aws-eks-helm-keycloak`. Most descriptions derive cleanly from each file's own opening prose; two were hand-written where derivation produced prompt-voice or stub text.

**`home-assistant-architect` hooks** — the plugin echoed `"only handle HA-specific commands…"` on **every** `UserPromptSubmit` and a backup reminder on every `Stop`. Plugin hooks run in every session, so that text was injected into unrelated projects and actively steered Claude away from the user's real task. Both now go through `hooks/scripts/ha-context-guard.sh`, which stays silent unless the working directory is a genuine HA config tree (`configuration.yaml` **plus** `.storage/`, `custom_components/`, `automations.yaml`, …) or `HASS_URL`/`HASS_TOKEN` is set. `HA_ARCHITECT_FORCE=1|0` overrides. Verified across 7 cases including the weak-signal one (`configuration.yaml` alone stays silent).

**Hook scripts** — set the executable bit on 34 scripts across 8 plugins that had shebangs but mode `100644`, so they silently never ran on macOS or Linux. All 67 are now `100755`.

**`scripts/validate-plugin-schema.mjs`** — resolved its root via `new URL(import.meta.url).pathname`, which yields `/C:/repo` on Windows and made every schema read fail with `ENOENT` at `C:\C:\repo`. This check had **never once run on Windows**; it now validates all 39 plugins.

**`pm-state` test** — compared `path.join` output against a hardcoded POSIX string, so `test:pm-plugin` could never pass on Windows. Now 13/13 there.

## Verification

| check | result |
|---|---|
| `check:plugin-indexes` | pass |
| `check:marketplace` | pass — 39/39 plugins |
| `check:plugin-schema` | pass — 39 plugins *(previously unrunnable on Windows)* |
| `check:hooks` | pass |
| `check:plugin-context` | pass |

- 667 agent+command files audited: **0** missing a description, **0** left on the generic fallback.
- Diffed all 91 changed files field-by-field against `HEAD`: **`description` is the only frontmatter key that differs in any of them.** No `flags`, `tools`, `model` or `allowed-tools` lost.
- Data-loss fix proven by injecting malformed YAML: the generator now aborts with `invalid YAML frontmatter - bad indentation of a mapping entry (2:21)` and leaves the file untouched.

## Not included

- **Namespaced `name:` on ~130 agents** produces doubled identifiers (`frontend-design-system:frontend-design-system:accessibility-auditor`). These agents load and their descriptions render correctly — **dispatch under the doubled identifier is untested**, so treat that as open rather than cleared. Held back because `agents/index.json` and the site build may resolve by that string; worth its own PR.

- **`project-management-plugin` is not fixed by this PR.** Its 3 descriptionless commands are repaired here, but the reason it contributes nothing to a session is that it is not installed — it is absent from the session plugin manifest entirely. Untested suspect for why installing it may fail: it is the **only** plugin in this repo shipping a plugin-local `.claude-plugin/marketplace.json`, which declares `version 1.3.0` against its own `plugin.json`'s `1.4.0` and is read by no script in `scripts/`. Left in place rather than deleted on a hunch.
- **23 pre-existing thin descriptions** (`"Compliance Reporter Agent"`, `"View deployment history"`). They register fine but trigger weakly.
- **`home-assistant-architect/mcp-server/src/index.ts`** is orphaned — no `.mcp.json`, no `mcpServers` entry, TypeScript with no build step. Wiring it up is feature work, and a separate `homeassistant` MCP server already exists in config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

